### PR TITLE
Mbarba/genome prepare fix

### DIFF
--- a/pipelines/nextflow/workflows/nextflow.config
+++ b/pipelines/nextflow/workflows/nextflow.config
@@ -45,6 +45,9 @@ profiles {
             perJobMemLimit = true
             errorStrategy = 'finish'
 
+            withLabel: 'local' {
+                executor = 'local'
+            }
             withLabel: 'default' {
                 cpus = 1
                 memory = 100.MB
@@ -79,6 +82,9 @@ profiles {
             perJobMemLimit = true
             errorStrategy = 'finish'
 
+            withLabel: 'local' {
+                executor = 'local'
+            }
             withLabel: 'default' {
                 cpus = 1
                 memory = 100.MB
@@ -103,11 +109,6 @@ profiles {
                 errorStrategy = { task.exitStatus == 140 ? 'retry' : 'finish' }
                 maxRetries = 3
             }
-        }
-        process {
-            executor = 'local'
-            perJobMemLimit = true
-            errorStrategy = 'finish'
         }
     }
 

--- a/pipelines/nextflow/workflows/nextflow.config
+++ b/pipelines/nextflow/workflows/nextflow.config
@@ -20,21 +20,6 @@ profiles {
             executor = 'local'
             perJobMemLimit = true
             errorStrategy = 'finish'
-
-            withLabel: 'default' {
-                cpus = 1
-                memory = 100.MB
-            }
-            withLabel: 'normal' {
-                cpus = 1
-                memory = 1.GB
-                time = 60.min
-            }
-            withLabel: 'adaptive' {
-                cpus = 1
-                memory = 1.GB
-                time = 60.min
-            }
         }
     }
 


### PR DESCRIPTION
Fix local nextflow config:

- The label needs to be in the same process of the profile, otherwise Slurm complains.
- Also remove the labels from the standard profile: time, memory, cpus are not used when run locally.