### PR TITLE
Add ncbi_check option

### DIFF
--- a/pipelines/nextflow/modules/manifest/manifest_stats.nf
+++ b/pipelines/nextflow/modules/manifest/manifest_stats.nf
@@ -20,12 +20,17 @@ process MANIFEST_STATS {
     input:
         tuple path(manifest_dir), val(accession)
         val datasets
+        val ncbi_check
 
     output:
         tuple path(manifest_dir), val(accession)
 
     script:
         """
-        manifest_stats --manifest_dir "$manifest_dir" --datasets_bin "$datasets" --accession $accession
+        CHECK_ASSEMBLY=""
+        if [ "$ncbi_check" == 1 ]; then
+            CHECK_ASSEMBLY=" --datasets_bin $datasets --accession $accession"
+        fi
+        manifest_stats --manifest_dir "$manifest_dir" \$CHECK_ASSEMBLY
         """
 }

--- a/pipelines/nextflow/subworkflows/additional_seq_prepare/main.nf
+++ b/pipelines/nextflow/subworkflows/additional_seq_prepare/main.nf
@@ -72,7 +72,7 @@ workflow additional_seq_prepare {
         
         manifest_checked = CHECK_INTEGRITY(manifest_dired, params.brc_mode)
         
-        manifest_stated = MANIFEST_STATS(manifest_checked, 'datasets')
+        manifest_stated = MANIFEST_STATS(manifest_checked, 'datasets', 0)
 
         // Publish the data to output directory
         PUBLISH_DIR(manifest_stated, output_dir)

--- a/pipelines/nextflow/subworkflows/genome_prepare/main.nf
+++ b/pipelines/nextflow/subworkflows/genome_prepare/main.nf
@@ -43,6 +43,7 @@ workflow GENOME_PREPARE {
         genomic_dataset // tuple composed of GCA_XXXXXXX.X (as path) and genome.json
         output_dir // User specified or default
         cache_dir
+        ncbi_check
 
     // Main data input to this subworkflow is genomic_dataset tuple
     main:        
@@ -104,7 +105,7 @@ workflow GENOME_PREPARE {
         
         manifest_checked = CHECK_INTEGRITY(manifest_dired, params.brc_mode)
         
-        manifest_stated = MANIFEST_STATS(manifest_checked, 'datasets')
+        manifest_stated = MANIFEST_STATS(manifest_checked, 'datasets', ncbi_check)
 
         // Publish the data to output directory
         PUBLISH_DIR(manifest_stated, output_dir)

--- a/pipelines/nextflow/subworkflows/genome_prepare/meta.yml
+++ b/pipelines/nextflow/subworkflows/genome_prepare/meta.yml
@@ -58,6 +58,11 @@ input:
       description: |
         NON MANDATORY param. Optional dir name used to store prepared genome data files (.gff3; .fa; .json)
         Default 'Output_GenomePrepare'. Contains one or more GCA_* sub directories. 
+  - ncbi_check:
+      type: boolean
+      description: |
+        NON MANDATORY param. Set to 0 to skip the NCBI stats check. If the stats fail, the script will die.
+        Default '1'.
 output:
   - fasta_dna:
       type: file

--- a/pipelines/nextflow/tests/test_genome_prepare.yml
+++ b/pipelines/nextflow/tests/test_genome_prepare.yml
@@ -34,10 +34,10 @@
       md5sum: eb834948fb9363dd71d02cb591848345
     - path: ./test_genome_prepare_output/GCA_017607445.1/gene_models.gff3
       md5sum: 3303f5a000173812ba53d01571037b30
+    # Genome contains fields that depend on the date, so can't check md5sum
     - path: ./test_genome_prepare_output/GCA_017607445.1/genome.json
-      md5sum: 04c0fd27fb52ebb3507a205e43b815b7
+    # Manifest depends on the genome checksum, so also date dependent
     - path: ./test_genome_prepare_output/GCA_017607445.1/manifest.json
-      md5sum: 2a9733a7701dfeae0be204c8a5ba27a8
     - path: ./test_genome_prepare_output/GCA_017607445.1/seq_region.json
       md5sum: 585da9f97f094e83702860ce43da652f
     - path: ./test_genome_prepare_output/GCA_017607445.1/stats.txt

--- a/pipelines/nextflow/tests/test_genome_prepare.yml
+++ b/pipelines/nextflow/tests/test_genome_prepare.yml
@@ -20,7 +20,8 @@
   command: nextflow run ./pipelines/nextflow/workflows/genome_prepare/main.nf \\
     --input_dir ./data/test/genome_prepare/inputDir \\
     --cache_dir ./data/test/genome_prepare/cache/ \\
-    --output_dir ./test_genome_prepare_output
+    --output_dir ./test_genome_prepare_output \\
+    --ncbi_check 0
 
   # Check that all the expected files are produced
   # Make sure to update those if the processing of the files changes!

--- a/pipelines/nextflow/workflows/genome_prepare/main.nf
+++ b/pipelines/nextflow/workflows/genome_prepare/main.nf
@@ -34,6 +34,7 @@ def helpMessage() {
 
         Optional arguments:
         --output_dir                   Name of Output directory to gather prepared outfiles. Default -> 'Output_GenomePrepare'.
+        --ncbi_check                   Set to 0 to skip the NCBI stats check.
         --help                         This usage statement.
         """
 }
@@ -64,5 +65,5 @@ workflow {
     PREPARE_GENOME_METADATA.out.genomic_dataset
         .map{ gca_dir, json_file -> tuple( gca_dir.getName(), json_file ) }
         .set { genome_metadata }
-    GENOME_PREPARE(genome_metadata, params.output_dir, params.cache_dir)
+    GENOME_PREPARE(genome_metadata, params.output_dir, params.cache_dir, params.ncbi_check)
 }

--- a/pipelines/nextflow/workflows/genome_prepare/nextflow.config
+++ b/pipelines/nextflow/workflows/genome_prepare/nextflow.config
@@ -23,6 +23,7 @@ params {
     regions_to_exclude = ""
     brc_mode = "1"
     output_dir = "Output_GenomePrepare"
+    ncbi_check = 1
 
     json_schemas {
         functional_annotation = "${projectDir}/../../../../schemas/functional_annotation_schema.json"


### PR DESCRIPTION
Only for assembly check,
so not used by sequence_addition

Set to 0 to skip the check

This is useful for e.g. the full pipeline run check (prevent failure, do not need to get data from NCBI, and ensure the stats file is not going to change).