### PR TITLE
Mbarba/fix map

### DIFF
--- a/lib/perl/Bio/EnsEMBL/Pipeline/Runnable/BRC4/DumpSeqRegionJson.pm
+++ b/lib/perl/Bio/EnsEMBL/Pipeline/Runnable/BRC4/DumpSeqRegionJson.pm
@@ -198,6 +198,7 @@ sub load_external_db_map {
       next if $line =~ /^\s*$/ or $line =~ /^#/;
       # We use the mapping in reverse order because we dump
       my ($to, $from) = split("\t", $line);
+      die("Incorrect external db map: $line") if not defined($to) and not defined($from);
       $map{$from} = $to;
     }
     close $mapfh;


### PR DESCRIPTION
Fix a silly mistake (the only real consequence is the code sends a lot of warnings since it's fails to skip empty lines).
Also add a check, in case the map is wrong (i.e. not 2 strings separated by a tab).