### PR TITLE
Mbarba/prepare fixes2

### DIFF
--- a/lib/python/ensembl/brc4/runnable/process_seq_region.py
+++ b/lib/python/ensembl/brc4/runnable/process_seq_region.py
@@ -127,7 +127,8 @@ class process_seq_region(eHive.BaseRunnable):
                 for syn in seqr["synonyms"]:
                     if syn["source"] == source:
                         insdc_name = syn["name"]
-                        flat_name, dot, version = insdc_name.partition(".")
+                        parts = insdc_name.partition(".")
+                        flat_name = parts[0]
                         seqr["BRC4_seq_region_name"] = flat_name
                         seqr["EBI_seq_region_name"] = flat_name
 


### PR DESCRIPTION
Add support for yet another kind of gff arrangement, where a gene has several CDS children but with different CDS ids, i.e. it correspond to different transcripts that need to be created under the gene.

E.g.
BBXB01000305.1  DDBJ  gene  21449 26149 . + . ID=gene-PINS_012179;
BBXB01000305.1  DDBJ  CDS 21449 21564 . + 0 ID=cds-GAY04353.1;Parent=gene-PINS_012179;
BBXB01000305.1  DDBJ  CDS 21631 22309 . + 1 ID=cds-GAY04353.1;Parent=gene-PINS_012179;
BBXB01000305.1  DDBJ  CDS 22310 22764 . + 0 ID=cds-GAY04354.1;Parent=gene-PINS_012179;
BBXB01000305.1  DDBJ  CDS 22825 23151 . + 1 ID=cds-GAY04354.1;Parent=gene-PINS_012179;
BBXB01000305.1  DDBJ  CDS 23410 26149 . + 1 ID=cds-GAY04354.1;Parent=gene-PINS_012179;

The code should create 2 mRNAs for each CDS id (GAY04353.1 and GAY04354.1).