### PR TITLE
Only deploy GitLab pages for 'main' branch

### DIFF
--- a/cicd/gitlab/parts/python.gitlab-ci.yml
+++ b/cicd/gitlab/parts/python.gitlab-ci.yml
@@ -139,5 +139,6 @@ pages:
   artifacts:
     paths:
       - public
-  except:
-    - external_pull_requests
+  only:
+    refs:
+      - main


### PR DESCRIPTION
I have checked the documentation and `extends` combines both elements of the `only` section, i.e. `pages` job will only run when any Python-related file has been changed and the pipeline is run for the `main` branch.