### PR TITLE
Mbarba/better cache

### DIFF
--- a/pipelines/nextflow/modules/gff3/gff3_validation.nf
+++ b/pipelines/nextflow/modules/gff3/gff3_validation.nf
@@ -19,19 +19,20 @@ process GFF3_VALIDATION {
 
   //beforeScript 'module load libffi-3.3-gcc-9.3.0-cgokng6'
   tag "${gene_models}"
-  label 'default'
+  label 'adaptive'
   container "biocontainers/genometools:v1.5.10ds-3-deb_cv1"
 
   input:
-    tuple val(gca), path (gene_models)
+    tuple val(gca), path (gene_models, stageAs: "incoming.gff3")
 
   output:
-    tuple val(gca), path(gene_models), emit: gene_models
+    tuple val(gca), path("gene_models.gff3"), emit: gene_models
 
   script:
+  def out_gff = "gene_models.gff3"
   """
-  cp ${gene_models} gene_models.gff3.tmp 
-  gt gff3 -tidy -sort -retainids -force -o ${gene_models} gene_models.gff3.tmp 
-  gt gff3validator ${gene_models}
+  cp $gene_models temp.gff3
+  gt gff3 -tidy -sort -retainids -force -o $out_gff temp.gff3 
+  gt gff3validator $out_gff
   """
 }

--- a/pipelines/nextflow/modules/gff3/process_gff3.nf
+++ b/pipelines/nextflow/modules/gff3/process_gff3.nf
@@ -17,19 +17,21 @@ nextflow.enable.dsl=2
 params.merge_split_genes="False"
 
 process PROCESS_GFF3 {
-    tag "$gff3 - $task.attempt"
+    tag "$gca"
     label 'variable_2_8_32'
-    errorStrategy 'ignore'
+    errorStrategy 'finish'
 
     input:
         tuple val(gca), path(gff3), path(genome)
 
     output:
-        tuple val(gca), path("*.json"), emit: functional_annotation
-        tuple val(gca), path("*.gff3"), emit: gene_models
+        tuple val(gca), path("functional_annotation.json"), emit: functional_annotation
+        tuple val(gca), path("gene_models.gff3"), emit: gene_models
 
     script:
+    def out_func = "functional_annotation.json"
+    def out_gff = "gene_models.gff3"
     """
-    process_gff3 --in_gff_path ${gff3} --genome_data ${genome}
+    process_gff3 --genome_data $genome --in_gff_path $gff3 --out_gff_path $out_gff --out_func_path $out_func
     """
 }

--- a/pipelines/nextflow/modules/schema/check_json_schema.nf
+++ b/pipelines/nextflow/modules/schema/check_json_schema.nf
@@ -15,7 +15,7 @@
 
 process CHECK_JSON_SCHEMA {
     tag "$json_file.name"
-    label 'default'
+    label 'adaptive'
 
     input:
         tuple val(gca), path(json_file)


### PR DESCRIPTION
Using explicit file names, and paths different from the input in the output, allow Nextflow to cache those results properly.
Also set resources to 'adaptive' to a few more processes.