### PR TITLE
Disha/compare comp report

### DIFF
--- a/lib/perl/Bio/EnsEMBL/Pipeline/PipeConfig/BRC4_genome_compare_conf.pm
+++ b/lib/perl/Bio/EnsEMBL/Pipeline/PipeConfig/BRC4_genome_compare_conf.pm
@@ -238,8 +238,8 @@ sub pipeline_analyses {
       -failed_job_tolerance => 0,
       -rc_name        => '8GB',
        -flow_into      => {
-        '2' => '?accu_name=stats&accu_address={species}'
-      }
+         '2' => '?accu_name=stats&accu_address={species}'
+        }
     },
 
     # Report comparisons

--- a/lib/perl/Bio/EnsEMBL/Pipeline/PipeConfig/BRC4_genome_compare_conf.pm
+++ b/lib/perl/Bio/EnsEMBL/Pipeline/PipeConfig/BRC4_genome_compare_conf.pm
@@ -216,7 +216,7 @@ sub pipeline_analyses {
         2 => [
           '?accu_name=insdc_fasta_dna&accu_input_variable=fasta_dna',
           '?accu_name=insdc_report&accu_input_variable=report',
-	        '?accu_name=accession&accu_input_variable=accession',
+	  '?accu_name=accession&accu_input_variable=accession',
         ],
       },
     },

--- a/lib/perl/Bio/EnsEMBL/Pipeline/PipeConfig/BRC4_genome_compare_conf.pm
+++ b/lib/perl/Bio/EnsEMBL/Pipeline/PipeConfig/BRC4_genome_compare_conf.pm
@@ -103,7 +103,7 @@ sub pipeline_wide_parameters {
             'pipeline_name' => $self->o('pipeline_name'), #This must be defined for the beekeeper to work properly
             'base_path'     => $self->o('tmp_dir'),
             'output_dir'     => $self->o('output_dir'),
-            download_dir   => catdir($self->o('tmp_dir'), "download", '#species#'),    
+            download_dir   => catdir($self->o('tmp_dir'), "download", '#species#'),
     };
 }
 
@@ -152,7 +152,6 @@ sub pipeline_analyses {
          ]
        }
      },
-
 
     { -logic_name  => 'Fasta_DNA',
       -module      => 'Bio::EnsEMBL::Pipeline::Runnable::BRC4::DumpFastaDNA',
@@ -216,7 +215,7 @@ sub pipeline_analyses {
         2 => [
           '?accu_name=insdc_fasta_dna&accu_input_variable=fasta_dna',
           '?accu_name=insdc_report&accu_input_variable=report',
-	  '?accu_name=accession&accu_input_variable=accession',
+          '?accu_name=accession&accu_input_variable=accession',
         ],
       },
     },
@@ -231,13 +230,13 @@ sub pipeline_analyses {
         fasta2 => "#core_fasta_dna#",
         seq_regions => "#seq_region_json#",
         comparison_name => "fasta_dna",
-	accession => "#accession#",
+        accession => "#accession#",
       },
       -language => 'python3',
       -analysis_capacity => 5,
       -failed_job_tolerance => 0,
       -rc_name        => '8GB',
-       -flow_into      => {
+      -flow_into      => {
          '2' => '?accu_name=stats&accu_address={species}'
         }
     },

--- a/lib/perl/Bio/EnsEMBL/Pipeline/PipeConfig/BRC4_genome_compare_conf.pm
+++ b/lib/perl/Bio/EnsEMBL/Pipeline/PipeConfig/BRC4_genome_compare_conf.pm
@@ -103,7 +103,7 @@ sub pipeline_wide_parameters {
             'pipeline_name' => $self->o('pipeline_name'), #This must be defined for the beekeeper to work properly
             'base_path'     => $self->o('tmp_dir'),
             'output_dir'     => $self->o('output_dir'),
-            download_dir   => catdir($self->o('tmp_dir'), "download", '#species#'),
+            download_dir   => catdir($self->o('tmp_dir'), "download", '#species#'),    
     };
 }
 
@@ -187,6 +187,7 @@ sub pipeline_analyses {
     { -logic_name  => 'Get_accession',
       -module      => 'Bio::EnsEMBL::Pipeline::Runnable::BRC4::GetMetaValue',
       -parameters => {
+        provider => "assembly.provider_name",
         param_name => "accession",
         param_key => "assembly.accession",
       },
@@ -215,7 +216,7 @@ sub pipeline_analyses {
         2 => [
           '?accu_name=insdc_fasta_dna&accu_input_variable=fasta_dna',
           '?accu_name=insdc_report&accu_input_variable=report',
-	  '?accu_name=accession&accu_input_variable=accession',
+	        '?accu_name=accession&accu_input_variable=accession',
         ],
       },
     },
@@ -230,15 +231,15 @@ sub pipeline_analyses {
         fasta2 => "#core_fasta_dna#",
         seq_regions => "#seq_region_json#",
         comparison_name => "fasta_dna",
-	accession => "#accession#",
+	      accession => "#accession#",
       },
       -language => 'python3',
       -analysis_capacity => 5,
       -failed_job_tolerance => 0,
       -rc_name        => '8GB',
        -flow_into      => {
-         '2' => '?accu_name=stats&accu_address={species}'
-        }
+        '2' => '?accu_name=stats&accu_address={species}'
+      }
     },
 
     # Report comparisons
@@ -267,4 +268,3 @@ sub resource_classes {
 }
 
 1;
-

--- a/lib/perl/Bio/EnsEMBL/Pipeline/PipeConfig/BRC4_genome_compare_conf.pm
+++ b/lib/perl/Bio/EnsEMBL/Pipeline/PipeConfig/BRC4_genome_compare_conf.pm
@@ -231,7 +231,7 @@ sub pipeline_analyses {
         fasta2 => "#core_fasta_dna#",
         seq_regions => "#seq_region_json#",
         comparison_name => "fasta_dna",
-	      accession => "#accession#",
+	accession => "#accession#",
       },
       -language => 'python3',
       -analysis_capacity => 5,

--- a/lib/perl/Bio/EnsEMBL/Pipeline/Runnable/BRC4/GetMetaValue.pm
+++ b/lib/perl/Bio/EnsEMBL/Pipeline/Runnable/BRC4/GetMetaValue.pm
@@ -30,13 +30,17 @@ sub run {
   
   my $key = $self->param_required("param_key");
   my $name = $self->param_required("param_name");
-
+  my $provider = $self->param_required("provider");
   my $dba = $self->core_dba();
   my $ma = $dba->get_adaptor('MetaContainer');
   
+  my $prov = $ma->single_value_by_key($provider);
   my $value = $ma->single_value_by_key($key);
-  
   print("Get value for $key: $value\n");
+
+  if($prov eq "RefSeq"){
+    $value=~ s/GCA/GCF/;
+  }
   
   $self->dataflow_output_id({ $name => $value }, 2);
 }

--- a/lib/perl/Bio/EnsEMBL/Pipeline/Runnable/BRC4/GetMetaValue.pm
+++ b/lib/perl/Bio/EnsEMBL/Pipeline/Runnable/BRC4/GetMetaValue.pm
@@ -1,3 +1,4 @@
+
 =head1 LICENSE
 
 See the NOTICE file distributed with this work for additional information
@@ -17,7 +18,6 @@ limitations under the License.
 
 =cut
 
-
 package Bio::EnsEMBL::Pipeline::Runnable::BRC4::GetMetaValue;
 
 use strict;
@@ -26,23 +26,23 @@ use warnings;
 use base ('Bio::EnsEMBL::Production::Pipeline::Common::Base');
 
 sub run {
-  my ($self) = @_;
-  
-  my $key = $self->param_required("param_key");
-  my $name = $self->param_required("param_name");
-  my $provider = $self->param_required("provider");
-  my $dba = $self->core_dba();
-  my $ma = $dba->get_adaptor('MetaContainer');
-  
-  my $prov = $ma->single_value_by_key($provider);
-  my $value = $ma->single_value_by_key($key);
-  print("Get value for $key: $value\n");
+    my ($self) = @_;
 
-  if($prov eq "RefSeq"){
-    $value=~ s/GCA/GCF/;
-  }
-  
-  $self->dataflow_output_id({ $name => $value }, 2);
+    my $key      = $self->param_required("param_key");
+    my $name     = $self->param_required("param_name");
+    my $provider = $self->param_required("provider");
+    my $dba      = $self->core_dba();
+    my $ma       = $dba->get_adaptor('MetaContainer');
+
+    my $prov  = $ma->single_value_by_key($provider);
+    my $value = $ma->single_value_by_key($key);
+    print("Get value for $key: $value\n");
+
+    if ( $prov eq "RefSeq" ) {
+        $value =~ s/GCA/GCF/;
+    }
+
+    $self->dataflow_output_id( { $name => $value }, 2 );
 }
 
 1;

--- a/lib/python/ensembl/brc4/runnable/compare_fasta.py
+++ b/lib/python/ensembl/brc4/runnable/compare_fasta.py
@@ -333,7 +333,7 @@ class compare_fasta(eHive.BaseRunnable):
         print(stats)
 
         if only1:
-            stats["max_only1"] = max(len(seq) for seq in only1.keys())
+            stats["max_only1"] = max(only1, key=lambda k: len(k))
             # Only list sequences where the length is > 200
             mini = {seq: name for seq, name in only1.items() if len(seq) <= 200}
             maxi = {seq: name for seq, name in only1.items() if len(seq) > 200}

--- a/lib/python/ensembl/brc4/runnable/compare_fasta.py
+++ b/lib/python/ensembl/brc4/runnable/compare_fasta.py
@@ -27,7 +27,7 @@ from os import path
 from ensembl.brc4.runnable.seqregion_parser import SeqregionParser
 
 
-class SeqGroup():
+class SeqGroup:
     def __init__(self, sequence, identifier=None):
         self.sequence = sequence
         self.length = len(self.sequence)
@@ -43,11 +43,10 @@ class SeqGroup():
         self.ids.append(identifier)
         self.count = len(self.ids)
 
-class compare_fasta(eHive.BaseRunnable):
 
+class compare_fasta(eHive.BaseRunnable):
     def param_defaults(self):
-        return {
-        }
+        return {}
 
     def run(self):
         report = self.param_required("report")
@@ -58,17 +57,16 @@ class compare_fasta(eHive.BaseRunnable):
         species = self.param_required("species")
         name = self.param_required("comparison_name")
         accession = self.param_required("accession")
-        
 
         map_dna = self.get_map(map_dna_path)
         seq1 = self.get_fasta(fasta1, map_dna)
         seq2 = self.get_fasta(fasta2, map_dna)
-        
+
         (stats, diffs, seq_map) = self.compare_seqs(seq1, seq2)
         # Print mapping to a file (add report data)
         map_file = output_dir + "/" + species + "_" + name + ".map"
         self.print_map(seq_map, map_file, report, accession)
-        
+
         # Print full list of results in a file
         output_file = output_dir + "/" + species + "_" + name + ".log"
         print("Write results in %s" % output_file)
@@ -77,25 +75,22 @@ class compare_fasta(eHive.BaseRunnable):
                 out_fh.write(line + "\n")
 
         # Print the stats separately
-        out = {
-                "species" : species,
-                "stats" : stats
-                }
+        out = {"species": species, "stats": stats}
         self.dataflow(out, 2)
-        
+
     def print_map(self, seq_map, map_file, report_file, accession):
-        
+
         report_parser = SeqregionParser()
         report_seq = report_parser.get_report_regions(report_file, accession)
         report = self.add_report_to_map(seq_map, report_seq)
-        
+
         print("Write map in %s" % map_file)
         with open(map_file, "w") as out_fh:
             out_fh.write(json.dumps(report, sort_keys=True, indent=4))
-            
+
     def add_report_to_map(self, seq_map, report_seq):
-        
-        accession_version = r'\.\d+$'
+
+        accession_version = r"\.\d+$"
         report = []
         for insdc_name, old_name in seq_map.items():
             if insdc_name not in report_seq:
@@ -105,38 +100,34 @@ class compare_fasta(eHive.BaseRunnable):
                 seqr["name"] = old_name
                 seqr["EBI_seq_region_name"] = old_name
                 brc4_name = insdc_name
-                brc4_name = re.sub(accession_version, '', brc4_name)
+                brc4_name = re.sub(accession_version, "", brc4_name)
                 seqr["BRC4_seq_region_name"] = brc4_name
-                syns = [{
-                    "source": "INSDC",
-                    "name": insdc_name
-                    }]
+                syns = [{"source": "INSDC", "name": insdc_name}]
                 seqr["synonyms"] = syns
                 report.append(seqr)
 
         return report
-        
-            
+
     def get_map(self, map_path):
-        
+
         print("Read file %s" % map_path)
         data = self.get_json(map_path)
-        
+
         map_dna = {}
-        
+
         for seqr in data:
             name = seqr["name"]
             if "synonyms" in seqr:
                 for syn in seqr["synonyms"]:
                     if syn["name"] == "INSDC":
                         map_dna[name] = syn["value"]
-        
+
         return map_dna
 
     def get_json(self, json_path):
         with open(json_path) as json_file:
             return json.load(json_file)
-        
+
     def build_seq_dict(self, seqs):
         """Build a seq dict taking duplicates into account"""
 
@@ -150,10 +141,10 @@ class compare_fasta(eHive.BaseRunnable):
         return seqs_dict
 
     def get_fasta(self, fasta_path, map_dna):
-        
+
         print("Read file %s" % fasta_path)
         sequences = {}
-        _open = partial(gzip.open, mode='rt') if fasta_path.endswith('.gz') else open
+        _open = partial(gzip.open, mode="rt") if fasta_path.endswith(".gz") else open
         with _open(fasta_path) as fasta_fh:
             for rec in SeqIO.parse(fasta_fh, "fasta"):
                 name = rec.id
@@ -185,123 +176,127 @@ class compare_fasta(eHive.BaseRunnable):
             "summary": None,
             "organellar_summary": None,
             "Assembly_level_1": None,
-            "Assembly_level_2": None
+            "Assembly_level_2": None,
         }
         value = "identical"  # variable used for summary
-        org_value = "no_organelles_present"   # variable used for organellar_summary
+        org_value = "no_organelles_present"  # variable used for organellar_summary
 
         # Compare sequences
         seqs1 = self.build_seq_dict(seq1)
         seqs2 = self.build_seq_dict(seq2)
-       
+
         # Compare number of sequences
         if len(seq1) != len(seq2):
-            comp.append("WARNING: Different number of sequences: %d vs %d" % (len(seq1), len(seq2)))
+            comp.append(
+                "WARNING: Different number of sequences: %d vs %d"
+                % (len(seq1), len(seq2))
+            )
         else:
             comp.append("Same number of sequences: %d" % len(seq1))
-        
-        
-        # Sequences that are not common
-        only1 = {seq: group for seq,
-                 group in seqs1.items() if not seq in seqs2}
 
-        only2 = {seq: group for seq,
-                 group in seqs2.items() if not seq in seqs1}
-        
-        common, group_comp = self.find_common_groups(
-            seqs1, seqs2)
+        # Sequences that are not common
+        only1 = {seq: group for seq, group in seqs1.items() if not seq in seqs2}
+
+        only2 = {seq: group for seq, group in seqs2.items() if not seq in seqs1}
+
+        common, group_comp = self.find_common_groups(seqs1, seqs2)
         comp += group_comp
 
         if only1 or only2:
             value = "mismatch"
-  
+
         # Gathering the organellar sequences
         report = self.param_required("report")
         report_parser = SeqregionParser()
-        report_seq = report_parser.get_report_regions(report,accession)
+        report_seq = report_parser.get_report_regions(report, accession)
         map_dna_path = self.param_required("seq_regions")
         seq_data = self.get_json(map_dna_path)
-        org_loc =self.organellar_assembly(report_seq, seq_data) 
-        INSDC_assembly_level, core_assembly_level = self.assembly_level(report_seq,seq_data)
+        org_loc = self.organellar_assembly(report_seq, seq_data)
+        INSDC_assembly_level, core_assembly_level = self.assembly_level(
+            report_seq, seq_data
+        )
 
-        comp.append("Assembly level: %s vs %s" % (INSDC_assembly_level,core_assembly_level))
+        comp.append(
+            "Assembly level: %s vs %s" % (INSDC_assembly_level, core_assembly_level)
+        )
 
         names_length = {}
         # sequences which have extra N at the end
         if only1 and only2:
             for seq1, name1 in only1.items():
                 len1 = len(seq1)
-                seq1_N = seq1.count('N')
+                seq1_N = seq1.count("N")
                 for seq2, name2 in only2.items():
                     len2 = len(seq2)
-                    seq2_N = seq2.count('N')
+                    seq2_N = seq2.count("N")
                     sequence_2 = seq2[:len1]
                     if sequence_2 == seq1:
                         ignored_seq = seq2[len1:]
-                        N = ignored_seq.count('N')
+                        N = ignored_seq.count("N")
                         if len(ignored_seq) == N:
                             comp.append(
-                                f"Please check extra Ns added in core in  %s and %s" % (name1, name2))
+                                f"Please check extra Ns added in core in  %s and %s"
+                                % (name1, name2)
+                            )
                         else:
                             comp.append(
-                                f"ALERT INSERTIONS at the end or diff assembly level  %s and %s" % (name1, name2))
+                                f"ALERT INSERTIONS at the end or diff assembly level  %s and %s"
+                                % (name1, name2)
+                            )
                     elif len1 == len2:
                         if seq2_N > seq1_N:
                             comp.append(
-                                f"Core has more Ns, check  %s and %s" % (name1, name2))
+                                f"Core has more Ns, check  %s and %s" % (name1, name2)
+                            )
                         elif seq1_N > seq2_N:
                             comp.append(
-                                f"INSDC has more Ns, check  %s and %s" % (name1, name2))
+                                f"INSDC has more Ns, check  %s and %s" % (name1, name2)
+                            )
                         else:
-                            names_length[name1] = name2                                  
+                            names_length[name1] = name2
                     else:
                         continue
 
         if names_length:
             length = len(names_length)
-            comp.append(
-                    f"%d sequences have the same length" % length)
+            comp.append(f"%d sequences have the same length" % length)
             for insdc, core in names_length.items():
-                comp.append(
-                        f"INSDC: %s and coredb : %s" % (insdc, core))
+                comp.append(f"INSDC: %s and coredb : %s" % (insdc, core))
 
         # Remove the duplicates
         for org_name in list(org_loc.keys()):
-            for insdc_id,core_id in common.items():
+            for insdc_id, core_id in common.items():
                 if org_name == core_id:
-                    org_loc.pop(org_name)           
-        
+                    org_loc.pop(org_name)
+
         # checking for multiple entries of organellar seq
-        multi_org = [name.split('.')[0] for name in org_loc.keys()]
+        multi_org = [name.split(".")[0] for name in org_loc.keys()]
         multi_org_acc = [j[:-1] for j in multi_org]  # similar accession
         unique_org_id = list(set(multi_org_acc))
         location = [location for location in org_loc.values()]
         unique_location = location.count("mitochondrial_chromosome")
         unique_apicoplast = location.count("apicoplast_chromosome")
 
-        only1_id=[str(id1) for id1 in only1.values()]
+        only1_id = [str(id1) for id1 in only1.values()]
 
         # comparing organellar sequences with common, only1 and only2
         count = 0
         for org_name, loc in org_loc.items():
-            if org_name == 'na':
+            if org_name == "na":
                 comp.append("MISSING accession in the report (na)")
             else:
                 if org_name in common.keys():
-                    count = count+1
-                    comp.append("%s (both) in location: %s" %
-                                (org_name, loc))
+                    count = count + 1
+                    comp.append("%s (both) in location: %s" % (org_name, loc))
                     if count > 0:
                         org_value = "identical"
                 elif org_name in only1_id:
-                    count = count+1
-                    comp.append("%s (only1) in  location: %s" %
-                                (org_name, loc))
+                    count = count + 1
+                    comp.append("%s (only1) in  location: %s" % (org_name, loc))
                     org_value = "unknown_with_organellar"
                 else:
-                    count = count+1
-                    comp.append("%s (only2) in location: %s" %
-                                (org_name, loc))
+                    count = count + 1
+                    comp.append("%s (only2) in location: %s" % (org_name, loc))
                     org_value = "unknown_with_organellar"
 
         # if the mistmatch is due to added organellar sequences
@@ -324,7 +319,7 @@ class compare_fasta(eHive.BaseRunnable):
         if len(multi_org_acc) != len(unique_org_id):
             if unique_location > 1 or unique_apicoplast > 1:
                 org_value = "WARNING:Multiple_entry"
-                
+
         # updating the stats
         stats["num_diff_seq"] = diff
         stats["common"] = len(common)
@@ -336,49 +331,61 @@ class compare_fasta(eHive.BaseRunnable):
         stats["Assembly_level_1"] = INSDC_assembly_level
         stats["Assembly_level_2"] = core_assembly_level
         print(stats)
-        
+
         if only1:
-            stats["max_only1"] = max(len(seq) for seq in only1.keys())       
+            stats["max_only1"] = max(len(seq) for seq in only1.keys())
             # Only list sequences where the length is > 200
             mini = {seq: name for seq, name in only1.items() if len(seq) <= 200}
             maxi = {seq: name for seq, name in only1.items() if len(seq) > 200}
-        
+
             if mini and len(mini) > 3000:
-                comp.append("WARNING: Ignoring %d sequences from 1 with length <= 200" % len(mini))
+                comp.append(
+                    "WARNING: Ignoring %d sequences from 1 with length <= 200"
+                    % len(mini)
+                )
                 only1 = maxi
-        
+
         if only1:
             # Only list sequences where the length is > 1000
             mini = {seq: name for seq, name in only1.items() if len(seq) <= 1000}
-            maxi = {seq: name for seq, name in only1.items() if len(seq) > 1000}    
+            maxi = {seq: name for seq, name in only1.items() if len(seq) > 1000}
             if mini and len(mini) > 3000:
-                comp.append("WARNING: Ignoring %d sequences from 1 with length <= 1000" % len(mini))
+                comp.append(
+                    "WARNING: Ignoring %d sequences from 1 with length <= 1000"
+                    % len(mini)
+                )
                 only1 = maxi
-    
+
         if only1:
             total = sum([len(seq) for seq in only1.keys()])
             comp.append("WARNING: Sequences only in 1: %d (%d)" % (len(only1), total))
             only_seq1 = {name: len(seq) for seq, name in only1.items()}
             for name, length in sorted(only_seq1.items(), key=lambda x: x[1]):
                 comp.append("\tOnly in 1: %s (%d)" % (name, length))
-            
+
         if only2:
-            stats["max_only2"] = max(len(seq) for seq in only2.keys())  
+            stats["max_only2"] = max(len(seq) for seq in only2.keys())
             # Only list sequences where the length is > 200
             mini = {seq: name for seq, name in only2.items() if len(seq) <= 200}
             maxi = {seq: name for seq, name in only2.items() if len(seq) > 200}
-        
+
             if mini and len(mini) > 3000:
-                comp.append("WARNING: Ignoring %d sequences from 2 with length <= 200" % len(mini))
+                comp.append(
+                    "WARNING: Ignoring %d sequences from 2 with length <= 200"
+                    % len(mini)
+                )
                 only2 = maxi
-                    
+
         if only2:
             # Only list sequences where the length is > 1000
             mini = {seq: name for seq, name in only2.items() if len(seq) <= 1000}
             maxi = {seq: name for seq, name in only2.items() if len(seq) > 1000}
-        
+
             if mini and len(mini) > 3000:
-                comp.append("WARNING: Ignoring %d sequences from 2 with length <= 1000" % len(mini))
+                comp.append(
+                    "WARNING: Ignoring %d sequences from 2 with length <= 1000"
+                    % len(mini)
+                )
                 only2 = maxi
 
         if only2:
@@ -387,7 +394,7 @@ class compare_fasta(eHive.BaseRunnable):
             only_seq2 = {name: len(seq) for seq, name in only2.items()}
             for name, length in sorted(only_seq2.items(), key=lambda x: x[1]):
                 comp.append("\tOnly in 2: %s (%d)" % (name, length))
-        
+
         return (stats, comp, common)
 
     def find_common_groups(self, seqs1, seqs2):
@@ -405,14 +412,16 @@ class compare_fasta(eHive.BaseRunnable):
                         common[group1.ids[0]] = group2.ids[0]
                     else:
                         comp.append(
-                            f"Matched 2 identical groups of sequences: {group1} and {group2}")
+                            f"Matched 2 identical groups of sequences: {group1} and {group2}"
+                        )
                         possible_id2 = " OR ".join(group2.ids)
                         for id1 in group1.ids:
                             common[id1] = possible_id2
 
                 else:
                     comp.append(
-                        f"Matched 2 different groups of sequences ({group1.count} vs {group2.count}): {group1} and {group2}")
+                        f"Matched 2 different groups of sequences ({group1.count} vs {group2.count}): {group1} and {group2}"
+                    )
 
         print(comp)
         print(len(common))
@@ -423,57 +432,71 @@ class compare_fasta(eHive.BaseRunnable):
         org_loc = {}
         org2 = []
         org3 = []
-        
+
         # Gathering data from the INSDC report file and storing it into a list
         for name1, details1 in report_seq.items():
             if "location" in details1:
-                if details1['location'] not in ("chromosome", "nuclear_chromosome", "linkage_group"):
-                    loc = details1['location']
-                    org_loc[name1]=loc
+                if details1["location"] not in (
+                    "chromosome",
+                    "nuclear_chromosome",
+                    "linkage_group",
+                ):
+                    loc = details1["location"]
+                    org_loc[name1] = loc
 
         # Gathering data from Seq_json file and storing it into a list
         for rep in data:
             for name2, details2 in rep.items():
                 if "location" in name2:
-                    if details2 not in ("chromosome", "nuclear_chromosome", "linkage_group"):
-                        name = rep['BRC4_seq_region_name']
+                    if details2 not in (
+                        "chromosome",
+                        "nuclear_chromosome",
+                        "linkage_group",
+                    ):
+                        name = rep["BRC4_seq_region_name"]
                         org_loc[name] = details2
-        
+
         return org_loc
 
     def assembly_level(self, report_seq, core_data):
 
-        INSDC_assembly_level=[]
-        core_assembly_level=[]
+        INSDC_assembly_level = []
+        core_assembly_level = []
         core_assembly = {}
         scaffold_INSDC = 0
         chromosome_INSDC = 0
         scaffold_core = 0
         chromosome_core = 0
-        
-    
+
         for name, insdc_rep in report_seq.items():
-            if insdc_rep['coord_system_level'] not in ("chromosome", "nuclear_chromosome"):
-                scaffold_INSDC+=1
+            if insdc_rep["coord_system_level"] not in (
+                "chromosome",
+                "nuclear_chromosome",
+            ):
+                scaffold_INSDC += 1
             else:
-                chromosome_INSDC+=1
-    
-        INSDC_assembly_level.extend([scaffold_INSDC,chromosome_INSDC])
-    
+                chromosome_INSDC += 1
+
+        INSDC_assembly_level.extend([scaffold_INSDC, chromosome_INSDC])
+
         for core_details in core_data:
-            name = core_details['BRC4_seq_region_name']
-            coord_system_level = core_details ['coord_system_level']
+            name = core_details["BRC4_seq_region_name"]
+            coord_system_level = core_details["coord_system_level"]
             core_assembly[name] = coord_system_level
-        
-        for name,coord_level in core_assembly.items():
+
+        for name, coord_level in core_assembly.items():
             if coord_level not in ("chromosome", "nuclear_chromosome"):
-                scaffold_core+=1
+                scaffold_core += 1
             else:
-                chromosome_core+=1
-                    
-        core_assembly_level.extend([scaffold_core,chromosome_core])
+                chromosome_core += 1
 
-        INSDC_assembly_level = ', '.join([str(assembly) for assembly in INSDC_assembly_level])
-        core_assembly_level = ', '.join([str(assembly) for assembly in core_assembly_level])
+        core_assembly_level.extend([scaffold_core, chromosome_core])
 
-        return INSDC_assembly_level,core_assembly_level     
+        INSDC_assembly_level = ", ".join(
+            [str(assembly) for assembly in INSDC_assembly_level]
+        )
+        core_assembly_level = ", ".join(
+            [str(assembly) for assembly in core_assembly_level]
+        )
+
+        return INSDC_assembly_level, core_assembly_level

--- a/lib/python/ensembl/brc4/runnable/compare_fasta.py
+++ b/lib/python/ensembl/brc4/runnable/compare_fasta.py
@@ -187,10 +187,7 @@ class compare_fasta(eHive.BaseRunnable):
 
         # Compare number of sequences
         if len(seq1) != len(seq2):
-            comp.append(
-                "WARNING: Different number of sequences: %d vs %d"
-                % (len(seq1), len(seq2))
-            )
+            comp.append("WARNING: Different number of sequences: %d vs %d" % (len(seq1), len(seq2)))
         else:
             comp.append("Same number of sequences: %d" % len(seq1))
 
@@ -212,13 +209,9 @@ class compare_fasta(eHive.BaseRunnable):
         map_dna_path = self.param_required("seq_regions")
         seq_data = self.get_json(map_dna_path)
         org_loc = self.organellar_assembly(report_seq, seq_data)
-        INSDC_assembly_level, core_assembly_level = self.assembly_level(
-            report_seq, seq_data
-        )
+        INSDC_assembly_level, core_assembly_level = self.assembly_level(report_seq, seq_data)
 
-        comp.append(
-            "Assembly level: %s vs %s" % (INSDC_assembly_level, core_assembly_level)
-        )
+        comp.append("Assembly level: %s vs %s" % (INSDC_assembly_level, core_assembly_level))
 
         names_length = {}
         # sequences which have extra N at the end
@@ -234,10 +227,7 @@ class compare_fasta(eHive.BaseRunnable):
                         ignored_seq = seq2[len1:]
                         N = ignored_seq.count("N")
                         if len(ignored_seq) == N:
-                            comp.append(
-                                f"Please check extra Ns added in core in  %s and %s"
-                                % (name1, name2)
-                            )
+                            comp.append(f"Please check extra Ns added in core in  %s and %s" % (name1, name2))
                         else:
                             comp.append(
                                 f"ALERT INSERTIONS at the end or diff assembly level  %s and %s"
@@ -245,13 +235,9 @@ class compare_fasta(eHive.BaseRunnable):
                             )
                     elif len1 == len2:
                         if seq2_N > seq1_N:
-                            comp.append(
-                                f"Core has more Ns, check  %s and %s" % (name1, name2)
-                            )
+                            comp.append(f"Core has more Ns, check  %s and %s" % (name1, name2))
                         elif seq1_N > seq2_N:
-                            comp.append(
-                                f"INSDC has more Ns, check  %s and %s" % (name1, name2)
-                            )
+                            comp.append(f"INSDC has more Ns, check  %s and %s" % (name1, name2))
                         else:
                             names_length[name1] = name2
                     else:
@@ -339,10 +325,7 @@ class compare_fasta(eHive.BaseRunnable):
             maxi = {seq: name for seq, name in only1.items() if len(seq) > 200}
 
             if mini and len(mini) > 3000:
-                comp.append(
-                    "WARNING: Ignoring %d sequences from 1 with length <= 200"
-                    % len(mini)
-                )
+                comp.append("WARNING: Ignoring %d sequences from 1 with length <= 200" % len(mini))
                 only1 = maxi
 
         if only1:
@@ -350,10 +333,7 @@ class compare_fasta(eHive.BaseRunnable):
             mini = {seq: name for seq, name in only1.items() if len(seq) <= 1000}
             maxi = {seq: name for seq, name in only1.items() if len(seq) > 1000}
             if mini and len(mini) > 3000:
-                comp.append(
-                    "WARNING: Ignoring %d sequences from 1 with length <= 1000"
-                    % len(mini)
-                )
+                comp.append("WARNING: Ignoring %d sequences from 1 with length <= 1000" % len(mini))
                 only1 = maxi
 
         if only1:
@@ -370,10 +350,7 @@ class compare_fasta(eHive.BaseRunnable):
             maxi = {seq: name for seq, name in only2.items() if len(seq) > 200}
 
             if mini and len(mini) > 3000:
-                comp.append(
-                    "WARNING: Ignoring %d sequences from 2 with length <= 200"
-                    % len(mini)
-                )
+                comp.append("WARNING: Ignoring %d sequences from 2 with length <= 200" % len(mini))
                 only2 = maxi
 
         if only2:
@@ -382,10 +359,7 @@ class compare_fasta(eHive.BaseRunnable):
             maxi = {seq: name for seq, name in only2.items() if len(seq) > 1000}
 
             if mini and len(mini) > 3000:
-                comp.append(
-                    "WARNING: Ignoring %d sequences from 2 with length <= 1000"
-                    % len(mini)
-                )
+                comp.append("WARNING: Ignoring %d sequences from 2 with length <= 1000" % len(mini))
                 only2 = maxi
 
         if only2:
@@ -411,9 +385,7 @@ class compare_fasta(eHive.BaseRunnable):
                     if group1.count == 1:
                         common[group1.ids[0]] = group2.ids[0]
                     else:
-                        comp.append(
-                            f"Matched 2 identical groups of sequences: {group1} and {group2}"
-                        )
+                        comp.append(f"Matched 2 identical groups of sequences: {group1} and {group2}")
                         possible_id2 = " OR ".join(group2.ids)
                         for id1 in group1.ids:
                             common[id1] = possible_id2
@@ -492,11 +464,7 @@ class compare_fasta(eHive.BaseRunnable):
 
         core_assembly_level.extend([scaffold_core, chromosome_core])
 
-        INSDC_assembly_level = ", ".join(
-            [str(assembly) for assembly in INSDC_assembly_level]
-        )
-        core_assembly_level = ", ".join(
-            [str(assembly) for assembly in core_assembly_level]
-        )
+        INSDC_assembly_level = ", ".join([str(assembly) for assembly in INSDC_assembly_level])
+        core_assembly_level = ", ".join([str(assembly) for assembly in core_assembly_level])
 
         return INSDC_assembly_level, core_assembly_level

--- a/lib/python/ensembl/brc4/runnable/compare_fasta.py
+++ b/lib/python/ensembl/brc4/runnable/compare_fasta.py
@@ -287,7 +287,7 @@ class compare_fasta(eHive.BaseRunnable):
             else:
                 if org_name in common.keys():
                     count = count + 1
-                    comp.append("%s (both) in location: %s" % (org_name, loc))
+                    comp.append(f"{org_name} (both) in location: {loc}")
                     if count > 0:
                         org_value = "identical"
                 elif org_name in only1_id:

--- a/lib/python/ensembl/brc4/runnable/compare_report.py
+++ b/lib/python/ensembl/brc4/runnable/compare_report.py
@@ -42,7 +42,8 @@ class compare_report(eHive.BaseRunnable):
         report = output_dir + "/report.log"
         print("Write report in %s" % report)
         
-        fields = ("species", "seq_count_1", "seq_count_2", "diff_length", "common", "only1", "only2", "max_only1", "max_only2")
+        fields = ("species", "accession", "seq_count_1", "seq_count_2", "num_diff_seq", "common",
+                    "only1", "only2", "max_only1", "max_only2", "other_locations", "summary", "organellar_summary", "Assembly_level_1", "Assembly_level_2")
         
         with open(report, "w") as out_fh:
             out_fh.write("#" + "\t".join(fields) + "\n")
@@ -56,4 +57,3 @@ class compare_report(eHive.BaseRunnable):
                     if f in stat:
                         line.append(str(stat[f]))
                 out_fh.write("\t".join(line) + "\n")
-                

--- a/lib/python/ensembl/brc4/runnable/compare_report.py
+++ b/lib/python/ensembl/brc4/runnable/compare_report.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 
-
 import eHive
 import gzip
 import json
@@ -29,29 +28,42 @@ from os import path
 
 
 class compare_report(eHive.BaseRunnable):
-
     def param_defaults(self):
-        return {
-        }
+        return {}
 
     def run(self):
         stats = self.param("stats")
         output_dir = self.param_required("output_dir")
-        
+
         # Print report
         report = output_dir + "/report.log"
         print("Write report in %s" % report)
-        
-        fields = ("species", "accession", "seq_count_1", "seq_count_2", "num_diff_seq", "common",
-                    "only1", "only2", "max_only1", "max_only2", "other_locations", "summary", "organellar_summary", "Assembly_level_1", "Assembly_level_2")
-        
+
+        fields = (
+            "species",
+            "accession",
+            "seq_count_1",
+            "seq_count_2",
+            "num_diff_seq",
+            "common",
+            "only1",
+            "only2",
+            "max_only1",
+            "max_only2",
+            "other_locations",
+            "summary",
+            "organellar_summary",
+            "Assembly_level_1",
+            "Assembly_level_2",
+        )
+
         with open(report, "w") as out_fh:
             out_fh.write("#" + "\t".join(fields) + "\n")
-            
+
             for species in sorted(stats.keys()):
                 stat = stats[species]
                 stat["species"] = species
-                
+
                 line = []
                 for f in fields:
                     if f in stat:

--- a/lib/python/ensembl/brc4/runnable/seqregion_parser.py
+++ b/lib/python/ensembl/brc4/runnable/seqregion_parser.py
@@ -60,9 +60,7 @@ class SeqregionParser:
         report_csv, metadata = self.report_to_csv(report_path)
 
         # Feed the csv string to the CSV reader
-        reader = csv.DictReader(
-            report_csv.splitlines(), delimiter="\t", quoting=csv.QUOTE_NONE
-        )
+        reader = csv.DictReader(report_csv.splitlines(), delimiter="\t", quoting=csv.QUOTE_NONE)
 
         # Metadata
         assembly_level = "contig"
@@ -108,9 +106,7 @@ class SeqregionParser:
                     data += line
             return data, metadata
 
-    def make_seq_region(
-        self, row: Dict[str, str], assembly_level: str, use_refseq: bool
-    ) -> Dict[str, Any]:
+    def make_seq_region(self, row: Dict[str, str], assembly_level: str, use_refseq: bool) -> Dict[str, Any]:
         """From a row of the report, create one seq_region dict.
 
         Args:

--- a/lib/python/ensembl/brc4/runnable/seqregion_parser.py
+++ b/lib/python/ensembl/brc4/runnable/seqregion_parser.py
@@ -43,7 +43,7 @@ class SeqregionParser:
             "kinetoplast" : "kinetoplast"
     }
     
-    def get_report_regions(self, report_path: str, use_refseq: bool = False) -> Dict[str, dict]:
+    def get_report_regions(self, report_path: str, accession: str, use_refseq: bool = False) -> Dict[str, dict]:
         """Get seq_region data from report file.
 
         Args:
@@ -52,6 +52,8 @@ class SeqregionParser:
         Returns:
             A dict of seq_regions dicts, with their name as the key
         """
+        if accession.startswith('GCF'):
+            use_refseq = True
         # Get the report in a CSV format, easier to manipulate
         report_csv, metadata = self.report_to_csv(report_path)
         

--- a/lib/python/ensembl/brc4/runnable/seqregion_parser.py
+++ b/lib/python/ensembl/brc4/runnable/seqregion_parser.py
@@ -28,22 +28,24 @@ class SeqregionParser:
     """
 
     synonym_map = {
-            "Sequence-Name" : "INSDC_submitted_name",
-            "GenBank-Accn" : "INSDC",
-            "RefSeq-Accn" : "RefSeq",
-            "Assigned-Molecule" : "GenBank",
-            }
+        "Sequence-Name": "INSDC_submitted_name",
+        "GenBank-Accn": "INSDC",
+        "RefSeq-Accn": "RefSeq",
+        "Assigned-Molecule": "GenBank",
+    }
 
     molecule_location = {
-            "chromosome" : "nuclear_chromosome",
-            "mitochondrion" : "mitochondrial_chromosome",
-            "apicoplast" : "apicoplast_chromosome",
-            "plasmid" : "plasmid",
-            "linkage group" : "linkage_group", 
-            "kinetoplast" : "kinetoplast"
+        "chromosome": "nuclear_chromosome",
+        "mitochondrion": "mitochondrial_chromosome",
+        "apicoplast": "apicoplast_chromosome",
+        "plasmid": "plasmid",
+        "linkage group": "linkage_group",
+        "kinetoplast": "kinetoplast",
     }
-    
-    def get_report_regions(self, report_path: str, accession: str, use_refseq: bool = False) -> Dict[str, dict]:
+
+    def get_report_regions(
+        self, report_path: str, accession: str, use_refseq: bool = False
+    ) -> Dict[str, dict]:
         """Get seq_region data from report file.
 
         Args:
@@ -52,26 +54,28 @@ class SeqregionParser:
         Returns:
             A dict of seq_regions dicts, with their name as the key
         """
-        if accession.startswith('GCF'):
+        if accession.startswith("GCF"):
             use_refseq = True
         # Get the report in a CSV format, easier to manipulate
         report_csv, metadata = self.report_to_csv(report_path)
-        
+
         # Feed the csv string to the CSV reader
-        reader = csv.DictReader(report_csv.splitlines(), delimiter="\t", quoting=csv.QUOTE_NONE)
-        
+        reader = csv.DictReader(
+            report_csv.splitlines(), delimiter="\t", quoting=csv.QUOTE_NONE
+        )
+
         # Metadata
         assembly_level = "contig"
         if "Assembly level" in metadata:
             assembly_level = metadata["Assembly level"].lower()
-        
+
         # Create the seq_regions
         seq_regions = {}
         for row in reader:
             seq_region = self.make_seq_region(row, assembly_level, use_refseq)
             name = seq_region["name"]
             seq_regions[name] = seq_region
-        
+
         return seq_regions
 
     def report_to_csv(self, report_path: str) -> Tuple[str, dict]:
@@ -84,7 +88,7 @@ class SeqregionParser:
         """
 
         _open = report_path.endswith(".gz") and gzip.open or open
-        with _open(report_path, 'rt') as report:
+        with _open(report_path, "rt") as report:
             data = ""
             metadata = {}
             last_head = ""
@@ -103,16 +107,17 @@ class SeqregionParser:
                         last_head = ""
                     data += line
             return data, metadata
-    
-    def make_seq_region(self, row: Dict[str, str], assembly_level: str,
-                        use_refseq: bool) -> Dict[str, Any]:
+
+    def make_seq_region(
+        self, row: Dict[str, str], assembly_level: str, use_refseq: bool
+    ) -> Dict[str, Any]:
         """From a row of the report, create one seq_region dict.
 
         Args:
             row: A seq_region row from the INSDC report.
             assembly_level: what level is the seq_region (chromosome, contig, etc.)
             use_refseq: Expect a RefSeq seq_region report.
-        
+
         Returns:
             A seq_region dict.
         """
@@ -126,41 +131,41 @@ class SeqregionParser:
         synonyms = []
         for field, source in synonym_map.items():
             if field in row and row[field].lower() != "na":
-                synonym = { "source" : source, "name" : row[field] }
+                synonym = {"source": source, "name": row[field]}
                 synonyms.append(synonym)
         if len(synonyms) > 0:
             synonyms.sort(key=lambda x: x["source"])
             seq_region["synonyms"] = synonyms
-        
+
         # Length
         field = "Sequence-Length"
         if field in row and row[field].lower() != "na":
             seq_region["length"] = int(row[field])
-        
+
         if use_refseq:
             if "RefSeq-Accn" in row:
                 seq_region["name"] = row["RefSeq-Accn"]
             else:
                 raise Exception(f"No RefSeq name for {row['Sequence-Name']}")
-            
+
         else:
             if "GenBank-Accn" in row:
                 seq_region["name"] = row["GenBank-Accn"]
             else:
                 raise Exception(f"No INSDC name for {row['Sequence-Name']}")
-        
+
         # Coord system and location
         seq_role = row["Sequence-Role"]
-        
+
         # Scaffold?
-        if seq_role in ("unplaced-scaffold", "unlocalized-scaffold","alt-scaffold"):
+        if seq_role in ("unplaced-scaffold", "unlocalized-scaffold", "alt-scaffold"):
             seq_region["coord_system_level"] = "scaffold"
-        
+
         # Chromosome? Check location
         elif seq_role == "assembled-molecule":
             seq_region["coord_system_level"] = "chromosome"
             location = row["Assigned-Molecule-Location/Type"].lower()
-            
+
             # Get location metadata
             if location in molecule_location:
                 seq_location = molecule_location[location]


### PR DESCRIPTION
1.  Added more comparison in compare_fasta:
- Compare the assembly level for INSDC and coredb
- Add to report, same length mismatched sequences
- Look for insertions and replaced Ns in INSDC or coredb

2. Changed accession to GCF when the provider is RefSeq and compared with RefSeq assembly.
All the RefSeq accessions are swapped to GCA (GCF --> GCA) format as all the assemblies are derived from Genbank but not all the RefSeq assemblies are identical to Genbank. Hence we want to compare RefSeq assembly to its own report file. 
3. Added more fields to report.log.
4. used black to format the modified python files.


