### PR TITLE
Mbarba/dump events

### DIFF
--- a/lib/perl/Bio/EnsEMBL/Pipeline/PipeConfig/BRC4_genome_dumper_conf.pm
+++ b/lib/perl/Bio/EnsEMBL/Pipeline/PipeConfig/BRC4_genome_dumper_conf.pm
@@ -31,7 +31,7 @@ package Bio::EnsEMBL::Pipeline::PipeConfig::BRC4_genome_dumper_conf;
 
 use strict;
 use warnings;
-use File::Spec::Functions qw/catfile/;
+use File::Spec::Functions qw/catfile catdir/;
 use Data::Dumper;
 use Bio::EnsEMBL::Hive::Version 2.4;
 use Bio::EnsEMBL::ApiVersion qw/software_version/;
@@ -45,6 +45,7 @@ my $root_dir = "$package_dir/../../../../../..";
 
 my $schema_dir = "$root_dir/schema";
 my $data_dir = "$root_dir/data";
+my $runnables_dir = "$root_dir/lib/python/ensembl/brc4/runnable";
 
 use base ('Bio::EnsEMBL::Pipeline::PipeConfig::BRC4_base_conf');
 
@@ -76,6 +77,7 @@ sub default_options {
        'do_fasta_pep' => $self->o('dump_all'),
        'do_gff' => $self->o('dump_all'),
        'do_agp' => $self->o('dump_all'),
+       'do_events' => $self->o('dump_all'),
        # Json meta
         'do_func' => $self->o('dump_all'),
         'do_genome' => $self->o('dump_all'),
@@ -178,6 +180,7 @@ sub pipeline_wide_parameters {
             'do_gff'      => $self->o('do_gff'),
             'do_agp'      => $self->o('do_agp'),
             'do_gff'      => $self->o('do_gff'),
+            'do_events'      => $self->o('do_events'),
             'do_genome'      => $self->o('do_genome'),
             'do_func'      => $self->o('do_func'),
             'do_seq_reg'      => $self->o('do_seq_reg'),
@@ -266,8 +269,45 @@ sub pipeline_analyses {
            'Metadata_makers',
            WHEN('#do_gff#', 'GFF3_maker'),
            WHEN('#do_agp#', 'AGP_maker'),
+           WHEN('#do_events#', 'Extract_connection'),
          ] }
      },
+
+### Ids events
+    {
+      -logic_name => 'Extract_connection',
+      -module     => 'Bio::EnsEMBL::Pipeline::Runnable::BRC4::ExtractConnection',
+      -max_retry_count => 0,
+      -hive_capacity   => 20,
+      -priority        => 5,
+      -rc_name         => 'default',
+      -flow_into  => { 2 => 'Events_dumper' },
+    },
+
+    {
+      -logic_name      => 'Events_dumper',
+      -module          => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
+      -parameters      => {
+        events_dir => catdir('#base_path#', 'events', '#species#'),
+        output_file => catfile('#events_dir#', 'ids_events.tab'),
+        hash_key => 'events',
+        cmd => "mkdir -p #events_dir#;"
+          . " python $runnables_dir/dump_stable_ids.py"
+          . " --host #host# "
+          . " --port #port# "
+          . " --user #user# "
+          . " --password '#password#' "
+          . " --dbname #dbname# "
+          . " --output_file #output_file#",
+      },
+      -max_retry_count => 0,
+      -analysis_capacity => 2,
+      -rc_name         => 'default',
+      -flow_into       => {
+        1 => '?accu_name=manifest&accu_address={hash_key}&accu_input_variable=output_file'
+      },
+    },
+
 
 ### GFF3
      { -logic_name     => 'GFF3_maker',

--- a/lib/perl/Bio/EnsEMBL/Pipeline/Runnable/BRC4/ExtractConnection.pm
+++ b/lib/perl/Bio/EnsEMBL/Pipeline/Runnable/BRC4/ExtractConnection.pm
@@ -1,0 +1,44 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::Pipeline::Runnable::BRC4::ExtractConnection;
+
+use strict;
+use warnings;
+use base ('Bio::EnsEMBL::Production::Pipeline::Common::Base');
+use File::Spec::Functions qw(catdir catfile);
+
+sub run {
+  my ($self) = @_;
+  my $species = $self->param_required('species');
+  
+  my $dba = $self->core_dba();
+
+  my $sql_params = {
+    host => $self->core_dbc->host,
+    port => $self->core_dbc->port,
+    user => $self->core_dbc->username,
+    password => $self->core_dbc->password,
+    dbname => $self->core_dbc->dbname,
+  };
+  
+  $self->dataflow_output_id($sql_params, 2);
+}
+
+1;

--- a/lib/perl/Bio/EnsEMBL/Pipeline/Runnable/BRC4/Manifest.pm
+++ b/lib/perl/Bio/EnsEMBL/Pipeline/Runnable/BRC4/Manifest.pm
@@ -35,9 +35,13 @@ use v5.14;
 sub run {
   my ($self) = @_;
 
-  my $manifest = $self->param_required('manifest');
-  my $output_dir = $self->param_required('output_dir');
   my $species = $self->param_required('species');
+  my $manifest = $self->param('manifest');
+  if (not manifest_has_files($manifest)) {
+    say("No manifest data for $species");
+    return;
+  }
+  my $output_dir = $self->param_required('output_dir');
   my $species_component = $self->get_meta_value('BRC4.component');
   my $species_abbrev = $self->get_meta_value('BRC4.organism_abbrev');
   my $species_name = $species_abbrev // $species;
@@ -73,6 +77,26 @@ sub run {
   $self->dataflow_output_id({ "manifest" => $manifest_path }, 2);
 
   return;
+}
+
+sub manifest_has_files {
+  my ($manifest) = @_;
+
+  my $has_files = 0;
+  for my $name (keys %$manifest) {
+
+    if (ref($manifest->{$name}) eq 'HASH') {
+      foreach my $subname (sort keys %{ $manifest->{$name} }) {
+        my $file = $manifest->{$name}->{$subname};
+        $has_files++ if -s $file;
+      }
+    } else {
+      my $file = $manifest->{$name};
+      $has_files++ if -s $file;
+    }
+  }
+  
+  return $has_files;
 }
 
 sub get_meta_value {

--- a/lib/perl/Bio/EnsEMBL/Pipeline/Runnable/BRC4/Manifest.pm
+++ b/lib/perl/Bio/EnsEMBL/Pipeline/Runnable/BRC4/Manifest.pm
@@ -54,7 +54,7 @@ sub run {
   for my $name (keys %$manifest) {
 
     if (ref($manifest->{$name}) eq 'HASH') {
-      foreach my $subname (sort keys %{ $manifest->{$name} }) {
+      foreach my $subname (keys %{ $manifest->{$name} }) {
         my $file = prepare_file($manifest->{$name}->{$subname}, $dir, $species, $species_abbrev);
         $final_manifest{$name}{$subname} = $file if $file;
       }
@@ -86,7 +86,7 @@ sub manifest_has_files {
   for my $name (keys %$manifest) {
 
     if (ref($manifest->{$name}) eq 'HASH') {
-      foreach my $subname (sort keys %{ $manifest->{$name} }) {
+      foreach my $subname (keys %{ $manifest->{$name} }) {
         my $file = $manifest->{$name}->{$subname};
         $has_files++ if -s $file;
       }

--- a/lib/python/ensembl/brc4/runnable/dump_stable_ids.py
+++ b/lib/python/ensembl/brc4/runnable/dump_stable_ids.py
@@ -324,6 +324,7 @@ class DumpStableIDs:
         WHERE (old_stable_id != new_stable_id OR old_stable_id IS NULL OR new_stable_id IS NULL)
             AND type="gene"
             AND mapping_session_id=%s
+        GROUP BY old_stable_id, new_stable_id, mapping_session_id
         """
         values = (session_id,)
         cursor = self.server.get_cursor()

--- a/lib/python/ensembl/brc4/runnable/dump_stable_ids.py
+++ b/lib/python/ensembl/brc4/runnable/dump_stable_ids.py
@@ -224,7 +224,7 @@ class StableIdEvent:
         if self.name != "new":
             new_pairs = []
             for pair in self.pairs:
-                if pair["old_id"] == "":
+                if pair.get("old_id", "") == "":
                     continue
                 new_pairs.append(pair)
             self.pairs = new_pairs

--- a/lib/python/ensembl/brc4/runnable/dump_stable_ids.py
+++ b/lib/python/ensembl/brc4/runnable/dump_stable_ids.py
@@ -23,7 +23,7 @@ from typing import Any, List, Dict, Optional, Set, Tuple
 from ensembl.brc4.runnable.core_server import CoreServer
 
 
-BRC4_START_DATE = datetime(2019, 9, 1)
+BRC4_START_DATE = datetime(2020, 5, 1)
 
 
 class UnsupportedEvent(ValueError):

--- a/lib/python/ensembl/brc4/runnable/dump_stable_ids.py
+++ b/lib/python/ensembl/brc4/runnable/dump_stable_ids.py
@@ -216,6 +216,19 @@ class StableIdEvent:
         else:
             raise UnsupportedEvent(f"Event {self.from_set} to {self.to_set} is not supported")
     
+    def clean_pairs(self) -> None:
+        """Remove the empty old pairs when the event is not 'new'."""
+        if not self.name:
+            self._name_event()
+        
+        if self.name != "new":
+            new_pairs = []
+            for pair in self.pairs:
+                if pair["old_id"] == "":
+                    continue
+                new_pairs.append(pair)
+            self.pairs = new_pairs
+    
     def get_name(self) -> str:
         """Retrieve the name for this event, update it beforehand."""
         self._name_event()
@@ -374,7 +387,7 @@ class DumpStableIDs:
         for to_id in to_list:
             to_list[to_id] = StableIdEvent.clean_set(to_list[to_id])
         
-        events = []
+        events: List[StableIdEvent] = []
         for old_id in from_list:
             if not old_id or old_id not in from_list: continue
             event = StableIdEvent([old_id], from_list[old_id])
@@ -392,6 +405,7 @@ class DumpStableIDs:
         stats = {}
         for event in events:
             name = event.get_name()
+            event.clean_pairs()
             if not name in stats:
                 stats[name] = 1
             else:

--- a/lib/python/ensembl/brc4/runnable/dump_stable_ids.py
+++ b/lib/python/ensembl/brc4/runnable/dump_stable_ids.py
@@ -151,6 +151,7 @@ class StableIdEvent:
             
         """
         return set([id for id in this_list if id])
+        
     
     def add_from(self, from_id: str) -> None:
         """Store an id in the from_set."""
@@ -359,12 +360,12 @@ class DumpStableIDs:
             if old_id in from_list:
                 from_list[old_id].add(new_id)
             else:
-                from_list[old_id] = set(new_id)
+                from_list[old_id] = set([new_id])
 
             if new_id in to_list:
                 to_list[new_id].add(old_id)
             else:
-                to_list[new_id] = set(old_id)
+                to_list[new_id] = set([old_id])
         
         # Remove empty elements
         for from_id in from_list:
@@ -423,7 +424,7 @@ class DumpStableIDs:
             # Extend the group in the to ids
             for to_id in event.to_set:
                 if to_id in to_list:
-                    to_from_ids = to_list[to_id]
+                    to_from_ids: List[str] = to_list[to_id]
                     # Add to the from list?
                     for to_from_id in to_from_ids:
                         if not to_from_id in event.from_set:
@@ -439,6 +440,7 @@ class DumpStableIDs:
                         if not from_to_id in event.to_set:
                             event.add_to(from_to_id)
                             extended = True
+            
             
             # Clean up
             from_list = {from_id: from_list[from_id] for from_id in from_list if from_id not in event.from_set}

--- a/lib/python/ensembl/brc4/runnable/dump_stable_ids.py
+++ b/lib/python/ensembl/brc4/runnable/dump_stable_ids.py
@@ -441,11 +441,10 @@ class DumpStableIDs:
                         if not from_to_id in event.to_set:
                             event.add_to(from_to_id)
                             extended = True
-            
-            
-            # Clean up
-            from_list = {from_id: from_list[from_id] for from_id in from_list if from_id not in event.from_set}
-            to_list = {to_id: to_list[to_id] for to_id in to_list if to_id not in event.to_set}
+        
+        # Clean up
+        from_list = {from_id: from_list[from_id] for from_id in from_list if from_id not in event.from_set}
+        to_list = {to_id: to_list[to_id] for to_id in to_list if to_id not in event.to_set}
         
         return (event, from_list, to_list)
 

--- a/schema/manifest_schema.json
+++ b/schema/manifest_schema.json
@@ -15,7 +15,8 @@
         "seq_attrib" : { "$ref" : "#/definitions/file_info" },
         "genome" : { "$ref" : "#/definitions/file_info" },
         "functional_annotation" : { "$ref" : "#/definitions/file_info" },
-        "agp" : { "$ref" : "#/definitions/agp_info" }
+        "agp" : { "$ref" : "#/definitions/agp_info" },
+        "events" : { "$ref" : "#/definitions/file_info" }
       }
     },
     "file_info" : {


### PR DESCRIPTION
Integrate the stable ids event dump in the dumper pipeline. The ids history will be dumped automatically if there is any, in the BRC4 expected format.
Also if there is no files created, then don't create a manifest or folder (e.g. when dumping history only, and some dbs don't have any).