### PR TITLE
Disha/valid gene cds exon

### DIFF
--- a/lib/python/ensembl/brc4/runnable/load_sequence_data.py
+++ b/lib/python/ensembl/brc4/runnable/load_sequence_data.py
@@ -1014,11 +1014,10 @@ class load_sequence_data(eHive.BaseRunnable):
         Throws exception if not able to get seq_region_id from "seq_region_map" and "throw_missing" is true.
         """
         #   get seq_region_id (perhaps, by using unversioned name)
-        unversion = self.param("unversion_scaffolds")
         seq_region_name = seq_region_item["name"]
         seq_region_id = seq_region_map.get(seq_region_name, None)
         unversioned_name = None
-        if seq_region_id is None and unversion:
+        if seq_region_id is None and try_unversion:
         # try to get seq_region_id for the unversioned name
             unversioned_name = re.sub(r"\.\d+$", "", seq_region_name)
             seq_region_id = seq_region_map.get(unversioned_name, "")

--- a/lib/python/ensembl/brc4/runnable/load_sequence_data.py
+++ b/lib/python/ensembl/brc4/runnable/load_sequence_data.py
@@ -1014,6 +1014,7 @@ class load_sequence_data(eHive.BaseRunnable):
         Throws exception if not able to get seq_region_id from "seq_region_map" and "throw_missing" is true.
         """
         #   get seq_region_id (perhaps, by using unversioned name)
+        unversion = self.param("unversion_scaffolds")
         seq_region_name = seq_region_item["name"]
         seq_region_id = seq_region_map.get(seq_region_name, None)
         unversioned_name = None

--- a/lib/python/ensembl/brc4/runnable/process_gff3.py
+++ b/lib/python/ensembl/brc4/runnable/process_gff3.py
@@ -240,8 +240,6 @@ class process_gff3(eHive.BaseRunnable):
                 
                 # GENES
                 for gene in record.features:
-                    
-                    
                     if gene.type in ignored_gene_types:
                         continue
                     

--- a/lib/python/ensembl/brc4/runnable/process_gff3.py
+++ b/lib/python/ensembl/brc4/runnable/process_gff3.py
@@ -88,7 +88,7 @@ class process_gff3(eHive.BaseRunnable):
                     "intron"
                     ),
             "skip_unrecognized": False,
-            "skip_transcript" : True,
+            "skip_transcript" : False,
             "allow_pseudogene_with_CDS": False,
             "merge_split_genes": False,
             "exclude_seq_regions": [],

--- a/lib/python/ensembl/brc4/runnable/process_gff3.py
+++ b/lib/python/ensembl/brc4/runnable/process_gff3.py
@@ -515,6 +515,7 @@ class process_gff3(eHive.BaseRunnable):
     
     def gene_to_cds(self, gene) -> list:
         """Create a transcript - exon - cds chain"""
+        
         gene_cds_skip_others = self.param("gene_cds_skip_others")
         transcripts_dict = {}
         del_transcript = []
@@ -526,11 +527,11 @@ class process_gff3(eHive.BaseRunnable):
                     continue
                 else:
                     raise Exception(
-                    "Can not create a chain 'transcript - exon - CDS'"
-                    f" when the gene children are not all CDSs"
-                    f" ({cds.id} of type {cds.type} is child of gene {gene.id})"
-                )
-        
+                        "Can not create a chain 'transcript - exon - CDS'"
+                        f" when the gene children are not all CDSs"
+                        f" ({cds.id} of type {cds.type} is child of gene {gene.id})"
+                    )
+     
             exon = SeqFeature(cds.location, type="exon")
 
             # Add to transcript or create a new one

--- a/lib/python/ensembl/brc4/runnable/process_gff3.py
+++ b/lib/python/ensembl/brc4/runnable/process_gff3.py
@@ -88,7 +88,7 @@ class process_gff3(eHive.BaseRunnable):
                     "intron"
                     ),
             "skip_unrecognized": False,
-            "skip_transcript" : False,
+            "gene_cds_skip_others" : False,
             "allow_pseudogene_with_CDS": False,
             "merge_split_genes": False,
             "exclude_seq_regions": [],
@@ -517,13 +517,13 @@ class process_gff3(eHive.BaseRunnable):
     
     def gene_to_cds(self, gene) -> list:
         """Create a transcript - exon - cds chain"""
-        skip_transcript = self.param("skip_transcript")
+        gene_cds_skip_others = self.param("gene_cds_skip_others")
         transcripts_dict = {}
         del_transcript = []
 
         for count, cds in enumerate(gene.sub_features):
             if cds.type != "CDS":
-                if skip_transcript:
+                if gene_cds_skip_others:
                     del_transcript.append(count)
                     continue
                 else:

--- a/lib/python/ensembl/brc4/runnable/process_gff3.py
+++ b/lib/python/ensembl/brc4/runnable/process_gff3.py
@@ -83,10 +83,12 @@ class process_gff3(eHive.BaseRunnable):
             "ignored_transcript_types": (
                     "antisense_RNA",
                     "RNase_MRP_RNA",
-		    "3'UTR",
-                    "5'UTR" 
+                    "3'UTR",
+                    "5'UTR",
+                    "intron"
                     ),
             "skip_unrecognized": False,
+            "skip_transcript" : True,
             "allow_pseudogene_with_CDS": False,
             "merge_split_genes": False,
             "exclude_seq_regions": [],
@@ -239,6 +241,7 @@ class process_gff3(eHive.BaseRunnable):
                 # GENES
                 for gene in record.features:
                     
+                    
                     if gene.type in ignored_gene_types:
                         continue
                     
@@ -329,7 +332,6 @@ class process_gff3(eHive.BaseRunnable):
         # TRANSCRIPTS
         transcripts_to_delete = []
         for count, transcript in enumerate(gene.sub_features):
-            
             if transcript.type not in allowed_transcript_types and transcript.type not in ignored_transcript_types:
                 fail_types["transcript=" + transcript.type] = 1
                 message = (
@@ -515,16 +517,22 @@ class process_gff3(eHive.BaseRunnable):
     
     def gene_to_cds(self, gene) -> list:
         """Create a transcript - exon - cds chain"""
-
+        skip_transcript = self.param("skip_transcript")
         transcripts_dict = {}
+        del_transcript = []
 
-        for cds in gene.sub_features:
+        for count, cds in enumerate(gene.sub_features):
             if cds.type != "CDS":
-                raise Exception(
+                if skip_transcript:
+                    del_transcript.append(count)
+                    continue
+                else:
+                    raise Exception(
                     "Can not create a chain 'transcript - exon - CDS'"
                     f" when the gene children are not all CDSs"
                     f" ({cds.id} of type {cds.type} is child of gene {gene.id})"
                 )
+        
             exon = SeqFeature(cds.location, type="exon")
 
             # Add to transcript or create a new one
@@ -535,6 +543,9 @@ class process_gff3(eHive.BaseRunnable):
             exon.qualifiers["source"] = gene.qualifiers["source"]
             transcripts_dict[cds.id].sub_features.append(exon)
             transcripts_dict[cds.id].sub_features.append(cds)
+
+        for elt in sorted(del_transcript, reverse=True):
+            gene.sub_features.pop(elt)
 
         transcripts = list(transcripts_dict.values())
         


### PR DESCRIPTION
added a skip_transcript parameter which can be set to 'True' when all mRNA, exon and CDS have gene as parent. This will remove the mRNA and create a mRNA and a separate exon for each CDS. Eg:

Original gff3 file:

>CAJZCX010000003.1	EMBL	gene	8063	9223	.	+	.	ID=gene-PVW1_140005100;Name=PVW1_140005100;
CAJZCX010000003.1	EMBL	CDS	    8063	8089	.	+	0	ID=cds-CAG9471735.1;Parent=gene-PVW1_140005100;
CAJZCX010000003.1	EMBL	CDS	    8232	8306	.	+	0	ID=cds-CAG9471735.1;Parent=gene-PVW1_140005100;
CAJZCX010000003.1	EMBL	CDS	    8511	8711	.	+	0	ID=cds-CAG9471735.1;Parent=gene-PVW1_140005100;
CAJZCX010000003.1   EMBL    CDS     9056	9223	.	+	0	ID=cds-CAG9471735.1;Parent=gene-PVW1_140005100;
CAJZCX010000003.1	EMBL	mRNA	8063	9223	.	+	.	ID=rna-PVW1_140005100;Parent=gene-PVW1_140005100;
CAJZCX010000003.1	EMBL	exon	8063	9223	.	+	.	ID=exon-PVW1_140005100-1;Parent=rna-PVW1_140005100;

gene_models.gff3 created:

> CAJZCX010000003.1	EMBL	gene	8063	9223	.	+	.	ID=PVW1_140005100
CAJZCX010000003.1	EMBL	mRNA	8063	9223	.	+	.	ID=PVW1_140005100_t1;Parent=PVW1_140005100
CAJZCX010000003.1	EMBL	exon	8063	8089	.	+	.	Parent=PVW1_140005100_t1
CAJZCX010000003.1	EMBL	CDS	    8063	8089	.	+	0	ID=CAG9471735.1;Parent=PVW1_140005100_t1
CAJZCX010000003.1	EMBL	exon	8232	8306	.	+	.	Parent=PVW1_140005100_t1
CAJZCX010000003.1	EMBL	CDS	    8232	8306	.	+	0	ID=CAG9471735.1;Parent=PVW1_140005100_t1
CAJZCX010000003.1	EMBL	exon	8511	8711	.	+	.	Parent=PVW1_140005100_t1
CAJZCX010000003.1	EMBL	CDS	    8511	8711	.	+	0	ID=CAG9471735.1;Parent=PVW1_140005100_t1
CAJZCX010000003.1	EMBL	exon	9056	9223	.	+	.	Parent=PVW1_140005100_t1
CAJZCX010000003.1	EMBL	CDS	    9056	9223	.	+	0	ID=CAG9471735.1;Parent=PVW1_140005100_t1
