### PR TITLE
Mbarba/fix stats

### DIFF
--- a/pipelines/nextflow/modules/files/publish_output.nf
+++ b/pipelines/nextflow/modules/files/publish_output.nf
@@ -14,21 +14,21 @@
 // limitations under the License.
 
 process PUBLISH_DIR {
-    publishDir "$out_dir", mode: 'copy', overwrite: false
+    publishDir "$out_dir/$accession", mode: 'copy', overwrite: false
     tag "Publish_${accession}"
     label 'default'
     time '5min'
 
     input:
-        tuple path(data_dir), val(accession)
+        tuple val(accession), path(genome_files)
         val (out_dir)
     
     output:
-        path data_dir
+        path("*.*", includeInputs: true)
     
     script:
         """
         echo "Just copy over the finished files"
-        echo "From '$data_dir' to '$out_dir' for accession '$accession'"
+        echo "All files here to '$out_dir/$accession'"
         """
 }

--- a/pipelines/nextflow/modules/manifest/integrity.nf
+++ b/pipelines/nextflow/modules/manifest/integrity.nf
@@ -15,7 +15,7 @@
 
 
 process CHECK_INTEGRITY {
-    tag "${manifest_dir}"
+    tag "${accession}"
     label 'variable_2_8_32'
     errorStrategy 'finish'
     time '1h'

--- a/pipelines/nextflow/modules/manifest/integrity.nf
+++ b/pipelines/nextflow/modules/manifest/integrity.nf
@@ -21,18 +21,19 @@ process CHECK_INTEGRITY {
     time '1h'
 
     input:
-        tuple path(manifest_dir), val(accession)
+        tuple val(accession), path(genome_files)
         val brc_mode
     
     output:
-        tuple path("${manifest_dir}/"), val(accession), emit: integrity_checked
+        tuple val(accession), path("*.*", includeInputs: true)
+    
     script:
         """
         brc_mode=''
         if [ $brc_mode == 1 ]; then
             brc_mode='--brc_mode 1'
         fi
-        check_integrity --manifest_file ${manifest_dir}/manifest.json \
+        check_integrity --manifest_file ./manifest.json \
             \$brc_mode
         """
 }

--- a/pipelines/nextflow/modules/manifest/manifest_maker.nf
+++ b/pipelines/nextflow/modules/manifest/manifest_maker.nf
@@ -18,13 +18,13 @@ process MANIFEST {
     label 'default'
     
     input:
-        tuple path(manifest_dir), val(accession)
+        tuple val(accession), path(files_to_record)
 
     output:
-        tuple path(manifest_dir), val(accession)
+        tuple val(accession), path("*.*", includeInputs: true)
     
     script:
         """
-        manifest_maker --manifest_dir ${manifest_dir}
+        manifest_maker --manifest_dir ./
         """
 }

--- a/pipelines/nextflow/modules/manifest/manifest_stats.nf
+++ b/pipelines/nextflow/modules/manifest/manifest_stats.nf
@@ -16,21 +16,27 @@
 process MANIFEST_STATS {
     tag "manifest_stats"
     label 'default'
+    publishDir "$out_dir/$accession", mode: 'copy'
 
     input:
-        tuple path(manifest_dir), val(accession)
+        tuple val(accession), path(genome_files)
         val datasets
-        val ignore_failed_stats
+        val ignore_failed
+        val out_dir
 
     output:
-        tuple path(manifest_dir), val(accession)
+        tuple val(accession), path("stats.txt")
 
     script:
         """
         MORE_CMD=""
-        if [ "$ignore_failed_stats" = "1" ]; then
+        if [ "$ignore_failed" = "1" ]; then
             MORE_CMD=" --ignore_failed 1"
         fi
-        manifest_stats --manifest_dir "$manifest_dir" --datasets_bin "$datasets" --accession "$accession" \$MORE_CMD
+        manifest_stats --manifest_dir "." \
+        --datasets_bin "$datasets" \
+        --accession "$accession" \
+        --stats_file ./stats.txt \
+        \$MORE_CMD
         """
 }

--- a/pipelines/nextflow/modules/manifest/manifest_stats.nf
+++ b/pipelines/nextflow/modules/manifest/manifest_stats.nf
@@ -26,6 +26,6 @@ process MANIFEST_STATS {
 
     script:
         """
-        manifest_stats --manifest_dir "$manifest_dir" --datasets_bin "$datasets"
+        manifest_stats --manifest_dir "$manifest_dir" --datasets_bin "$datasets" --accession "$accession"
         """
 }

--- a/pipelines/nextflow/modules/manifest/manifest_stats.nf
+++ b/pipelines/nextflow/modules/manifest/manifest_stats.nf
@@ -20,12 +20,17 @@ process MANIFEST_STATS {
     input:
         tuple path(manifest_dir), val(accession)
         val datasets
+        val ignore_failed_stats
 
     output:
         tuple path(manifest_dir), val(accession)
 
     script:
         """
-        manifest_stats --manifest_dir "$manifest_dir" --datasets_bin "$datasets" --accession "$accession"
+        MORE_CMD=""
+        if [ "$ignore_failed_stats" = "1" ]; then
+            MORE_CMD=" --ignore_failed 1"
+        fi
+        manifest_stats --manifest_dir "$manifest_dir" --datasets_bin "$datasets" --accession "$accession" \$MORE_CMD
         """
 }

--- a/pipelines/nextflow/subworkflows/genome_prepare/main.nf
+++ b/pipelines/nextflow/subworkflows/genome_prepare/main.nf
@@ -43,6 +43,7 @@ workflow GENOME_PREPARE {
         genomic_dataset // tuple composed of GCA_XXXXXXX.X (as path) and genome.json
         output_dir // User specified or default
         cache_dir
+        ignore_failed_stats
 
     // Main data input to this subworkflow is genomic_dataset tuple
     main:        
@@ -104,7 +105,7 @@ workflow GENOME_PREPARE {
         
         manifest_checked = CHECK_INTEGRITY(manifest_dired, params.brc_mode)
         
-        manifest_stated = MANIFEST_STATS(manifest_checked, 'datasets')
+        manifest_stated = MANIFEST_STATS(manifest_checked, 'datasets', ignore_failed_stats)
 
         // Publish the data to output directory
         PUBLISH_DIR(manifest_stated, output_dir)

--- a/pipelines/nextflow/subworkflows/genome_prepare/main.nf
+++ b/pipelines/nextflow/subworkflows/genome_prepare/main.nf
@@ -99,14 +99,12 @@ workflow GENOME_PREPARE {
                     .groupTuple()
 
         // Collect in manifest, checks and generate sequence stats
-        collect_dir = COLLECT_FILES(prepared_files)
-
-        manifest_dired = MANIFEST(collect_dir)
-        
-        manifest_checked = CHECK_INTEGRITY(manifest_dired, params.brc_mode)
-        
-        manifest_stated = MANIFEST_STATS(manifest_checked, 'datasets', ignore_failed_stats)
+        manifest = MANIFEST(prepared_files)
+        manifest_checked = CHECK_INTEGRITY(manifest, params.brc_mode)
 
         // Publish the data to output directory
-        PUBLISH_DIR(manifest_stated, output_dir)
+        PUBLISH_DIR(manifest_checked, output_dir)
+
+        // Include a stats file, outside of the manifest files
+        MANIFEST_STATS(manifest_checked, 'datasets', ignore_failed_stats, output_dir)
 }

--- a/pipelines/nextflow/tests/test_genome_prepare.yml
+++ b/pipelines/nextflow/tests/test_genome_prepare.yml
@@ -20,7 +20,8 @@
   command: nextflow run ./pipelines/nextflow/workflows/genome_prepare/main.nf \\
     --input_dir ./data/test/genome_prepare/inputDir \\
     --cache_dir ./data/test/genome_prepare/cache/ \\
-    --output_dir ./test_genome_prepare_output
+    --output_dir ./test_genome_prepare_output \\
+    --ignore_failed_stats 1
 
   # Check that all the expected files are produced
   # Make sure to update those if the processing of the files changes!

--- a/pipelines/nextflow/tests/test_genome_prepare.yml
+++ b/pipelines/nextflow/tests/test_genome_prepare.yml
@@ -35,10 +35,9 @@
     - path: ./test_genome_prepare_output/GCA_017607445.1/gene_models.gff3
       md5sum: 3303f5a000173812ba53d01571037b30
     - path: ./test_genome_prepare_output/GCA_017607445.1/genome.json
-      md5sum: 04c0fd27fb52ebb3507a205e43b815b7
+      md5sum: 97624cfffdcf43edd3f00df35ba24d30
     - path: ./test_genome_prepare_output/GCA_017607445.1/manifest.json
-      md5sum: 2a9733a7701dfeae0be204c8a5ba27a8
+      md5sum: 493dc0486e5a5b66e481a88f5ed433ae
     - path: ./test_genome_prepare_output/GCA_017607445.1/seq_region.json
       md5sum: 585da9f97f094e83702860ce43da652f
     - path: ./test_genome_prepare_output/GCA_017607445.1/stats.txt
-      md5sum: 6104869d437ec4a9d13a2d070c307b0f

--- a/pipelines/nextflow/workflows/genome_prepare/main.nf
+++ b/pipelines/nextflow/workflows/genome_prepare/main.nf
@@ -34,6 +34,7 @@ def helpMessage() {
 
         Optional arguments:
         --output_dir                   Name of Output directory to gather prepared outfiles. Default -> 'Output_GenomePrepare'.
+        --ignore_failed_stats          Skip and continue if stats counts fail
         --help                         This usage statement.
         """
 }
@@ -51,6 +52,9 @@ if (params.input_dir) {
 if (!params.cache_dir) {
     params.cache_dir = "./genome_prepare_download_cache"
 }
+if (!params.ignore_failed_stats) {
+    params.ignore_failed_stats = 1
+}
 
 // Import subworkflow
 include { GENOME_PREPARE } from '../../subworkflows/genome_prepare/main.nf'
@@ -64,5 +68,5 @@ workflow {
     PREPARE_GENOME_METADATA.out.genomic_dataset
         .map{ gca_dir, json_file -> tuple( gca_dir.getName(), json_file ) }
         .set { genome_metadata }
-    GENOME_PREPARE(genome_metadata, params.output_dir, params.cache_dir)
+    GENOME_PREPARE(genome_metadata, params.output_dir, params.cache_dir, params.ignore_failed_stats)
 }

--- a/pipelines/nextflow/workflows/genome_prepare/nextflow.config
+++ b/pipelines/nextflow/workflows/genome_prepare/nextflow.config
@@ -23,6 +23,7 @@ params {
     regions_to_exclude = ""
     brc_mode = "1"
     output_dir = "Output_GenomePrepare"
+    ignore_failed_stats = false
 
     json_schemas {
         functional_annotation = "${projectDir}/../../../../schemas/functional_annotation_schema.json"

--- a/src/python/ensembl/io/genomio/manifest_stats.py
+++ b/src/python/ensembl/io/genomio/manifest_stats.py
@@ -17,6 +17,7 @@
 """
 
 import json
+from os import PathLike
 from pathlib import Path
 from shutil import which
 from statistics import mean
@@ -75,8 +76,9 @@ class manifest_stats:
         self.datasets_bin = datasets_bin
         self.manifest_parent = manifest_dir
         self.check_ncbi = False
+        self.ignore_failed = False
 
-    def run(self):
+    def run(self, stats_path: PathLike):
         """Compute stats in the files and output a stats.txt file in the same folder.
 
         Raises:
@@ -97,13 +99,12 @@ class manifest_stats:
             stats += self.get_seq_region_stats(Path(manifest["seq_region"]))
 
         # Print out the stats in a separate file
-        stats_path = f"{self.manifest_parent}/stats.txt"
         print(stats_path)
         with open(stats_path, "w") as stats_out:
             stats_out.write("\n".join(stats))
 
         # Die if there were errors in stats comparison
-        if self.error:
+        if self.error and not self.ignore_failed:
             raise StatsError(f"Stats count errors, check the file {stats_path}")
 
     def get_manifest(self) -> Dict:
@@ -409,7 +410,12 @@ class InputSchema(argschema.ArgSchema):  # need more metadata/'True' requirement
         metadata={"description": "Sequence accession ID to compare stats with NCBI"}
     )
     datasets_bin = argschema.fields.String(metadata={"description": "Datasets bin status"})
+    ignore_failed = argschema.fields.Bool(default=False, metadata={"description": "Do not fail if stats do not match NCBI"})
 
+    stats_file = argschema.fields.files.OutputFile(
+        required=False,
+        metadata={"description": "Output file with the stats"},
+    )
 
 def main():
     """Main entrypoint."""
@@ -417,7 +423,15 @@ def main():
     mstats = manifest_stats(mod.args["manifest_dir"], mod.args.get("accession"), mod.args.get("datasets_bin"))
     if mod.args.get("accession"):
         mstats.check_ncbi = True
-    mstats.run()
+    if mod.args.get("ignore_failed"):
+            mstats.ignore_failed = True
+    stats_file: Path
+    if mod.args.get("stats_file"):
+        stats_file = mod.args.get('stats_file')
+    else:
+        stats_file = Path(mod.args.get('manifest_dir')) / "stats.txt"
+
+    mstats.run(stats_file)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Current manifest_stats.nf was missing the accession, which mean that the NCBI stats comparison wasn't done
- Add option to not fail when the stats comparison fail (the file is still written)
- Simplify the collection of files, and make the stats generation independent (published separately)
- Make changes to some shared modules, so this might break things in addition_prepare/dumper