### PR TITLE
preserving "cds/parent" rule in metaparser.conf to keep CDSs with no IDs

### DIFF
--- a/config/gff_metaparser/metaparser.conf
+++ b/config/gff_metaparser/metaparser.conf
@@ -75,7 +75,7 @@
 exon/parent	GFF	# obsolete
 exon/@BIOTYPE	GFF	biotype
 
-# cds/parent	GFF	# we'll be preserved automatically
+cds/parent	GFF	# safeguard for CDSs with no IDs; "metaparser/flybase.conf", "metaparser/cds_with_parent_id.patch" -- for other strategies
 cds/id	GFF
 cds/protein_id	GFF_SUB	ID,protein_id # overwrite and copy
 

--- a/config/gff_metaparser/metaparser/cds_with_parent_id.patch
+++ b/config/gff_metaparser/metaparser/cds_with_parent_id.patch
@@ -1,0 +1,5 @@
+# patch for the gff_metaparser.conf to propagate use mRNA IDs for CDSs with no IDs
+
+#   overriding the default "keep empty" approach
+cds/parent	GFF	parent	{"_FROM_STASH":{"ID": "mrna:_PARENT/_STASH/cds_id"}}
+

--- a/config/gff_metaparser/metaparser/flybase.conf
+++ b/config/gff_metaparser/metaparser/flybase.conf
@@ -48,6 +48,7 @@ chromosome_band/name	JSON	seq_region:_SEQID/@karyotype_bands/name	{"_SUB":"^band
 # part that's different
 
 # CDS with no IDs and other quals
+#   not using the default "keep empty" approach
 cds/parent	GFF	parent	{"_FROM_STASH":{"ID": "mrna:_PARENT/_STASH/cds_id"}}
 
 @PROTEIN	ALIAS	protein,polypeptide


### PR DESCRIPTION
preserving "cds/parent" rule in metaparser.conf to keep CDSs with no IDs