### PR TITLE
by default remove cds from pseudogenes

### DIFF
--- a/lib/python/ensembl/brc4/runnable/process_gff3.py
+++ b/lib/python/ensembl/brc4/runnable/process_gff3.py
@@ -764,7 +764,7 @@ class process_gff3(eHive.BaseRunnable):
         """Create a transcript ID based on a gene and the number of the transcript"""
         
         # Simply add a numbered suffix to the gene_id
-        transcript_id = "%s_t%d" (gene_id, transcript_number)
+        transcript_id = f"{gene_id}_t{transcript_number}"
 
         return transcript_id
 

--- a/lib/python/ensembl/brc4/runnable/process_gff3.py
+++ b/lib/python/ensembl/brc4/runnable/process_gff3.py
@@ -322,9 +322,9 @@ class process_gff3(eHive.BaseRunnable):
             transcript = self.gene_to_exon(gene)
             gene.sub_features = [transcript]
 
-        # Store gene functional annotation
-        self.transfer_description(gene)
-        self.add_funcann_feature(functional_annotation, gene, "gene")
+        # Remove CDS from pseudogenes
+        if gene.type == 'pseudogene' and not self.param('allow_pseudogene_with_cds'):
+            self.remove_cds_from_pseudogene(gene)
         
         # TRANSCRIPTS
         transcripts_to_delete = []
@@ -412,11 +412,12 @@ class process_gff3(eHive.BaseRunnable):
                 gene.sub_features.pop(elt)
         
         # PSEUDOGENE CDS IDs
-        if gene.type == "pseudogene":
-            if self.param('allow_pseudogene_with_cds'):
+        if gene.type == "pseudogene" and self.param('allow_pseudogene_with_cds'):
                 self.normalize_pseudogene_cds(gene)
-            else:
-                self.remove_cds_from_pseudogene(gene)
+
+        # Finally, store gene functional annotation
+        self.transfer_description(gene)
+        self.add_funcann_feature(functional_annotation, gene, "gene")
     
         return gene
 
@@ -750,15 +751,23 @@ class process_gff3(eHive.BaseRunnable):
     
     def remove_cds_from_pseudogene(self, gene) -> None:
         """Remove CDS from a pseudogene
-        This assumes the CDSs are sub features of the transcript
+        This assumes the CDSs are sub features of the transcript or the gene
         """
 
+        gene_subfeats = []
         for transcript in gene.sub_features:
+            if transcript.type == "CDS":
+                print(f"Remove pseudo CDS {transcript.id}")
+                continue
             new_subfeats = []
             for feat in transcript.sub_features:
-                if not feat.type == "CDS":
-                    new_subfeats.append(feat)
+                if feat.type == "CDS":
+                    print(f"Remove pseudo CDS {feat.id}")
+                    continue
+                new_subfeats.append(feat)
             transcript.sub_features = new_subfeats
+            gene_subfeats.append(transcript)
+        gene.sub_features = gene_subfeats
     
     def make_transcript_id(self, gene_id, transcript_number) -> str:
         """Create a transcript ID based on a gene and the number of the transcript"""


### PR DESCRIPTION
Right now we don't load pseudogenes_with_CDS at the step LoadGFF3, but we should exclude them when we prepare the data already.