### PR TITLE
BRC4_genome_loader: commenting out default queue name to stop overriding env one

### DIFF
--- a/src/perl/Bio/EnsEMBL/Pipeline/PipeConfig/BRC4_genome_loader_conf.pm
+++ b/src/perl/Bio/EnsEMBL/Pipeline/PipeConfig/BRC4_genome_loader_conf.pm
@@ -48,7 +48,11 @@ sub default_options {
     %{ $self->SUPER::default_options() },
 
     ## default LSF/Slurm queue name 
-    queue_name => "standard",
+    #   is defined at Bio::EnsEMBL::EGPipeline::PipeConfig::EGGeneric_conf
+    #   via Bio::EnsEMBL::EGPipeline::PrivateConfDetails::Impl
+    #   (https://github.com/Ensembl/ensembl-production-imported/blob/main/lib/perl/Bio/EnsEMBL/EGPipeline/PrivateConfDetails/Impl.pm.example)
+    #
+    # queue_name => "standard",
 
     ############################################
     # Config to be set by the user


### PR DESCRIPTION
`Bio::EnsEMBL::Pipeline::PipeConfig::BRC4_genome_loader_conf::default_options->{queue_name}` overrides the env one from ancestor `Bio::EnsEMBL::EGPipeline::PipeConfig::EGGeneric_conf`
and defined at [`Bio::EnsEMBL::EGPipeline::PrivateConfDetails::Impl`](https://github.com/Ensembl/ensembl-production-imported/blob/main/lib/perl/Bio/EnsEMBL/EGPipeline/PrivateConfDetails/Impl.pm.example)
