### PR TITLE
Mbarba/patch build

### DIFF
--- a/docs/genome_prepare.md
+++ b/docs/genome_prepare.md
@@ -22,7 +22,7 @@ These files can then be fed to the Genome loader pipeline.
 ### How to run
 
 ```
-init_pipeline.pl Bio::EnsEMBL::EGPipeline::PipeConfig::BRC4_genome_prepare_conf \
+init_pipeline.pl Bio::EnsEMBL::Pipeline::PipeConfig::BRC4_genome_prepare_conf \
     --host $HOST --port $PORT --user $USER --pass $PASS \
     --hive_force_init 1 \
     --pipeline_dir temp/prepare \

--- a/scripts/brc4/patch_build/allocate_stable_ids.pl
+++ b/scripts/brc4/patch_build/allocate_stable_ids.pl
@@ -237,12 +237,12 @@ if ($opt{update} and not $opt{mock_osid}) {
   $osid = OSID_service_dev->new();
 }
 $osid->connect($opt{organism});
-allocate_genes($osid, $registry, $opt{species}, $opt{update}, $opt{xref_source}, $opt{analysis_name}, $opt{prefix}, $opt{created_date}, $opt{out_gene_map});
+allocate_genes($osid, $registry, $opt{species}, $opt{update}, $opt{xref_source}, $opt{analysis_name}, $opt{prefix}, $opt{after_date}, $opt{out_gene_map});
 
 ###############################################################################
 
 sub allocate_genes {
-  my ($osid, $registry, $species, $update, $xref_source, $analysis_name, $prefix, $created_date, $gene_map_path) = @_;
+  my ($osid, $registry, $species, $update, $xref_source, $analysis_name, $prefix, $after_date, $gene_map_path) = @_;
   
   my $ga = $registry->get_adaptor($species, "core", "gene");
   my $tra = $registry->get_adaptor($species, "core", "transcript");
@@ -265,11 +265,11 @@ sub allocate_genes {
     my $nnew = scalar(@genes);
     $logger->info("Reduce list using prefix $prefix: from $nold genes to $nnew");
   }
-  if ($created_date) {
+  if ($after_date) {
     my $nold = scalar(@genes);
-    @genes = grep { localtime($_->created_date)->datetime >= $created_date } @genes;
+    @genes = grep { localtime($_->created_date)->datetime gt $after_date } @genes;
     my $nnew = scalar(@genes);
-    $logger->info("Reduce list using date $created_date: from $nold genes to $nnew");
+    $logger->info("Reduce list using date $after_date: from $nold genes to $nnew");
   }
   $logger->info(scalar(@genes) . " genes will have a new stable_id allocated");
   

--- a/src/perl/Bio/EnsEMBL/Pipeline/PipeConfig/LoadGFF3Batch_conf.pm
+++ b/src/perl/Bio/EnsEMBL/Pipeline/PipeConfig/LoadGFF3Batch_conf.pm
@@ -66,6 +66,7 @@ sub default_options {
     # Since this mode was designed to be used with patch builds,
     # default to not deleting any existing genes.
     delete_existing => 0,
+    keep_logic_name => 1,
   };
 }
 

--- a/src/perl/Bio/EnsEMBL/Pipeline/PipeConfig/LoadGFF3_conf.pm
+++ b/src/perl/Bio/EnsEMBL/Pipeline/PipeConfig/LoadGFF3_conf.pm
@@ -315,7 +315,7 @@ sub pipeline_analyses_generic {
 
     {
       -logic_name        => 'AnalysisSetup',
-      -module            => 'Bio::EnsEMBL::EGPipeline::Common::RunnableDB::AnalysisSetup',
+      -module            => 'Bio::EnsEMBL::Pipeline::Runnable::EG::LoadGFF3::AnalysisSetup',
       -analysis_capacity => 10,
       -max_retry_count   => 0,
       -parameters        => {

--- a/src/perl/Bio/EnsEMBL/Pipeline/PipeConfig/LoadGFF3_conf.pm
+++ b/src/perl/Bio/EnsEMBL/Pipeline/PipeConfig/LoadGFF3_conf.pm
@@ -97,6 +97,7 @@ sub default_options_generic {
     # Remove existing genes; if => 0 then existing analyses
     # and their features will remain, with the logic_name suffixed by '_bkp'.
     delete_existing => 1,
+    keep_logic_name => 0,
     
     # Retrieve analysis descriptions from the production database;
     # the supplied registry file will need the relevant server details.
@@ -322,6 +323,7 @@ sub pipeline_analyses_generic {
                               db_backup_file     => catdir($self->o('pipeline_dir'), '#species#', 'pre_gff3_bkp.sql.gz'),
                               module             => $self->o('analysis_module'),
                               delete_existing    => $self->o('delete_existing'),
+                              keep_logic_name    => $self->o('keep_logic_name'),
                               production_lookup  => $self->o('production_lookup'),
                               production_db      => $self->o('production_db'),
                             },

--- a/src/python/ensembl/io/genomio/events/format_events.py
+++ b/src/python/ensembl/io/genomio/events/format_events.py
@@ -61,6 +61,12 @@ class InputSchema(argschema.ArgSchema):
     map_file = argschema.fields.InputFile(
         required=True, metadata={"description": "Mapping tab file with 2 columns: old_id, new_id"}
     )
+    release_name = argschema.fields.String(
+        required=True, metadata={"description": "Name of the release for all event."}
+    )
+    release_date = argschema.fields.String(
+        required=True, metadata={"description": "Date of the release for all events."}
+    )
 
 
 def main() -> None:
@@ -70,7 +76,9 @@ def main() -> None:
 
     # Start
     events = EventCollection()
-    events.load_events_from_gene_diff(args["input_file"])
+    events.load_events_from_gene_diff(
+        args.get("input_file"), args.get("release_name"), args.get("release_date")
+    )
     mapper = IdsMapper(args["map_file"])
     events.remap_to_ids(mapper.map)
     events.write_events_to_file(args["output_file"])

--- a/src/python/ensembl/io/genomio/events/format_events.py
+++ b/src/python/ensembl/io/genomio/events/format_events.py
@@ -50,9 +50,9 @@ class IdsMapper:
 
         return mapping
 
+
 def load_list(list_file: Path) -> List[str]:
-    """Return a simple list from a file.
-    """
+    """Return a simple list from a file."""
     items = set()
     empty_spaces = re.compile(r"\s+")
     with Path(list_file).open("r") as map_fh:
@@ -73,7 +73,8 @@ class InputSchema(argschema.ArgSchema):
         required=True, metadata={"description": "Input file from gene_diff"}
     )
     deletes_file = argschema.fields.InputFile(
-        required=True, metadata={"description": "Deleted genes files (apart from the deletes from the gene diff)."}
+        required=True,
+        metadata={"description": "Deleted genes files (apart from the deletes from the gene diff)."},
     )
     output_file = argschema.fields.OutputFile(required=True, metadata={"description": "Formatted event file"})
     map_file = argschema.fields.InputFile(

--- a/src/python/ensembl/io/genomio/events/format_events.py
+++ b/src/python/ensembl/io/genomio/events/format_events.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Module to map stable ids in a file, given a mapping."""
+
+
+from os import PathLike
+from pathlib import Path
+from typing import Dict
+
+import argschema
+
+from ensembl.io.genomio.events_loader import EventCollection
+
+
+class IdsMapper:
+    """Simple mapper object, to cleanly get a mapping dict."""
+
+    def __init__(self, map_file: PathLike) -> None:
+        self.map = self._load_mapping(Path(map_file))
+
+    def _load_mapping(self, map_file: Path) -> Dict[str, str]:
+        """Return a mapping in a simple dict from a tab file with 2 columns: from_id, to_id.
+
+        Args:
+            map_file: Tab file path.
+        """
+        mapping = {}
+        with map_file.open("r") as map_fh:
+            for line in map_fh:
+                if line == "":
+                    continue
+                (from_id, to_id) = line.split("\t")[0:2]
+                mapping[from_id] = to_id
+
+        return mapping
+
+
+class InputSchema(argschema.ArgSchema):
+    """Input arguments expected by this script."""
+
+    # Server parameters
+    input_file = argschema.fields.InputFile(
+        required=True, metadata={"description": "Input file from gene_diff"}
+    )
+    output_file = argschema.fields.OutputFile(required=True, metadata={"description": "Formatted event file"})
+    map_file = argschema.fields.InputFile(
+        required=True, metadata={"description": "Mapping tab file with 2 columns: old_id, new_id"}
+    )
+
+
+def main() -> None:
+    """Main entrypoint"""
+    mod = argschema.ArgSchemaParser(schema_type=InputSchema)
+    args = mod.args
+
+    # Start
+    events = EventCollection()
+    events.load_events_from_gene_diff(args["input_file"])
+    mapper = IdsMapper(args["map_file"])
+    events.remap_to_ids(mapper.map)
+    events.write_events_to_file(args["output_file"])
+
+
+if __name__ == "__main__":
+    main()

--- a/src/python/ensembl/io/genomio/events_loader.py
+++ b/src/python/ensembl/io/genomio/events_loader.py
@@ -39,11 +39,12 @@ class IdEvent:
 
     from_id: str
     to_id: str
+    event: str
     release: str
     release_date: str
 
     def __str__(self) -> str:
-        fields = [self.from_id, self.to_id, self.release, self.release_date]
+        fields = [self.from_id, self.to_id, self.event, self.release, self.release_date]
         return "\t".join(fields)
 
 
@@ -78,8 +79,8 @@ class EventCollection:
                 line.strip()
                 if line == "":
                     continue
-                (from_id, to_id, _, release, release_date) = line.split("\t")
-                event = IdEvent(from_id=from_id, to_id=to_id, release=release, release_date=release_date)
+                (from_id, to_id, event_name, release, release_date) = line.split("\t")
+                event = IdEvent(from_id=from_id, to_id=to_id, event=event_name, release=release, release_date=release_date)
                 events.append(event)
         self.events = events
 
@@ -88,6 +89,7 @@ class EventCollection:
     ):
         """Load events from input file from gene_diff."""
         events: List[IdEvent] = []
+        event_name = "event"
 
         with Path(input_file).open("r") as events_fh:
             for line in events_fh:
@@ -97,7 +99,7 @@ class EventCollection:
                 for pair in self._parse_gene_diff_event(event_string):
                     (from_id, to_id) = pair
                     event = IdEvent(
-                        from_id=from_id, to_id=to_id, release=release_name, release_date=release_date
+                        from_id=from_id, to_id=to_id, event=event_name, release=release_name, release_date=release_date
                     )
                     events.append(event)
         self.events = events

--- a/src/python/ensembl/io/genomio/events_loader.py
+++ b/src/python/ensembl/io/genomio/events_loader.py
@@ -22,7 +22,8 @@ cf the load_events functions for the events tab file format.
 from dataclasses import dataclass
 from os import PathLike
 from pathlib import Path
-from typing import Dict, List
+import re
+from typing import Dict, Generator, List, Tuple
 
 import argschema
 from sqlalchemy.engine import URL
@@ -41,6 +42,10 @@ class IdEvent:
     release: str
     release_date: str
 
+    def __str__(self) -> str:
+        fields = [self.from_id, self.to_id, self.release, self.release_date]
+        return "\t".join(fields)
+
 
 class MapSession:
     """Simple mapping_sessions representation from the input file"""
@@ -55,58 +60,119 @@ class MapSession:
         self.events.append(event)
 
 
-def load_events(input_file: PathLike) -> List[IdEvent]:
-    """Load events from input file.
-    Expected tab file columns: old_id, new_id, event_name, release, release_date
+class EventCollection:
+    """ "Collection of events with loader/writer in various formats."""
 
-    """
-    events: List[IdEvent] = []
+    def __init__(self) -> None:
+        self.events: List[IdEvent] = []
 
-    with Path(input_file).open("r") as events_fh:
-        for line in events_fh:
-            line.strip()
-            if line == "":
-                continue
-            (from_id, to_id, _, release, release_date) = line.split("\t")
-            event = IdEvent(from_id=from_id, to_id=to_id, release=release, release_date=release_date)
-            events.append(event)
-    return events
+    def load_events(self, input_file: PathLike):
+        """Load events from input file.
+        Expected tab file columns: old_id, new_id, event_name, release, release_date
 
+        """
+        events: List[IdEvent] = []
 
-def write_events(session: Session, events: List[IdEvent], update: bool = False) -> None:
-    """Insert the events in the core database.
-    A mapping session is created for each different 'release'.
+        with Path(input_file).open("r") as events_fh:
+            for line in events_fh:
+                line.strip()
+                if line == "":
+                    continue
+                (from_id, to_id, _, release, release_date) = line.split("\t")
+                event = IdEvent(from_id=from_id, to_id=to_id, release=release, release_date=release_date)
+                events.append(event)
+        self.events = events
 
-    """
-    # First, create mapping_sessions based on the release
-    mappings: Dict[str, MapSession] = {}
-    for event in events:
-        release = event.release
+    def load_events_from_gene_diff(self, input_file: PathLike):
+        """Load events from input file from gene_diff."""
+        events: List[IdEvent] = []
+        release_name = "release_name"
+        release_date = "release_date"
 
-        if release in mappings:
-            mappings[release].add_event(event)
-        else:
-            mappings[release] = MapSession(release, event.release_date)
+        with Path(input_file).open("r") as events_fh:
+            for line in events_fh:
+                if line.startswith("//") or line == "":
+                    continue
+                (_, event_string, _) = line.split("\t")
+                for pair in self._parse_gene_diff_event(event_string):
+                    (from_id, to_id) = pair
+                    event = IdEvent(
+                        from_id=from_id, to_id=to_id, release=release_name, release_date=release_date
+                    )
+                    events.append(event)
+        self.events = events
 
-    # Then, add the mapping, and the events for this mapping
-    for release, mapping in mappings.items():
-        print(f"Adding mapping for release {release} ({len(mapping.events)} events)")
-        if update:
-            map_session = MappingSession(new_release=mapping.release, created=mapping.release_date)
-            session.add(map_session)
-            session.flush()
-            session.refresh(map_session)
-            for event in mapping.events:
-                id_event = StableIdEvent(
-                    mapping_session_id=map_session.mapping_session_id,
-                    old_stable_id=event.from_id,
-                    new_stable_id=event.to_id,
-                    id_type="gene",
-                    old_version=1,
-                    new_version=1,
-                )
-                session.add(id_event)
-            session.commit()
+    def _parse_gene_diff_event(self, event_string: str) -> Generator[Tuple[str, str], None, None]:
+        """Gets all the pairs of IDs from an event string from gene diff."""
+        splitter = re.compile(r"(~|\+|=\+|=-|=!|=|>|<)")
+        parts = re.split(splitter, event_string)
+        if len(parts) != 3:
+            return
+        [from_ids, sep, to_ids] = parts
+
+        # Identical gene: no need to keep in the history
+        if sep == "~":
+            return
+
+        for from_id in from_ids.split(":"):
+            for to_id in to_ids.split(":"):
+                yield (from_id, to_id)
+
+    def remap_to_ids(self, map_dict: Dict[str, str]):
+        """Using a mapping dict, remap the to_id of all events."""
+
+        no_map = 0
+        for event in self.events:
+            if event.to_id in map_dict:
+                event.to_id = map_dict[event.to_id]
+            else:
+                print(f"No map for to_id {event.to_id}")
+                no_map += 1
+
+        if no_map:
+            raise ValueError(f"No map for {no_map} event to_ids")
+
+    def write_events_to_file(self, output_file: PathLike) -> None:
+        """Write the events to a file."""
+        with Path(output_file).open("w") as out_fh:
+            print(f"Write {len(self.events)} events to {output_file}")
+            for event in self.events:
+                out_fh.write(f"{event}\n")
+
+    def write_events_to_db(self, session: Session, update: bool = False) -> None:
+        """Insert the events in the core database.
+        A mapping session is created for each different 'release'.
+
+        """
+        # First, create mapping_sessions based on the release
+        mappings: Dict[str, MapSession] = {}
+        for event in self.events:
+            release = event.release
+
+            if release in mappings:
+                mappings[release].add_event(event)
+            else:
+                mappings[release] = MapSession(release, event.release_date)
+
+        # Then, add the mapping, and the events for this mapping
+        for release, mapping in mappings.items():
+            print(f"Adding mapping for release {release} ({len(mapping.events)} events)")
+            if update:
+                map_session = MappingSession(new_release=mapping.release, created=mapping.release_date)
+                session.add(map_session)
+                session.flush()
+                session.refresh(map_session)
+                for event in mapping.events:
+                    id_event = StableIdEvent(
+                        mapping_session_id=map_session.mapping_session_id,
+                        old_stable_id=event.from_id,
+                        new_stable_id=event.to_id,
+                        id_type="gene",
+                        old_version=1,
+                        new_version=1,
+                    )
+                    session.add(id_event)
+                session.commit()
 
 
 class InputSchema(argschema.ArgSchema):
@@ -149,10 +215,11 @@ def main() -> None:
     )
     dbc = DBConnection(db_url)
 
-    events = load_events(mod.args.get("input_file"))
+    collection = EventCollection()
+    collection.load_events(mod.args.get("input_file"))
 
     with dbc.session_scope() as session:
-        write_events(session, events, mod.args["update"])
+        collection.write_events_to_db(session, mod.args["update"])
 
 
 if __name__ == "__main__":

--- a/src/python/ensembl/io/genomio/events_loader.py
+++ b/src/python/ensembl/io/genomio/events_loader.py
@@ -90,6 +90,7 @@ class EventCollection:
         """Load events from input file from gene_diff."""
         events: List[IdEvent] = []
         event_name = "event"
+        loaded_event = set()
 
         with Path(input_file).open("r") as events_fh:
             for line in events_fh:
@@ -98,6 +99,11 @@ class EventCollection:
                 (_, event_string, _) = line.split("\t")
                 for pair in self._parse_gene_diff_event(event_string):
                     (from_id, to_id) = pair
+                    fingerprint = f"{from_id} {to_id}"
+                    if fingerprint in loaded_event:
+                        print(f"Duplicated event, skipped: {fingerprint}")
+                        continue
+                    loaded_event.add(fingerprint)
                     event = IdEvent(
                         from_id=from_id, to_id=to_id, event=event_name, release=release_name, release_date=release_date
                     )

--- a/src/python/ensembl/io/genomio/events_loader.py
+++ b/src/python/ensembl/io/genomio/events_loader.py
@@ -80,7 +80,9 @@ class EventCollection:
                 if line == "":
                     continue
                 (from_id, to_id, event_name, release, release_date) = line.split("\t")
-                event = IdEvent(from_id=from_id, to_id=to_id, event=event_name, release=release, release_date=release_date)
+                event = IdEvent(
+                    from_id=from_id, to_id=to_id, event=event_name, release=release, release_date=release_date
+                )
                 events.append(event)
         self.events = events
 
@@ -105,7 +107,11 @@ class EventCollection:
                         continue
                     loaded_event.add(fingerprint)
                     event = IdEvent(
-                        from_id=from_id, to_id=to_id, event=event_name, release=release_name, release_date=release_date
+                        from_id=from_id,
+                        to_id=to_id,
+                        event=event_name,
+                        release=release_name,
+                        release_date=release_date,
                     )
                     events.append(event)
         self.events = events

--- a/src/python/ensembl/io/genomio/events_loader.py
+++ b/src/python/ensembl/io/genomio/events_loader.py
@@ -85,12 +85,20 @@ class EventCollection:
                 )
                 events.append(event)
         self.events = events
+    
+    def add_deletes(self, genes: List[str], release_name: str = "release_name", release_date: str = "release_date") -> None:
+        """Add deletion events from a list of deleted genes."""
+        for gene_id in genes:
+            event = IdEvent(
+                from_id=gene_id, to_id="", event="deletion", release=release_name, release_date=release_date
+            )
+            self.events.append(event)
+
 
     def load_events_from_gene_diff(
         self, input_file: PathLike, release_name: str = "release_name", release_date: str = "release_date"
     ):
         """Load events from input file from gene_diff."""
-        events: List[IdEvent] = []
         event_name = "event"
         loaded_event = set()
 
@@ -113,8 +121,7 @@ class EventCollection:
                         release=release_name,
                         release_date=release_date,
                     )
-                    events.append(event)
-        self.events = events
+                    self.events.append(event)
 
     def _parse_gene_diff_event(self, event_string: str) -> Generator[Tuple[str, str], None, None]:
         """Gets all the pairs of IDs from an event string from gene diff."""
@@ -137,6 +144,8 @@ class EventCollection:
 
         no_map = 0
         for event in self.events:
+            if not event.to_id:
+                continue
             if event.to_id in map_dict:
                 event.to_id = map_dict[event.to_id]
             else:

--- a/src/python/ensembl/io/genomio/events_loader.py
+++ b/src/python/ensembl/io/genomio/events_loader.py
@@ -83,11 +83,11 @@ class EventCollection:
                 events.append(event)
         self.events = events
 
-    def load_events_from_gene_diff(self, input_file: PathLike):
+    def load_events_from_gene_diff(
+        self, input_file: PathLike, release_name: str = "release_name", release_date: str = "release_date"
+    ):
         """Load events from input file from gene_diff."""
         events: List[IdEvent] = []
-        release_name = "release_name"
-        release_date = "release_date"
 
         with Path(input_file).open("r") as events_fh:
             for line in events_fh:

--- a/src/python/ensembl/io/genomio/events_loader.py
+++ b/src/python/ensembl/io/genomio/events_loader.py
@@ -85,15 +85,16 @@ class EventCollection:
                 )
                 events.append(event)
         self.events = events
-    
-    def add_deletes(self, genes: List[str], release_name: str = "release_name", release_date: str = "release_date") -> None:
+
+    def add_deletes(
+        self, genes: List[str], release_name: str = "release_name", release_date: str = "release_date"
+    ) -> None:
         """Add deletion events from a list of deleted genes."""
         for gene_id in genes:
             event = IdEvent(
                 from_id=gene_id, to_id="", event="deletion", release=release_name, release_date=release_date
             )
             self.events.append(event)
-
 
     def load_events_from_gene_diff(
         self, input_file: PathLike, release_name: str = "release_name", release_date: str = "release_date"

--- a/src/python/ensembl/io/genomio/gff3/process_gff3.py
+++ b/src/python/ensembl/io/genomio/gff3/process_gff3.py
@@ -115,6 +115,8 @@ class GFFParserCommon:
         "3'UTR",
         "5'UTR",
         "intron",
+        "non_canonical_five_prime_splice_site",
+        "non_canonical_three_prime_splice_site",
     ]
 
 


### PR DESCRIPTION
Patch build related fixes:
- Allow selecting genes with creation date, for stable id allocation
- When running GFF3 loader batch pipeline, do not rename the existing logic_name, use the same one (if it has the same name). This is BRC specific.
- Add non_canonical split sites to skip in the process gff3 part
- Also, fix to use genomio AnalysisSetup instead of the protein-imported one