### PR TITLE
Removed deprecated dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,6 @@ dependencies = [
 dev = [
     "mock",
     "Sphinx",
-    "toml-validator",
 ]
 
 doc = [


### PR DESCRIPTION
This library is no longer maintained and it is not compatible with click v8.0 (needed by other libraries and `black`).

Unfortunately, I have not been able to find a suitable replacement from a quick search.