### PR TITLE
Add license header check

### DIFF
--- a/cicd/gitlab/parts/license.gitlab-ci.yml
+++ b/cicd/gitlab/parts/license.gitlab-ci.yml
@@ -27,6 +27,4 @@ license:tests:notice:
 license:tests:header:
   stage: license:tests
   script:
-    - FILE_EXT="\(pl\|pm\|py\|nf\|config\|\(my\|pg\|\)sql\|sqlite\|bash\|sh\|toml\|yml\)"
-    - LICENSE_HEADER='[#-/]*\s*See the NOTICE file distributed with this work for additional information\n[#-/]*\s*regarding copyright ownership\.\n[#-/]*\s*[#-/]*\s*Licensed under the Apache License, Version 2\.0 \(the "License"\);\n[#-/]*\s*you may not use this file except in compliance with the License\.\n[#-/]*\s*You may obtain a copy of the License at\n[#-/]*\s*[#-/]*\s*http://www\.apache\.org/licenses/LICENSE-2\.0\n[#-/]*\s*[#-/]*\s*Unless required by applicable law or agreed to in writing, software\n[#-/]*\s*distributed under the License is distributed on an "AS IS" BASIS,\n[#-/]*\s*WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied\.\n[#-/]*\s*See the License for the specific language governing permissions and\n[#-/]*\s*limitations under the License\.\n'
-    - find . -regex ".*\.$FILE_EXT" -print0 | xargs -0 grep -LPzo "$LICENSE_HEADER"
+    - bash cicd/gitlab/scripts/license_header.sh

--- a/cicd/gitlab/parts/license.gitlab-ci.yml
+++ b/cicd/gitlab/parts/license.gitlab-ci.yml
@@ -23,3 +23,10 @@ license:tests:notice:
   stage: license:tests
   script:
     - grep $(date +"%Y") NOTICE
+
+license:tests:header:
+  stage: license:tests
+  script:
+    - FILE_EXT="\(pl\|pm\|py\|nf\|config\|\(my\|pg\|\)sql\|sqlite\|bash\|sh\|toml\|yml\)"
+    - LICENSE_HEADER='[#-/]*\s*See the NOTICE file distributed with this work for additional information\n[#-/]*\s*regarding copyright ownership\.\n[#-/]*\s*[#-/]*\s*Licensed under the Apache License, Version 2\.0 \(the "License"\);\n[#-/]*\s*you may not use this file except in compliance with the License\.\n[#-/]*\s*You may obtain a copy of the License at\n[#-/]*\s*[#-/]*\s*http://www\.apache\.org/licenses/LICENSE-2\.0\n[#-/]*\s*[#-/]*\s*Unless required by applicable law or agreed to in writing, software\n[#-/]*\s*distributed under the License is distributed on an "AS IS" BASIS,\n[#-/]*\s*WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied\.\n[#-/]*\s*See the License for the specific language governing permissions and\n[#-/]*\s*limitations under the License\.\n'
+    - find . -regex ".*\.$FILE_EXT" -print0 | xargs -0 grep -LPzo "$LICENSE_HEADER"

--- a/cicd/gitlab/scripts/license_header.sh
+++ b/cicd/gitlab/scripts/license_header.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FILE_EXT="\(pl\|pm\|py\|nf\|config\|\(my\|pg\|\)sql\|sqlite\|bash\|sh\|toml\|yml\)"
+
+LICENSE_HEADER=(
+    'See the NOTICE file distributed with this work for additional information'
+    'regarding copyright ownership\.'
+    ''
+    'Licensed under the Apache License, Version 2\.0 \(the "License"\);'
+    'you may not use this file except in compliance with the License\.'
+    'You may obtain a copy of the License at'
+    ''
+    'http://www\.apache\.org/licenses/LICENSE-2\.0'
+    ''
+    'Unless required by applicable law or agreed to in writing, software'
+    'distributed under the License is distributed on an "AS IS" BASIS,'
+    'WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied\.'
+    'See the License for the specific language governing permissions and'
+    'limitations under the License\.'
+)
+
+PATTERN=""
+for line in "${LICENSE_HEADER[@]}"; do
+    if [ -z "$line" ]; then
+        PATTERN="${PATTERN}[#-/]*\\s*"
+    else
+        PATTERN="${PATTERN}[#-/]*\\s*${line}\\n"
+    fi
+done
+
+find . -regex ".*\.$FILE_EXT" -print0 | xargs -0 -I {} grep -LPzo "$PATTERN" {}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,3 +1,17 @@
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Configuration file for the Sphinx documentation builder.
 #
 # This file only contains a selection of the most common options. For a full

--- a/pipelines/nextflow/modules/download_genbank.nf
+++ b/pipelines/nextflow/modules/download_genbank.nf
@@ -1,4 +1,18 @@
-#!/usr/bin/env nextflow
+// See the NOTICE file distributed with this work for additional information
+// regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 nextflow.enable.dsl=2
 
 process DOWNLOAD_GENBANK {

--- a/pipelines/nextflow/modules/extract_from_gb.nf
+++ b/pipelines/nextflow/modules/extract_from_gb.nf
@@ -1,4 +1,18 @@
-#!/usr/bin/env nextflow
+// See the NOTICE file distributed with this work for additional information
+// regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 nextflow.enable.dsl=2
 
 process EXTRACT_FROM_GB {

--- a/pipelines/nextflow/modules/gff3_validation.nf
+++ b/pipelines/nextflow/modules/gff3_validation.nf
@@ -1,4 +1,18 @@
-#!/usr/bin/env nextflow
+// See the NOTICE file distributed with this work for additional information
+// regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 nextflow.enable.dsl=2
 
 process GFF3_VALIDATION {

--- a/pipelines/nextflow/modules/manifest_stats.nf
+++ b/pipelines/nextflow/modules/manifest_stats.nf
@@ -1,18 +1,31 @@
-#!/usr/bin/env nextflow
+// See the NOTICE file distributed with this work for additional information
+// regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 process MANIFEST_STATS {
-	tag "manifest_stats"                  
-	label 'default'                
+    tag "manifest_stats"
+    label 'default'
 
-input:
-	path manifest_dir
-	val datasets
+    input:
+        path manifest_dir
+        val datasets
 
-output:
-	path manifest_dir
+    output:
+        path manifest_dir
 
-script:
- """
- manifest_stats --manifest_dir "$manifest_dir" --datasets_bin "$datasets"
- """
- }
+    script:
+        """
+        manifest_stats --manifest_dir "$manifest_dir" --datasets_bin "$datasets"
+        """
+}

--- a/pipelines/nextflow/modules/process_gff3.nf
+++ b/pipelines/nextflow/modules/process_gff3.nf
@@ -1,4 +1,31 @@
-#!/usr/bin/env nextflow
+// See the NOTICE file distributed with this work for additional information
+// regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.// See the NOTICE file distributed with this work for additional information
+// regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 nextflow.enable.dsl=2
 params.merge_split_genes="False"
 

--- a/pipelines/nextflow/modules/process_gff3.nf
+++ b/pipelines/nextflow/modules/process_gff3.nf
@@ -11,19 +11,6 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitations under the License.// See the NOTICE file distributed with this work for additional information
-// regarding copyright ownership.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
 // limitations under the License.
 
 nextflow.enable.dsl=2

--- a/pipelines/nextflow/workflows/additional_seq_prepare/nextflow.config
+++ b/pipelines/nextflow/workflows/additional_seq_prepare/nextflow.config
@@ -1,3 +1,18 @@
+// See the NOTICE file distributed with this work for additional information
+// regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 includeConfig '../nextflow.config'
 
 // Set work directory with the same name as the workflow (without extension)

--- a/scripts/setup/docs/build_sphinx_docs.sh
+++ b/scripts/setup/docs/build_sphinx_docs.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 cd docs
 sphinx-apidoc -Mf --implicit-namespaces -o source ../src/python/ensembl


### PR DESCRIPTION
I have done two different ways to apply the check:
1. Simple header check with all the command inside the CI/CD pipeline ([f0dbd9d](https://github.com/Ensembl/ensembl-genomio/pull/94/commits/f0dbd9d79f462dd286c8102387e5bcec3d23b3da))
2. Move code into bash script so the license header can be readable ([59003fd](https://github.com/Ensembl/ensembl-genomio/pull/94/commits/59003fd1b5181a7e029fc77bd0b4f846f55c1a4f))

Finally, I have fixed all the files raised as missing/incorrect license header by the check.

_Note:_ I do not know what was happening with [pipelines/nextflow/modules/manifest_stats.nf](https://github.com/Ensembl/ensembl-genomio/pull/94/files#diff-c8bb64fd707cbd5c3ed84ac9ab343311b3ec9354d006ba10de956978edcd3a8d), but I have had to discard it and add it again from scratch as something seemed wrong with its internal format.