### PR TITLE
Addition of IGNORE rules for cases of pseudogenes linked to 3_prime |…

### DIFF
--- a/scripts/gff_metaparser/conf/valid_structures.conf
+++ b/scripts/gff_metaparser/conf/valid_structures.conf
@@ -94,9 +94,6 @@ gene/pseudogene/CDS	SUB:load_pseudogene_with_CDS:IGNORE	pseudogene/mRNA:biotype=
 
 pseudogene/pseudogenic_trna/exon	VALID	# will be substituted to pseudogene/tRNA_pseudogene/exon by LoadGFF3
 
-pseudogene/three_prime_UTR      IGNORE:ignore_pseudogene_utr:UNSEEN
-pseudogene/five_prime_UTR       IGNORE:ignore_pseudogene_utr:UNSEEN
-
 # MT related
 gene	SUB	pseudogene/+pseudogenic_transcript/+exon	# MT related (ie MT ORI in flybase)
 
@@ -152,6 +149,9 @@ gene/pseudogene/intron	IGNORE
 gene/trna/intron	IGNORE
 gene/sequence_variant	IGNORE
 
+## IGNORED STRANGE OR INVALID MODELS / PARTS
+pseudogene/three_prime_UTR	IGNORE:ignore_pseudogene_utr:UNSEEN
+pseudogene/five_prime_UTR	IGNORE:ignore_pseudogene_utr:UNSEEN
 
 ## IGNORED GENERIC FEATURES
 bac_cloned_genomic_insert	IGNORE

--- a/scripts/gff_metaparser/conf/valid_structures.conf
+++ b/scripts/gff_metaparser/conf/valid_structures.conf
@@ -94,6 +94,8 @@ gene/pseudogene/CDS	SUB:load_pseudogene_with_CDS:IGNORE	pseudogene/mRNA:biotype=
 
 pseudogene/pseudogenic_trna/exon	VALID	# will be substituted to pseudogene/tRNA_pseudogene/exon by LoadGFF3
 
+pseudogene/three_prime_UTR      IGNORE:ignore_pseudogene_utr:UNSEEN
+pseudogene/five_prime_UTR       IGNORE:ignore_pseudogene_utr:UNSEEN
 
 # MT related
 gene	SUB	pseudogene/+pseudogenic_transcript/+exon	# MT related (ie MT ORI in flybase)


### PR DESCRIPTION
… 5_prime UTRs

Updates to valid_structures.conf to account for cases encountered in a MAKER2 annotation in which pseudogenes were defined with CDS, exon and UTRs. 

E.g:
[pseudo_with_UTRs.txt](https://github.com/Ensembl/ensembl-genomio/files/9072562/pseudo_with_UTRs.txt)

