### PR TITLE
Fix CI/CD job trigger issues

### DIFF
--- a/cicd/gitlab/parts/python.gitlab-ci.yml
+++ b/cicd/gitlab/parts/python.gitlab-ci.yml
@@ -23,6 +23,7 @@
   image: python:3.8
   only:
     changes:
+      - cicd/gitlab/parts/python.gitlab-ci.yml
       - pyproject.toml
       - "*.py"
       - src/python/**/*.py

--- a/cicd/gitlab/parts/python.gitlab-ci.yml
+++ b/cicd/gitlab/parts/python.gitlab-ci.yml
@@ -128,6 +128,7 @@ python:coverage:
 ## Generate GitLab pages with HTML coverage report
 
 pages:
+  extends: .python
   stage: deploy
   needs:
     - job: python:coverage


### PR DESCRIPTION
This job was missing the same `only` requirements as every other python job, making it fail because `python:coverage` may not be found (if no Python part of the codebase is changed). Made `pages` extend `.python` description (changing the `stage`) to make sure `python:coverage` is always present when this job is run.

Added trigger when Python pipeline (YAML) is updated (noticed in this PR that this pipeline was not triggered when it had been updated).