### PR TITLE
Mbarba/gff3 improve

### DIFF
--- a/src/python/ensembl/io/genomio/gff3/functional_annotation.py
+++ b/src/python/ensembl/io/genomio/gff3/functional_annotation.py
@@ -85,7 +85,7 @@ class FunctionalAnnotations:
 
         Args:
             feature: The feature to create an annotation.
-            feat_type: type of the feature to annotate.
+            feat_type: Type of the feature to annotate.
         """
         if feat_type not in self.features:
             raise AnnotationError(f"Unsupported feature type {feat_type}")
@@ -148,7 +148,7 @@ class FunctionalAnnotations:
 
     def _transfer_descriptions(self) -> None:
         """Transfers the feature descriptions in 2 steps:
-        - from translations to transcripts (if the transcript description is empty
+        - from translations to transcripts (if the transcript description is empty)
         - from transcripts to genes (same case)
 
         """
@@ -159,7 +159,7 @@ class FunctionalAnnotations:
         """Transfer descriptions from all feature of a given type, up to their parent.
 
         Args:
-            child_feature: either "translation" (transfer to transcript) or "transcript" (to gene)
+            child_feature: Either "translation" (transfer to transcript) or "transcript" (to gene).
 
         """
         children_features = self.get_features(child_feature)

--- a/src/python/ensembl/io/genomio/gff3/functional_annotation.py
+++ b/src/python/ensembl/io/genomio/gff3/functional_annotation.py
@@ -178,7 +178,7 @@ class FunctionalAnnotations:
             "putative",
             "uncharacterized",
             "unspecified",
-            "of unknown function",
+            r"(of )?unknown function",
             "conserved",
             "predicted",
             "fragment",

--- a/src/python/ensembl/io/genomio/gff3/functional_annotation.py
+++ b/src/python/ensembl/io/genomio/gff3/functional_annotation.py
@@ -123,12 +123,8 @@ class FunctionalAnnotations:
             feature_object["description"] = feature.qualifiers["Name"][0]
 
         # Don't keep useless description
-        # Don't keep description if it contains the ID
-        if ("description" in feature_object) and (
-            (
-                not self.product_is_valid(feature_object["description"])
-                or (feature.id.lower() in feature_object["description"].lower())
-            )
+        if ("description" in feature_object) and not self.product_is_valid(
+            feature_object["description"], feature.id
         ):
             del feature_object["description"]
 

--- a/src/python/ensembl/io/genomio/gff3/functional_annotation.py
+++ b/src/python/ensembl/io/genomio/gff3/functional_annotation.py
@@ -220,9 +220,7 @@ class FunctionalAnnotations:
 
         # Anything (informative) left?
         empty_re = re.compile(r"^[ ]*$")
-        if empty_re.match(product):
-            return False
-        return True
+        return not bool(empty_re.match(product))
 
     def _to_list(self):
         all_list = []

--- a/src/python/ensembl/io/genomio/gff3/functional_annotation.py
+++ b/src/python/ensembl/io/genomio/gff3/functional_annotation.py
@@ -17,7 +17,7 @@
 from os import PathLike
 from pathlib import Path
 import re
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from Bio.SeqFeature import SeqFeature
 
@@ -164,7 +164,7 @@ class FunctionalAnnotations:
                     parent_gene["description"] = description
 
     @staticmethod
-    def product_is_valid(product: str, feat_id: str = None) -> bool:
+    def product_is_valid(product: str, feat_id: Optional[str] = None) -> bool:
         """Returns True if the product name contains informative words (not just hypothetical etc.).
         If an ID is provided, ignore it as well (we don't want description to be just the ID).
 
@@ -190,7 +190,7 @@ class FunctionalAnnotations:
         non_informative_re = re.compile(r"|".join(non_informative_words), re.IGNORECASE)
 
         # Remove the feature ID if it's in the description
-        if feat_id:
+        if feat_id is not None:
             feat_id_re = re.compile(feat_id, re.IGNORECASE)
             product = re.sub(feat_id_re, "", product)
 

--- a/src/python/ensembl/io/genomio/gff3/functional_annotation.py
+++ b/src/python/ensembl/io/genomio/gff3/functional_annotation.py
@@ -41,20 +41,35 @@ class FunctionalAnnotations:
     def __init__(self) -> None:
         self.annotations: List[Annotation] = []
 
-        self.genes = {}
-        self.transcripts = {}
-        self.translations = {}
-        self.transposable_elements = {}
-        self.gene_parent = {}
-        self.transcript_parent = {}
+        # Annotated features
+        self.genes: Dict[str, Annotation] = {}
+        self.transcripts: Dict[str, Annotation] = {}
+        self.translations: Dict[str, Annotation] = {}
+        self.transposable_elements: Dict[str, Annotation] = {}
+        # Keep parent info: key is the feature ID, value is the parent ID
+        self.gene_parent: Dict[str, str] = {}
+        self.transcript_parent: Dict[str, str] = {}
 
     def add_gene(self, feature: SeqFeature) -> None:
+        """Add the functional annotation of a given gene.
+
+        Raises:
+            DuplicateIdError: Do not allow genes with the same ID.
+
+        """
         if feature.id in self.genes:
             raise DuplicateIdError(f"Gene ID {feature.id} already added")
         gene = self._generic_feature(feature, "gene")
         self.genes[gene["id"]] = gene
 
     def add_transcript(self, feature: SeqFeature, gene_id: str) -> None:
+        """Add the functional annotation of a given transcript,
+        and keep a record of its gene parent.
+
+        Raises:
+            DuplicateIdError: Do not allow transcripts with the same ID.
+
+        """
         if feature.id in self.transcripts:
             raise DuplicateIdError(f"Transcript ID {feature.id} already added")
         transcript = self._generic_feature(feature, "transcript")
@@ -62,6 +77,13 @@ class FunctionalAnnotations:
         self.gene_parent[transcript["id"]] = gene_id
 
     def add_translation(self, feature: SeqFeature, transcript_id: str) -> None:
+        """Add the functional annotation of a given translation,
+        and keep a record of its transcript parent.
+
+        Raises:
+            DuplicateIdError: Do not allow translations with the same ID.
+
+        """
         if feature.id in self.translations:
             raise DuplicateIdError(f"Translation ID {feature.id} already added")
         translation = self._generic_feature(feature, "translation")
@@ -69,6 +91,12 @@ class FunctionalAnnotations:
         self.transcript_parent[translation["id"]] = transcript_id
 
     def add_transposable_element(self, feature: SeqFeature) -> None:
+        """Add the functional annotation of a transposable_element,
+
+        Raises:
+            DuplicateIdError: Do not allow transposable_elements with the same ID.
+
+        """
         if feature.id in self.transposable_elements:
             raise DuplicateIdError(f"TE ID {feature.id} already added")
         te = self._generic_feature(feature, "transposable_element")
@@ -162,10 +190,10 @@ class FunctionalAnnotations:
     def _to_list(self):
         feat_list = []
         for feat in (
-            list(self.genes.values()) +
-            list(self.transcripts.values()) +
-            list(self.translations.values()) +
-            list(self.transposable_elements.values())
+            list(self.genes.values())
+            + list(self.transcripts.values())
+            + list(self.translations.values())
+            + list(self.transposable_elements.values())
         ):
             feat_list.append(feat)
         return feat_list

--- a/src/python/ensembl/io/genomio/gff3/functional_annotation.py
+++ b/src/python/ensembl/io/genomio/gff3/functional_annotation.py
@@ -59,19 +59,22 @@ class FunctionalAnnotations:
             "transposable_element": {},
         }
         # Keep parent info: key is the feature ID, value is the parent ID
-        self.parent: Dict[str, str] = {}
+        self.parents: Dict[str, Dict[str, str]] = {
+            "gene": {},
+            "transcript": {},
+        }
 
     def add_parent(self, parent_type: str, parent_id: str, child_id: str) -> None:
         """Record a parent-child IDs relationship for a given parent biotype."""
-        if parent_type in ("gene", "transcript"):
-            self.parent[f"{parent_type}-{child_id}"] = parent_id
+        if parent_type in self.parents:
+            self.parents[parent_type][child_id] = parent_id
         else:
             raise MissingParentError(f"Unsupported parent type {parent_type}")
 
     def get_parent(self, parent_type: str, child_id: str) -> str:
         """Returns the parent ID of a given child for a given parent biotype."""
-        if parent_type in ("gene", "transcript"):
-            parent_id = self.parent.get(f"{parent_type}-{child_id}")
+        if parent_type in self.parents:
+            parent_id = self.parents[parent_type].get(child_id)
             if parent_id is None:
                 raise MissingParentError(f"Can't find {parent_type} parent for {child_id}")
             return parent_id

--- a/src/python/ensembl/io/genomio/gff3/functional_annotation.py
+++ b/src/python/ensembl/io/genomio/gff3/functional_annotation.py
@@ -107,14 +107,14 @@ class FunctionalAnnotations:
         self.add_parent("transcript", transcript_id, translation["id"])
 
     def add_transposable_element(self, feature: SeqFeature) -> None:
-        """Add the functional annotation of a transposable_element,
+        """Add the functional annotation of a transposable element.
 
         Raises:
-            DuplicateIdError: Do not allow transposable_elements with the same ID.
+            DuplicateIdError: Do not allow transposable elements with the same ID.
 
         """
         if feature.id in self.transposable_elements:
-            raise DuplicateIdError(f"TE ID {feature.id} already added")
+            raise DuplicateIdError(f"Transposable element ID {feature.id} already added")
         te = self._generic_feature(feature, "transposable_element")
         self.transposable_elements[te["id"]] = te
 
@@ -181,8 +181,11 @@ class FunctionalAnnotations:
 
     @staticmethod
     def product_is_informative(product: str, feat_id: Optional[str] = None) -> bool:
-        """Returns True if the product name contains informative words (not just hypothetical etc.).
-        If an ID is provided, ignore it as well (we don't want description to be just the ID).
+        """Returns True if the product name contains informative words, False otherwise.
+
+        It is considered uninformative when the description contains words such as "hypothetical" or
+        or "putative". If a feature ID is provided, consider it uninformative as well (we do not want
+        descriptions to be just the ID).
 
         Args:
             product: A product name.

--- a/src/python/ensembl/io/genomio/gff3/functional_annotation.py
+++ b/src/python/ensembl/io/genomio/gff3/functional_annotation.py
@@ -54,7 +54,7 @@ class FunctionalAnnotations:
             name = feature.qualifiers["Name"][0]
 
             # Exclude Name if it just a variant of the feature ID
-            if feature.id not in name:
+            if feature.id.lower() not in name.lower():
                 feature_object["description"] = name
 
         # Synonyms?

--- a/src/python/ensembl/io/genomio/gff3/functional_annotation.py
+++ b/src/python/ensembl/io/genomio/gff3/functional_annotation.py
@@ -50,12 +50,14 @@ class FunctionalAnnotations:
         self.parent: Dict[str, str] = {}
 
     def add_parent(self, parent_type: str, parent_id: str, child_id: str) -> None:
+        """Record a parent-child IDs relationship for a given parent biotype."""
         if parent_type in ("gene", "transcript"):
             self.parent[f"{parent_type}-{child_id}"] = parent_id
         else:
             raise MissingParentError(f"Unsupported parent type {parent_type}")
 
     def get_parent(self, parent_type: str, child_id: str) -> str:
+        """Returns the parent ID of a given child for a given parent biotype."""
         if parent_type in ("gene", "transcript"):
             parent_id = self.parent.get(f"{parent_type}-{child_id}")
             if parent_id is None:

--- a/src/python/ensembl/io/genomio/gff3/functional_annotation.py
+++ b/src/python/ensembl/io/genomio/gff3/functional_annotation.py
@@ -116,14 +116,14 @@ class FunctionalAnnotations:
         # Description?
         if "product" in feature.qualifiers:
             description = feature.qualifiers["product"][0]
-            if self.product_is_valid(description):
+            if self.product_is_informative(description):
                 feature_object["description"] = description
 
         if "Name" in feature.qualifiers and "description" not in feature_object:
             feature_object["description"] = feature.qualifiers["Name"][0]
 
         # Don't keep useless description
-        if ("description" in feature_object) and not self.product_is_valid(
+        if ("description" in feature_object) and not self.product_is_informative(
             feature_object["description"], feature.id
         ):
             del feature_object["description"]
@@ -164,7 +164,7 @@ class FunctionalAnnotations:
                     parent_gene["description"] = description
 
     @staticmethod
-    def product_is_valid(product: str, feat_id: Optional[str] = None) -> bool:
+    def product_is_informative(product: str, feat_id: Optional[str] = None) -> bool:
         """Returns True if the product name contains informative words (not just hypothetical etc.).
         If an ID is provided, ignore it as well (we don't want description to be just the ID).
 

--- a/src/python/ensembl/io/genomio/gff3/process_gff3.py
+++ b/src/python/ensembl/io/genomio/gff3/process_gff3.py
@@ -216,7 +216,6 @@ class GFFSimplifier(GFFParserCommon):
     skip_unrecognized = False
     gene_cds_skip_others = False
     allow_pseudogene_with_CDS = False
-    merge_split_genes = True
     exclude_seq_regions: List = []
     validate_gene_id = True
     min_id_length = 8

--- a/src/python/ensembl/io/genomio/gff3/process_gff3.py
+++ b/src/python/ensembl/io/genomio/gff3/process_gff3.py
@@ -216,7 +216,7 @@ class GFFSimplifier(GFFParserCommon):
     skip_unrecognized = False
     gene_cds_skip_others = False
     allow_pseudogene_with_CDS = False
-    merge_split_genes = False
+    merge_split_genes = True
     exclude_seq_regions: List = []
     validate_gene_id = True
     min_id_length = 8

--- a/src/python/ensembl/io/genomio/gff3/process_gff3.py
+++ b/src/python/ensembl/io/genomio/gff3/process_gff3.py
@@ -227,7 +227,7 @@ class GFFSimplifier(GFFParserCommon):
         self.records = Records()
         self.annotations = FunctionalAnnotations()
         self.genome = {}
-        if genome_path is not None:
+        if genome_path:
             with Path(genome_path).open("r") as genome_fh:
                 self.genome = json.load(genome_fh)
 
@@ -801,10 +801,10 @@ class GFFSimplifier(GFFParserCommon):
         else:
             if self.genome:
                 org = self.genome.get("BRC4", {}).get("organism_abbrev")
-            if org is not None:
-                prefix = "TMP_" + org + "_"
-            else:
+            if org is None:
                 prefix = "TMP_PREFIX_"
+            else:
+                prefix = "TMP_" + org + "_"
             self.stable_id_prefix = prefix
 
         number = self.current_stable_id_number + 1

--- a/src/python/ensembl/io/genomio/gff3/process_gff3.py
+++ b/src/python/ensembl/io/genomio/gff3/process_gff3.py
@@ -486,41 +486,6 @@ class GFFSimplifier(GFFParserCommon):
                 transcript.sub_features.pop(elt)
         return transcript
 
-    def transfer_description(self, gene: SeqFeature) -> None:
-        """Transfer descriptions from transcripts/translations to gene/transcripts.
-
-        If a gene has no description but the transcript has one, transfer it to the gene.
-        Otherwise, if the translation has a description, transfer it to the transcript and gene.
-
-        Args:
-            gene: Gene to transfer descriptions.
-
-        """
-        allowed_transcript_types = self.transcript_types
-
-        if "product" not in gene.qualifiers:
-            for tran in gene.sub_features:
-                if tran.type in allowed_transcript_types:
-                    if "product" in tran.qualifiers:
-                        description = tran.qualifiers["product"][0]
-                        gene.qualifiers["product"] = [description]
-                        return
-
-                    # No transcript product, but a CDS product? Copy it to both transcript and gene
-                    for cds in tran.sub_features:
-                        if cds.type == "CDS" and "product" in cds.qualifiers:
-                            print(f"Transfer description from CDS to gene and transcript in {gene.id}")
-                            description = cds.qualifiers["product"][0]
-                            tran.qualifiers["product"] = [description]
-                            gene.qualifiers["product"] = [description]
-                        else:
-                            print(f"No transfer possible for {gene.id}")
-                    # Continue transfering the translation products to the transcripts
-                else:
-                    print(f"Transfer not allowed: {gene.id} <- {tran.id} ({tran.type})")
-        else:
-            print("No transfer")
-
     def transcript_gene(self, ncrna: SeqFeature) -> SeqFeature:
         """Create a gene for lone transcripts: 'gene' for tRNA/rRNA, and 'ncRNA' for all others
 

--- a/src/python/ensembl/io/genomio/gff3/process_gff3.py
+++ b/src/python/ensembl/io/genomio/gff3/process_gff3.py
@@ -319,7 +319,7 @@ class GFFSimplifier(GFFParserCommon):
 
         # Generate ID if needed and add it to the functional annotation
         feat.id = self.normalize_gene_id(feat)
-        self.annotations.add_transposable_element(feat)
+        self.annotations.add_feature(feat, "transposable_element")
         feat.qualifiers = {"ID": feat.id}
 
         return feat
@@ -381,7 +381,7 @@ class GFFSimplifier(GFFParserCommon):
             self.normalize_pseudogene_cds(gene)
 
         # Finally, store gene functional annotation
-        self.annotations.add_gene(gene)
+        self.annotations.add_feature(gene, "gene")
 
         # replace qualifiers
         old_gene_qualifiers = gene.qualifiers
@@ -414,7 +414,7 @@ class GFFSimplifier(GFFParserCommon):
             transcript.id = self.normalize_transcript_id(gene.id, transcript_number)
 
             # Store transcript functional annotation
-            self.annotations.add_transcript(transcript, gene.id)
+            self.annotations.add_feature(transcript, "transcript", gene.id)
 
             # Replace qualifiers
             old_transcript_qualifiers = transcript.qualifiers
@@ -457,7 +457,7 @@ class GFFSimplifier(GFFParserCommon):
                 # Store CDS functional annotation (only once)
                 if not cds_found:
                     cds_found = True
-                    self.annotations.add_translation(feat, transcript.id)
+                    self.annotations.add_feature(feat, "translation", transcript.id)
 
                 # Replace qualifiers
                 feat.qualifiers = {

--- a/src/python/ensembl/io/genomio/gff3/process_gff3.py
+++ b/src/python/ensembl/io/genomio/gff3/process_gff3.py
@@ -793,14 +793,17 @@ class GFFSimplifier(GFFParserCommon):
         or use the genome organism_abbrev and prepend "TMP_" to it.
 
         """
-        genome_data = Path(InputSchema().genome_data)
         if self.stable_id_prefix:
             prefix = self.stable_id_prefix
         else:
-            with genome_data.open("r") as genome_data_fh:
-                dat = json.load(genome_data_fh)
-            org = dat["BRC4"]["organism_abbrev"]
-            prefix = "TMP_" + org + "_"
+            genome_data_path = InputSchema().genome_data
+            if genome_data_path:
+                with Path(genome_data_path).open("r") as genome_data_fh:
+                    dat = json.load(genome_data_fh)
+                org = dat["BRC4"]["organism_abbrev"]
+                prefix = "TMP_" + org + "_"
+            else:
+                prefix = "TMP_PREFIX_"
             self.stable_id_prefix = prefix
 
         number = self.current_stable_id_number + 1
@@ -911,7 +914,7 @@ class InputSchema(argschema.ArgSchema):
     """Input arguments expected by this script."""
 
     in_gff_path = argschema.fields.InputFile(required=True, metadata={"description": "Input gene.gff3 path"})
-    genome_data = argschema.fields.InputFile(required=True, metadata={"description": "genome.json path"})
+    genome_data = argschema.fields.InputFile(metadata={"description": "genome.json path"})
     out_gff_path = argschema.fields.OutputFile(
         default="gene_models.gff3", metadata={"description": "Output gff path"}
     )

--- a/src/python/ensembl/io/genomio/gff3/process_gff3.py
+++ b/src/python/ensembl/io/genomio/gff3/process_gff3.py
@@ -915,14 +915,14 @@ class InputSchema(argschema.ArgSchema):
     in_gff_path = argschema.fields.InputFile(required=True, metadata={"description": "Input gene.gff3 path"})
     genome_data = argschema.fields.InputFile(metadata={"description": "genome.json path"})
     out_gff_path = argschema.fields.OutputFile(
-        default="gene_models.gff3", metadata={"description": "Output gff path"}
+        dump_default="gene_models.gff3", metadata={"description": "Output gff path"}
     )
     out_func_path = argschema.fields.OutputFile(
-        default="functional_annotation.json",
+        dump_default="functional_annotation.json",
         metadata={"description": "Output functional_annotation.json path"},
     )
     merge_split_genes = argschema.fields.Boolean(
-        default=True, metadata={"description": "Should split genes be merged automatically"}
+        dump_default=True, metadata={"description": "Should split genes be merged automatically"}
     )
 
 

--- a/src/python/tests/flatfiles/process_gff3/merge_genes/input1.gff3
+++ b/src/python/tests/flatfiles/process_gff3/merge_genes/input1.gff3
@@ -1,0 +1,7 @@
+##gff-version 3
+CAIX01000001.1	EMBL	gene	4264	4403	.	+	.	ID=gene-BN9_000020;Name=BN9_000020;gbkey=Gene;gene_biotype=protein_coding;is_ordered=true;locus_tag=BN9_000020;partial=true;start_range=.,4264
+CAIX01000001.1	EMBL	gene	4455	4655	.	+	.	ID=gene-BN9_000020;Name=BN9_000020;gbkey=Gene;gene_biotype=protein_coding;is_ordered=true;locus_tag=BN9_000020;partial=true;start_range=.,4264
+CAIX01000001.1	EMBL	gene	4707	4847	.	+	.	ID=gene-BN9_000020;Name=BN9_000020;gbkey=Gene;gene_biotype=protein_coding;is_ordered=true;locus_tag=BN9_000020;partial=true;start_range=.,4264
+CAIX01000001.1	EMBL	CDS	4264	4403	.	+	0	ID=cds-CCI39219.1;Parent=gene-BN9_000020;Dbxref=NCBI_GP:CCI39219.1;Name=CCI39219.1;gbkey=CDS;locus_tag=BN9_000020;partial=true;product=CCI39219.1;protein_id=CCI39219.1;start_range=.,4264
+CAIX01000001.1	EMBL	CDS	4455	4655	.	+	1	ID=cds-CCI39219.1;Parent=gene-BN9_000020;Dbxref=NCBI_GP:CCI39219.1;Name=CCI39219.1;gbkey=CDS;locus_tag=BN9_000020;partial=true;product=CCI39219.1;protein_id=CCI39219.1
+CAIX01000001.1	EMBL	CDS	4707	4847	.	+	1	ID=cds-CCI39219.1;Parent=gene-BN9_000020;Dbxref=NCBI_GP:CCI39219.1;Name=CCI39219.1;gbkey=CDS;locus_tag=BN9_000020;partial=true;product=CCI39219.1;protein_id=CCI39219.1

--- a/src/python/tests/flatfiles/process_gff3/merge_genes/output1.gff3
+++ b/src/python/tests/flatfiles/process_gff3/merge_genes/output1.gff3
@@ -1,0 +1,5 @@
+##gff-version 3
+CAIX01000001.1	EMBL	gene	4264	4847	.	+	.	ID=gene-BN9_000020;Name=BN9_000020;gbkey=Gene;gene_biotype=protein_coding;locus_tag=BN9_000020;partial=true;start_range=.,4264
+CAIX01000001.1	EMBL	CDS	4264	4403	.	+	0	ID=cds-CCI39219.1;Parent=gene-BN9_000020;Dbxref=NCBI_GP:CCI39219.1;Name=CCI39219.1;gbkey=CDS;locus_tag=BN9_000020;partial=true;product=CCI39219.1;protein_id=CCI39219.1;start_range=.,4264
+CAIX01000001.1	EMBL	CDS	4455	4655	.	+	1	ID=cds-CCI39219.1;Parent=gene-BN9_000020;Dbxref=NCBI_GP:CCI39219.1;Name=CCI39219.1;gbkey=CDS;locus_tag=BN9_000020;partial=true;product=CCI39219.1;protein_id=CCI39219.1
+CAIX01000001.1	EMBL	CDS	4707	4847	.	+	1	ID=cds-CCI39219.1;Parent=gene-BN9_000020;Dbxref=NCBI_GP:CCI39219.1;Name=CCI39219.1;gbkey=CDS;locus_tag=BN9_000020;partial=true;product=CCI39219.1;protein_id=CCI39219.1

--- a/src/python/tests/test_functional_annotation.py
+++ b/src/python/tests/test_functional_annotation.py
@@ -47,6 +47,7 @@ class TestMergeGFF3:
             "Hypothetical conserved protein",
             "conserved hypothetical protein",
             "conserved hypothetical protein, putative",
+            "conserved protein, unknown function",
             "putative protein",
             "putative_protein",
             "hypothetical RNA",

--- a/src/python/tests/test_functional_annotation.py
+++ b/src/python/tests/test_functional_annotation.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit testing of :mod:`ensembl.io.genomio.schemas` module.
+
+The unit testing is divided into one test class per submodule/class found in this module, and one test method
+per public function/class method.
+
+Typical usage example::
+    $ pytest test_schemas.py
+
+"""
+
+import pytest
+
+from ensembl.io.genomio.gff3.functional_annotation import FunctionalAnnotations as fa
+
+
+class TestMergeGFF3:
+    """Tests for the integrity module."""
+
+    @pytest.mark.parametrize(
+        "description",
+        [
+            "",
+            "hypothetical protein",
+            "hypothetical_protein",
+            "Hypothetical protein",
+            "hypothetical protein (fragment)",
+            "hypothetical protein, variant",
+            "hypothetical protein, variant 2",
+            "hypothetical protein - conserved",
+            "hypothetical protein, conserved",
+            "Hypothetical_protein_conserved",
+            "Hypothetical conserved protein",
+            "conserved hypothetical protein",
+            "conserved hypothetical protein, putative",
+            "putative protein",
+            "putative_protein",
+            "hypothetical RNA",
+            "unspecified product",
+            "Unspecified product",
+        ],
+    )
+    def test_invalid_description(self, description: str) -> None:
+        """Tests `functional_annotation.product_is_valid` method.
+
+        Args:
+            description: Description string to check.
+
+        """
+        assert not fa.product_is_valid(description)
+
+    @pytest.mark.parametrize(
+        "description",
+        [
+            "conserved hypothetical transmembrane protein",
+        ],
+    )
+    def test_valid_description(self, description: str) -> None:
+        """Tests `functional_annotation.product_is_valid` method with valid descriptions.
+
+        Args:
+            description: Description string to check.
+
+        """
+        assert fa.product_is_valid(description)
+
+    @pytest.mark.parametrize(
+        "description, feat_id",
+        [
+            ("", "PROTID12345"),
+            ("PROTID12345", "PROTID12345"),
+            ("ProtId12345", "PROTID12345"),
+            ("hypothetical protein PROTID12345", "PROTID12345"),
+            ("hypothetical protein ProtId12345", "PROTID12345"),
+            ("hypothetical protein (ProtId12345)", "PROTID12345"),
+            ("hypothetical PROTID12345 (ProtId12345)", "PROTID12345"),
+        ],
+    )
+    def test_invalid_description_with_id(self, description: str, feat_id: str) -> None:
+        """Tests `functional_annotation.product_is_valid` method with an ID in the description.
+
+        Args:
+            description: Description string to check.
+            feat_id: Feature ID that might be in the description.
+
+        """
+        assert not fa.product_is_valid(description, feat_id)

--- a/src/python/tests/test_functional_annotation.py
+++ b/src/python/tests/test_functional_annotation.py
@@ -25,7 +25,7 @@ Typical usage example::
 from typing import Optional
 import pytest
 
-from ensembl.io.genomio.gff3.functional_annotation import FunctionalAnnotations as fa
+from ensembl.io.genomio.gff3.functional_annotation import FunctionalAnnotations
 
 
 class TestMergeGFF3:
@@ -70,4 +70,4 @@ class TestMergeGFF3:
             feature_id: Feature ID that might be in the description.
             output: True if description is informative, False otherwise.
         """
-        assert fa.product_is_informative(description, feature_id) == output
+        assert FunctionalAnnotations.product_is_informative(description, feature_id) == output

--- a/src/python/tests/test_functional_annotation.py
+++ b/src/python/tests/test_functional_annotation.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # See the NOTICE file distributed with this work for additional information
 # regarding copyright ownership.
 #
@@ -32,71 +31,42 @@ class TestMergeGFF3:
     """Tests for the integrity module."""
 
     @pytest.mark.parametrize(
-        "description",
+        "description, feature_id, output",
         [
-            "",
-            "hypothetical protein",
-            "hypothetical_protein",
-            "Hypothetical protein",
-            "hypothetical protein (fragment)",
-            "hypothetical protein, variant",
-            "hypothetical protein, variant 2",
-            "hypothetical protein - conserved",
-            "hypothetical protein, conserved",
-            "Hypothetical_protein_conserved",
-            "Hypothetical conserved protein",
-            "conserved hypothetical protein",
-            "conserved hypothetical protein, putative",
-            "conserved protein, unknown function",
-            "putative protein",
-            "putative_protein",
-            "hypothetical RNA",
-            "unspecified product",
-            "Unspecified product",
+            ("", None, False),
+            ("", "PROTID12345", False),
+            ("PROTID12345", "PROTID12345", False),
+            ("ProtId12345", "PROTID12345", False),
+            ("hypothetical PROTID12345 (ProtId12345)", "PROTID12345", False),
+            ("hypothetical protein", None, False),
+            ("hypothetical_protein", None, False),
+            ("Hypothetical protein", None, False),
+            ("hypothetical protein PROTID12345", "PROTID12345", False),
+            ("hypothetical protein ProtId12345", "PROTID12345", False),
+            ("hypothetical protein (ProtId12345)", "PROTID12345", False),
+            ("hypothetical protein (fragment)", None, False),
+            ("hypothetical protein, variant", None, False),
+            ("hypothetical protein, variant 2", None, False),
+            ("hypothetical protein - conserved", None, False),
+            ("hypothetical protein, conserved", None, False),
+            ("Hypothetical_protein_conserved", None, False),
+            ("Hypothetical conserved protein", None, False),
+            ("conserved hypothetical protein", None, False),
+            ("conserved hypothetical protein, putative", None, False),
+            ("conserved protein, unknown function", None, False),
+            ("putative protein", None, False),
+            ("putative_protein", None, False),
+            ("hypothetical RNA", None, False),
+            ("unspecified product", None, False),
+            ("Unspecified product", None, False),
+            ("conserved hypothetical transmembrane protein", None, True),
         ],
     )
-    def test_invalid_description(self, description: str) -> None:
+    def test_product_is_informative(self, description: str, feature_id: Optional[str], output: bool) -> None:
         """Tests `functional_annotation.product_is_informative` method.
-
         Args:
-            description: Description string to check.
-
+            description: Product description.
+            feature_id: Feature ID that might be in the description.
+            output: True if description is informative, False otherwise.
         """
-        assert not fa.product_is_informative(description)
-
-    @pytest.mark.parametrize(
-        "description",
-        [
-            "conserved hypothetical transmembrane protein",
-        ],
-    )
-    def test_valid_description(self, description: str) -> None:
-        """Tests `functional_annotation.product_is_informative` method with valid descriptions.
-
-        Args:
-            description: Description string to check.
-
-        """
-        assert fa.product_is_informative(description)
-
-    @pytest.mark.parametrize(
-        "description, feat_id",
-        [
-            ("", "PROTID12345"),
-            ("PROTID12345", "PROTID12345"),
-            ("ProtId12345", "PROTID12345"),
-            ("hypothetical protein PROTID12345", "PROTID12345"),
-            ("hypothetical protein ProtId12345", "PROTID12345"),
-            ("hypothetical protein (ProtId12345)", "PROTID12345"),
-            ("hypothetical PROTID12345 (ProtId12345)", "PROTID12345"),
-        ],
-    )
-    def test_invalid_description_with_id(self, description: str, feat_id: str) -> None:
-        """Tests `functional_annotation.product_is_informative` method with an ID in the description.
-
-        Args:
-            description: Description string to check.
-            feat_id: Feature ID that might be in the description.
-
-        """
-        assert not fa.product_is_informative(description, feat_id)
+        assert fa.product_is_informative(description, feature_id) == output

--- a/src/python/tests/test_functional_annotation.py
+++ b/src/python/tests/test_functional_annotation.py
@@ -22,6 +22,7 @@ Typical usage example::
 
 """
 
+from typing import Optional
 import pytest
 
 from ensembl.io.genomio.gff3.functional_annotation import FunctionalAnnotations as fa

--- a/src/python/tests/test_functional_annotation.py
+++ b/src/python/tests/test_functional_annotation.py
@@ -55,13 +55,13 @@ class TestMergeGFF3:
         ],
     )
     def test_invalid_description(self, description: str) -> None:
-        """Tests `functional_annotation.product_is_valid` method.
+        """Tests `functional_annotation.product_is_informative` method.
 
         Args:
             description: Description string to check.
 
         """
-        assert not fa.product_is_valid(description)
+        assert not fa.product_is_informative(description)
 
     @pytest.mark.parametrize(
         "description",
@@ -70,13 +70,13 @@ class TestMergeGFF3:
         ],
     )
     def test_valid_description(self, description: str) -> None:
-        """Tests `functional_annotation.product_is_valid` method with valid descriptions.
+        """Tests `functional_annotation.product_is_informative` method with valid descriptions.
 
         Args:
             description: Description string to check.
 
         """
-        assert fa.product_is_valid(description)
+        assert fa.product_is_informative(description)
 
     @pytest.mark.parametrize(
         "description, feat_id",
@@ -91,11 +91,11 @@ class TestMergeGFF3:
         ],
     )
     def test_invalid_description_with_id(self, description: str, feat_id: str) -> None:
-        """Tests `functional_annotation.product_is_valid` method with an ID in the description.
+        """Tests `functional_annotation.product_is_informative` method with an ID in the description.
 
         Args:
             description: Description string to check.
             feat_id: Feature ID that might be in the description.
 
         """
-        assert not fa.product_is_valid(description, feat_id)
+        assert not fa.product_is_informative(description, feat_id)

--- a/src/python/tests/test_gff3_merge.py
+++ b/src/python/tests/test_gff3_merge.py
@@ -13,13 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Unit testing of :mod:`ensembl.io.genomio.schemas` module.
-
-The unit testing is divided into one test class per submodule/class found in this module, and one test method
-per public function/class method.
-
-Typical usage example::
-    $ pytest test_schemas.py
+"""Unit testing of :mod:`ensembl.io.genomio.gff3.process_gff3` module.
 
 """
 
@@ -40,7 +34,7 @@ class TestGFF3Merge:
     def setup(self, tmp_dir: Path, files_dir: Path):
         """Loads necessary fixtures and values as class attributes."""
         type(self).tmp_dir = tmp_dir
-        type(self).data_dir = files_dir / 'process_gff3/merge_genes'
+        type(self).data_dir = files_dir / "process_gff3/merge_genes"
 
     @pytest.mark.parametrize(
         "input_name, expected_name",
@@ -49,11 +43,12 @@ class TestGFF3Merge:
         ],
     )
     def test_merge(self, tmp_path: Path, input_name: str, expected_name: str) -> None:
-        """Tests `integrity:IntegrityTool` method.
+        """Tests merge method.
 
         Args:
-            brc_mode: BRC specific mode.
-            ignore_false_stops: Ignore false stops.
+            tmp_path: Where temporary files will be created.
+            input_name: Name of the GFF file with example input, in the test folder.
+            expected_name: Name of the GFF file with expected output, in the test folder.
 
         """
         merger = GFFGeneMerger()

--- a/src/python/tests/test_gff3_merge.py
+++ b/src/python/tests/test_gff3_merge.py
@@ -52,7 +52,6 @@ class TestGFF3Merge:
 
         """
         merger = GFFGeneMerger()
-        assert isinstance(merger, GFFGeneMerger)
 
         gff_input_path = self.data_dir / input_name
         test_output_path = tmp_path / f"{input_name}.test.gff3"

--- a/src/python/tests/test_gff3_merge.py
+++ b/src/python/tests/test_gff3_merge.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit testing of :mod:`ensembl.io.genomio.schemas` module.
+
+The unit testing is divided into one test class per submodule/class found in this module, and one test method
+per public function/class method.
+
+Typical usage example::
+    $ pytest test_schemas.py
+
+"""
+
+from pathlib import Path
+
+import pytest
+
+from ensembl.io.genomio.gff3.process_gff3 import GFFGeneMerger
+
+
+class TestGFF3Merge:
+    """Tests for the GFF3GeneMerger module."""
+
+    tmp_dir: Path
+    data_dir: Path
+
+    @pytest.fixture(scope="class", autouse=True)
+    def setup(self, tmp_dir: Path, files_dir: Path):
+        """Loads necessary fixtures and values as class attributes."""
+        type(self).tmp_dir = tmp_dir
+        type(self).data_dir = files_dir / 'process_gff3/merge_genes'
+
+    @pytest.mark.parametrize(
+        "input_name, expected_name",
+        [
+            ("input1.gff3", "output1.gff3"),
+        ],
+    )
+    def test_merge(self, tmp_path: Path, input_name: str, expected_name: str) -> None:
+        """Tests `integrity:IntegrityTool` method.
+
+        Args:
+            brc_mode: BRC specific mode.
+            ignore_false_stops: Ignore false stops.
+
+        """
+        merger = GFFGeneMerger()
+        assert isinstance(merger, GFFGeneMerger)
+
+        gff_input_path = self.data_dir / input_name
+        test_output_path = tmp_path / f"{input_name}.test.gff3"
+
+        merger.merge(gff_input_path, test_output_path)
+
+        expected_path = self.data_dir / expected_name
+        assert test_output_path.read_text() == expected_path.read_text()

--- a/src/python/tests/test_gff3_merge.py
+++ b/src/python/tests/test_gff3_merge.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # See the NOTICE file distributed with this work for additional information
 # regarding copyright ownership.
 #
@@ -17,6 +16,7 @@
 
 """
 
+import filecmp
 from pathlib import Path
 
 import pytest
@@ -61,3 +61,4 @@ class TestGFF3Merge:
 
         expected_path = self.data_dir / expected_name
         assert test_output_path.read_text() == expected_path.read_text()
+        assert filecmp.cmp(test_output_path, expected_path)

--- a/src/python/tests/test_gff3_merge.py
+++ b/src/python/tests/test_gff3_merge.py
@@ -60,5 +60,4 @@ class TestGFF3Merge:
         merger.merge(gff_input_path, test_output_path)
 
         expected_path = self.data_dir / expected_name
-        assert test_output_path.read_text() == expected_path.read_text()
         assert filecmp.cmp(test_output_path, expected_path)


### PR DESCRIPTION
Changes to better handle descriptions:

Functional annotations are now kept as a separate entity which keeps a record of the parents of all features. This allows a cleaner (and less error-prone) description transfer from translation -> transcript -> gene.

Also a new version of the product_is_informative check, which now relies on a list of non-informative words, and can also take the feature ID into account. If the description is only made up of those informative words (and the ID), then it is deemed non-informative.
Add unit testing for product_is_informative.