### PR TITLE
NOTICE copyright year check

### DIFF
--- a/cicd/gitlab/dot.gitlab-ci.yml
+++ b/cicd/gitlab/dot.gitlab-ci.yml
@@ -46,14 +46,23 @@ debug:gitlab_env:
     include:
     - local: /cicd/gitlab/parts/debug.gitlab-ci.yml
 
-#   python related
+#   Python checks
 test:python:
-  stage: test 
+  stage: test
   # using sub-pipeline from ./parts
   trigger:
     strategy: depend
     include:
     - local: /cicd/gitlab/parts/python.gitlab-ci.yml
+
+#   License checks
+test:license:
+  stage: test
+  # using sub-pipeline from ./parts
+  trigger:
+    strategy: depend
+    include:
+    - local: /cicd/gitlab/parts/license.gitlab-ci.yml
 
 
 # external pipelines

--- a/cicd/gitlab/parts/license.gitlab-ci.yml
+++ b/cicd/gitlab/parts/license.gitlab-ci.yml
@@ -1,0 +1,25 @@
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# License-related part of the Ensembl/ensembl-genomio CI/CD pipeline
+
+stages:
+  - license:tests
+
+
+# Check if the NOTICE file has the latest year in its copyright
+license:tests:notice:
+  stage: license:tests
+  script:
+    - grep $(date +"%Y") NOTICE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,7 +161,7 @@ filterwarnings = [
 [tool.coverage.run]
 branch = true
 source = [
-    "src/python/ensembl"
+    "ensembl.io.genomio",
 ]
 
 [tool.coverage.report]


### PR DESCRIPTION
Added new CI/CD pipeline for License-related checks, starting for checking if the NOTICE file has the latest copyright year.

I have also taken the opportunity to do a small change in the coverage check to use the library namespace instead of the source, so if GenomIO is not installed with `-e` it should still return the right coverage information.