### PR TITLE
Mbarba/patch pipeline

### DIFF
--- a/pipelines/nextflow/modules/patch_build/allocate_ids.nf
+++ b/pipelines/nextflow/modules/patch_build/allocate_ids.nf
@@ -32,7 +32,7 @@ process ALLOCATE_IDS {
     if (osid.mock) {
         osid_params = "--mock_osid"
     } else {
-        exit 1, "Actual OSID not implemented yet: $osid";
+        osid_params = "--osid_url $osid.url --osid_user $osid.user --osid_pass $osid.pass --organism $osid.species"
     }
     def feat_list = ""
     if (mode == "gene") {

--- a/pipelines/nextflow/modules/patch_build/allocate_ids.nf
+++ b/pipelines/nextflow/modules/patch_build/allocate_ids.nf
@@ -34,11 +34,11 @@ process ALLOCATE_IDS {
     } else {
         exit 1, "Actual OSID not implemented yet: $osid";
     }
-    def list = ""
+    def feat_list = ""
     if (mode == "gene") {
-        list = "--gene_list $new_feats"
+        feat_list = "--gene_list $new_feats"
     } else if (mode == "transcript") {
-        list = "--transcript_list $new_feats"
+        feat_list = "--transcript_list $new_feats"
     } else {
         exit 1, "Unsupported allocation mode";
     }
@@ -46,7 +46,7 @@ process ALLOCATE_IDS {
     perl $params.scripts_dir/allocate_stable_ids.pl \\
         --reg ./$new_registry \\
         --species $species \\
-        --gene_list $new_feats \\
+        $feat_list \\
         --output_map $output_map \\
         $osid_params \\
         --update

--- a/pipelines/nextflow/modules/patch_build/allocate_ids.nf
+++ b/pipelines/nextflow/modules/patch_build/allocate_ids.nf
@@ -1,0 +1,54 @@
+// See the NOTICE file distributed with this work for additional information
+// regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+process ALLOCATE_IDS {
+    label 'local'
+
+    input:
+        path(new_registry)
+        val(species)
+        val(osid)
+        path(new_feats)
+        val(mode)
+    
+    output:
+        path("output_map.txt")
+
+    script:
+    def output_map = "output_map.txt"
+    def osid_params = ""
+    if (osid.mock) {
+        osid_params = "--mock_osid"
+    } else {
+        exit 1, "Actual OSID not implemented yet: $osid";
+    }
+    def list = ""
+    if (mode == "gene") {
+        list = "--gene_list $new_feats"
+    } else if (mode == "transcript") {
+        list = "--transcript_list $new_feats"
+    } else {
+        exit 1, "Unsupported allocation mode";
+    }
+    """
+    perl $params.scripts_dir/allocate_stable_ids.pl \\
+        --reg ./$new_registry \\
+        --species $species \\
+        --gene_list $new_feats \\
+        --output_map $output_map \\
+        $osid_params \\
+        --update
+    """
+}

--- a/pipelines/nextflow/modules/patch_build/allocate_ids.nf
+++ b/pipelines/nextflow/modules/patch_build/allocate_ids.nf
@@ -43,6 +43,7 @@ process ALLOCATE_IDS {
         exit 1, "Unsupported allocation mode";
     }
     """
+    touch $output_map   # Not necessarily created if no genes were allocated, only transcripts
     perl $params.scripts_dir/allocate_stable_ids.pl \\
         --reg ./$new_registry \\
         --species $species \\

--- a/pipelines/nextflow/modules/patch_build/allocate_ids.nf
+++ b/pipelines/nextflow/modules/patch_build/allocate_ids.nf
@@ -24,10 +24,10 @@ process ALLOCATE_IDS {
         val(mode)
     
     output:
-        path("output_map.txt")
+        path("output_map*.txt")
 
     script:
-    def output_map = "output_map.txt"
+    def output_map = "output_map_${mode}.txt"
     def osid_params = ""
     if (osid.mock) {
         osid_params = "--mock_osid"

--- a/pipelines/nextflow/modules/patch_build/check_osid.nf
+++ b/pipelines/nextflow/modules/patch_build/check_osid.nf
@@ -23,17 +23,21 @@ process CHECK_OSID {
         val(osid)
 
     script:
-    def osid_params = ""
-    if (!osid.mock) {
-        osid_params = "--osid_url $osid.url --osid_user $osid.user --osid_pass $osid.pass --species $osid.species"
-    }
+    def osid_file = "osid_organism.json"
     """
-    if [ "$osid_params" != "" ]; then
-        perl $params.scripts_dir/osid_check_organisms.pl $osid_params > osid_organism.json
-        size=\$(wc -l osid_organism.json)
-        if [ \$size -eq 0 ]; then
+    if [ "$osid.mock" != "true" ]; then
+        python $params.scripts_dir/osid_check_organisms.py \\
+        --url $osid.url \\
+        --user $osid.user \\
+        --key $osid.pass \\
+        --species $osid.species \\
+         > $osid_file
+        FOUND=\$(cat osid_organism.json)
+        if [ "\$FOUND" = "[]" ]; then
             echo "Cannot get organism info from OSID for $osid.species"
             exit 1
+        else
+            echo "$osid.species is in OSID"
         fi
     fi
     """

--- a/pipelines/nextflow/modules/patch_build/check_osid.nf
+++ b/pipelines/nextflow/modules/patch_build/check_osid.nf
@@ -1,0 +1,40 @@
+// See the NOTICE file distributed with this work for additional information
+// regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+process CHECK_OSID {
+    label 'local'
+
+    input:
+        val(osid)
+    
+    output:
+        val(osid)
+
+    script:
+    def osid_params = ""
+    if (!osid.mock) {
+        osid_params = "--osid_url $osid.url --osid_user $osid.user --osid_pass $osid.pass --species $osid.species"
+    }
+    """
+    if [ "$osid_params" != "" ]; then
+        perl $params.scripts_dir/osid_check_organisms.pl $osid_params > osid_organism.json
+        size=\$(wc -l osid_organism.json)
+        if [ \$size -eq 0 ]; then
+            echo "Cannot get organism info from OSID for $osid.species"
+            exit 1
+        fi
+    fi
+    """
+}

--- a/pipelines/nextflow/modules/patch_build/check_patch.nf
+++ b/pipelines/nextflow/modules/patch_build/check_patch.nf
@@ -41,7 +41,7 @@ process CHECK_PATCH {
         table=$1
         dups=$(run_sql "SELECT stable_id FROM $table GROUP BY stable_id HAVING count(*)>1" | wc -l)
         if [ "$dups" -gt "0" ]; then
-            echo "$dups duplicate $table stable ids" > $error_report
+            echo "$dups duplicate $table stable ids" >> $error_report
             echo 1
             return
         fi
@@ -53,7 +53,7 @@ process CHECK_PATCH {
         apollo_pattern="[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
         apids=$(run_sql "SELECT stable_id FROM $table" | grep -E "$apollo_pattern" | wc -l)
         if [ "$apids" -gt "0" ]; then
-            echo "$apids Apollo IDs remain in $table" > $error_report
+            echo "$apids Apollo IDs remain in $table" >> $error_report
             echo 1
             return
         fi
@@ -74,7 +74,8 @@ process CHECK_PATCH {
     done
 
     if [ "$errors" -gt "0" ]; then
-        echo "$errors errors found, abort" > $error_report
+        echo "$errors errors found, abort" >> $error_report
+        cat $error_report
         exit 1
     fi
     '''

--- a/pipelines/nextflow/modules/patch_build/check_patch.nf
+++ b/pipelines/nextflow/modules/patch_build/check_patch.nf
@@ -1,0 +1,81 @@
+// See the NOTICE file distributed with this work for additional information
+// regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+process CHECK_PATCH {
+    label 'local'
+
+    input:
+        val(server)
+        path(waited_file)
+    
+    output:
+        path("patch_ids_error_report.log")
+
+    shell:
+    '''
+    error_report="patch_ids_error_report.log"
+    touch $error_report
+
+    function run_sql {
+        mysql --host=!{server.host} \\
+        --port=!{server.port} \\
+        --user=!{server.user} \\
+        --password=!{server.password} \\
+        -e "$1" \\
+        !{server.database}
+    }
+    
+    function check_duplicates {
+        table=$1
+        dups=$(run_sql "SELECT stable_id FROM $table GROUP BY stable_id HAVING count(*)>1" | wc -l)
+        if [ "$dups" -gt "0" ]; then
+            echo "$dups duplicate $table stable ids" > $error_report
+            echo 1
+            return
+        fi
+        echo 0
+    }
+    
+    function check_apollo_id {
+        table=$1
+        apollo_pattern="[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+        apids=$(run_sql "SELECT stable_id FROM $table" | grep -E "$apollo_pattern" | wc -l)
+        if [ "$apids" -gt "0" ]; then
+            echo "$apids Apollo IDs remain in $table" > $error_report
+            echo 1
+            return
+        fi
+        echo 0
+    }
+
+    # Check for stable ids duplicates
+    errors=0
+    for table in "gene" "transcript" "translation"; do
+        error=$(check_duplicates $table)
+        errors=$(($errors + $error))
+    done
+
+    # Check for Apollo ids remaining
+    for table in "gene" "transcript" "translation" "exon"; do
+        error=$(check_apollo_id $table)
+        errors=$(($errors + $error))
+    done
+
+    if [ "$errors" -gt "0" ]; then
+        echo "$errors errors found, abort" > $error_report
+        exit 1
+    fi
+    '''
+}

--- a/pipelines/nextflow/modules/patch_build/extract_gene_lists.nf
+++ b/pipelines/nextflow/modules/patch_build/extract_gene_lists.nf
@@ -1,0 +1,33 @@
+// See the NOTICE file distributed with this work for additional information
+// regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+process EXTRACT_GENE_LISTS {
+    label 'local'
+
+    input:
+        path(events, stageAs: "events.tab")
+
+    output:
+        path("new_genes.tab")
+        path("changed_genes.tab")
+
+    script:
+    def changed_genes = "changed_genes.tab"
+    def new_genes = "new_genes.tab"
+    """
+    grep -v "//" $events | grep -v "=" | grep -v "~" | sed s'/[+><]/\\t/' | cut -f3 | sed 's/:/\\n/g' | sort -u > $new_genes
+    grep "=" $events | cut -f2 | sed -r 's/=[+!-]?/\t/' > $changed_genes
+    """
+}

--- a/pipelines/nextflow/modules/patch_build/finalize_versions.nf
+++ b/pipelines/nextflow/modules/patch_build/finalize_versions.nf
@@ -1,0 +1,41 @@
+// See the NOTICE file distributed with this work for additional information
+// regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+process FINALIZE_VERSIONS {
+    label 'local'
+
+    input:
+        val(server)
+        path(waited_file)
+
+    script:
+    """
+    function run_sql {
+        mysql --host=$server.host --port=$server.port --user=$server.user --password=$server.password \\
+        -e "\$1" \\
+        $server.database
+    }
+
+    # Transfer version from gene down to transcript and translation
+    run_sql "UPDATE transcript LEFT JOIN gene USING(gene_id) SET transcript.version = gene.version";
+    run_sql "UPDATE translation LEFT JOIN transcript USING(transcript_id) SET translation.version = transcript.version";
+
+    # Set exons to standard name: "{transcript_name}-E{exon_rank}"
+    run_sql "UPDATE exon LEFT JOIN exon_transcript USING(exon_id) LEFT JOIN transcript USING(transcript_id) SET exon.stable_id=CONCAT(transcript.stable_id, '-E', rank)"
+
+    # Set exons to standard version 1
+    run_sql "UPDATE exon SET version = 1";
+    """
+}

--- a/pipelines/nextflow/modules/patch_build/format_events.nf
+++ b/pipelines/nextflow/modules/patch_build/format_events.nf
@@ -1,0 +1,39 @@
+// See the NOTICE file distributed with this work for additional information
+// regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+process FORMAT_EVENTS {
+    label 'local'
+
+    input:
+        path(events, stageAs: "annotation_events.txt")
+        path(deletes)
+        path(new_genes)
+        val(release)
+    
+    output:
+        path("events.tab")
+
+    script:
+    def final_events = "events.tab"
+    """
+    format_events \\
+    --input_file $events \\
+    --map $new_genes \\
+    --deletes $deletes \\
+    --release_name $release.name \\
+    --release_date $release.date \\
+    --output_file $final_events
+    """
+}

--- a/pipelines/nextflow/modules/patch_build/load_events.nf
+++ b/pipelines/nextflow/modules/patch_build/load_events.nf
@@ -1,0 +1,34 @@
+// See the NOTICE file distributed with this work for additional information
+// regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+process LOAD_EVENTS {
+    label 'local'
+
+    input:
+        val(server)
+        path(events)
+
+    script:
+    """
+    events_loader \\
+    --host $server.host \\
+    --user $server.user \\
+    --port $server.port \\
+    --password $server.password \\
+    --database $server.database \\
+    --input_file $events \\
+    --update 1
+    """
+}

--- a/pipelines/nextflow/modules/patch_build/publish_files.nf
+++ b/pipelines/nextflow/modules/patch_build/publish_files.nf
@@ -1,0 +1,31 @@
+// See the NOTICE file distributed with this work for additional information
+// regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+process PUBLISH_FILES {
+    label "local"
+    publishDir "$output_dir", mode: "copy"
+
+    input:
+    path(files)
+    val(output_dir)
+
+    output:
+    path(files, includeInputs: true)
+    
+    script:
+    """
+    echo "$output_dir"
+    """
+}

--- a/pipelines/nextflow/modules/patch_build/transfer_ids.nf
+++ b/pipelines/nextflow/modules/patch_build/transfer_ids.nf
@@ -1,0 +1,39 @@
+// See the NOTICE file distributed with this work for additional information
+// regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+process TRANSFER_IDS {
+    label 'local'
+
+    input:
+        path(changed_genes)
+        path(old_registry, stageAs: "old_registry.pm")
+        path(new_registry, stageAs: "new_registry.pm")
+        val(species)
+
+    output:
+        path("new_transcripts.txt")
+
+    script:
+    def new_transcripts = "new_transcripts.txt"
+    """
+    perl $params.scripts_dir/transfer_ids.pl \\
+        --mapping $changed_genes \\
+        --old ./$old_registry \\
+        --new ./$new_registry \\
+        --species $species \\
+        --out_transcripts $new_transcripts \\
+        --update
+    """
+}

--- a/pipelines/nextflow/modules/patch_build/transfer_metadata.nf
+++ b/pipelines/nextflow/modules/patch_build/transfer_metadata.nf
@@ -1,0 +1,40 @@
+// See the NOTICE file distributed with this work for additional information
+// regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+process TRANSFER_METADATA {
+    label 'local'
+
+    input:
+        path(waited_file)
+        path(old_registry)
+        path(new_registry)
+        val(species)
+    
+    output:
+        path("transfer_metadata.err")
+
+    script:
+    """
+    perl $params.scripts_dir/transfer_metadata.pl \\
+        --old ./$old_registry \\
+        --new ./$new_registry \\
+        --species $species \\
+        --descriptions \\
+        --versions \\
+        --xrefs \\
+        --verbose \\
+        --update 2> transfer_metadata.err
+    """
+}

--- a/pipelines/nextflow/subworkflows/patch_build_post_process/main.nf
+++ b/pipelines/nextflow/subworkflows/patch_build_post_process/main.nf
@@ -1,0 +1,67 @@
+// See the NOTICE file distributed with this work for additional information
+// regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Patch build post-processing pipeline
+
+// Import modules/subworkflows
+include { EXTRACT_GENE_LISTS } from '../../modules/patch_build/extract_gene_lists.nf'
+include { TRANSFER_IDS } from '../../modules/patch_build/transfer_ids.nf'
+include { TRANSFER_METADATA } from '../../modules/patch_build/transfer_metadata.nf'
+include { FORMAT_EVENTS } from '../../modules/patch_build/format_events.nf'
+include { LOAD_EVENTS } from '../../modules/patch_build/load_events.nf'
+include { ALLOCATE_IDS as ALLOCATE_GENE_IDS } from '../../modules/patch_build/allocate_ids.nf'
+include { ALLOCATE_IDS as ALLOCATE_TRANSCRIPT_IDS } from '../../modules/patch_build/allocate_ids.nf'
+
+workflow PATCH_BUILD_PROCESS {
+
+    take:
+        events
+        deleted
+        old_registry
+        new_registry
+        server
+        osid
+        release
+    
+    emit:
+        logs
+    
+    main:
+        // Extract the genes lists from the annotation event file
+        (new_genes, changed_genes) = EXTRACT_GENE_LISTS(events)
+
+        // Transfer the genes from the old db to the new db
+        // Requires 2 registries and the species name
+        new_transcripts = TRANSFER_IDS(changed_genes, old_registry, new_registry, server.species)
+
+        // Transfer metadata (can be done any time after the ids are transfered?)
+        transfer_log = TRANSFER_METADATA(new_transcripts, old_registry, new_registry, server.species)
+
+        // Allocate ids for both the new_genes and the changed_genes new transcripts
+        new_genes_map = ALLOCATE_GENE_IDS(new_registry, server.species, osid, new_genes, "gene")
+        new_transcripts_map = ALLOCATE_TRANSCRIPT_IDS(new_registry, server.species, osid, new_transcripts, "transcript")
+
+        // Format the annotation events file into a compatible event file
+        events_file = FORMAT_EVENTS(events, deleted, new_genes_map, release)
+        LOAD_EVENTS(server, events_file)
+
+        // Get out all generated files if we want to review them
+        logs = changed_genes
+            .concat(new_genes)
+            .concat(new_genes_map)
+            .concat(new_transcripts)
+            .concat(events_file)
+            .concat(transfer_log)
+}

--- a/pipelines/nextflow/subworkflows/patch_build_post_process/main.nf
+++ b/pipelines/nextflow/subworkflows/patch_build_post_process/main.nf
@@ -59,7 +59,7 @@ workflow PATCH_BUILD_PROCESS {
         new_transcripts_map = ALLOCATE_TRANSCRIPT_IDS(new_registry, server.species, osid, new_transcripts, "transcript")
 
         // Finalize the versions
-        waited_files = new_genes_map.concat(new_transcripts_map)
+        waited_files = new_genes_map.concat(new_transcripts_map).last()
         FINALIZE_VERSIONS(server, waited_files)
 
         // Format the annotation events file into a compatible event file

--- a/pipelines/nextflow/subworkflows/patch_build_post_process/main.nf
+++ b/pipelines/nextflow/subworkflows/patch_build_post_process/main.nf
@@ -25,6 +25,7 @@ include { LOAD_EVENTS } from '../../modules/patch_build/load_events.nf'
 include { ALLOCATE_IDS as ALLOCATE_GENE_IDS } from '../../modules/patch_build/allocate_ids.nf'
 include { ALLOCATE_IDS as ALLOCATE_TRANSCRIPT_IDS } from '../../modules/patch_build/allocate_ids.nf'
 include { FINALIZE_VERSIONS } from '../../modules/patch_build/finalize_versions.nf'
+include { CHECK_PATCH } from '../../modules/patch_build/check_patch.nf'
 
 workflow PATCH_BUILD_PROCESS {
 
@@ -62,6 +63,9 @@ workflow PATCH_BUILD_PROCESS {
         waited_files = new_genes_map.concat(new_transcripts_map).last()
         FINALIZE_VERSIONS(server, waited_files)
 
+        // Check stable ids
+        patch_errors=CHECK_PATCH(server, waited_files)
+
         // Format the annotation events file into a compatible event file
         events_file = FORMAT_EVENTS(events, deleted, new_genes_map, release)
         LOAD_EVENTS(server, events_file)
@@ -73,4 +77,5 @@ workflow PATCH_BUILD_PROCESS {
             .concat(new_transcripts)
             .concat(events_file)
             .concat(transfer_log)
+            .concat(patch_errors)
 }

--- a/pipelines/nextflow/subworkflows/patch_build_post_process/main.nf
+++ b/pipelines/nextflow/subworkflows/patch_build_post_process/main.nf
@@ -24,6 +24,7 @@ include { FORMAT_EVENTS } from '../../modules/patch_build/format_events.nf'
 include { LOAD_EVENTS } from '../../modules/patch_build/load_events.nf'
 include { ALLOCATE_IDS as ALLOCATE_GENE_IDS } from '../../modules/patch_build/allocate_ids.nf'
 include { ALLOCATE_IDS as ALLOCATE_TRANSCRIPT_IDS } from '../../modules/patch_build/allocate_ids.nf'
+include { FINALIZE_VERSIONS } from '../../modules/patch_build/finalize_versions.nf'
 
 workflow PATCH_BUILD_PROCESS {
 
@@ -56,6 +57,10 @@ workflow PATCH_BUILD_PROCESS {
         // Allocate ids for both the new_genes and the changed_genes new transcripts
         new_genes_map = ALLOCATE_GENE_IDS(new_registry, server.species, osid, new_genes, "gene")
         new_transcripts_map = ALLOCATE_TRANSCRIPT_IDS(new_registry, server.species, osid, new_transcripts, "transcript")
+
+        // Finalize the versions
+        waited_files = new_genes_map.concat(new_transcripts_map)
+        FINALIZE_VERSIONS(server, waited_files)
 
         // Format the annotation events file into a compatible event file
         events_file = FORMAT_EVENTS(events, deleted, new_genes_map, release)

--- a/pipelines/nextflow/subworkflows/patch_build_post_process/main.nf
+++ b/pipelines/nextflow/subworkflows/patch_build_post_process/main.nf
@@ -16,6 +16,7 @@
 // Patch build post-processing pipeline
 
 // Import modules/subworkflows
+include { CHECK_OSID } from '../../modules/patch_build/check_osid.nf'
 include { EXTRACT_GENE_LISTS } from '../../modules/patch_build/extract_gene_lists.nf'
 include { TRANSFER_IDS } from '../../modules/patch_build/transfer_ids.nf'
 include { TRANSFER_METADATA } from '../../modules/patch_build/transfer_metadata.nf'
@@ -32,13 +33,16 @@ workflow PATCH_BUILD_PROCESS {
         old_registry
         new_registry
         server
-        osid
+        osid_params
         release
     
     emit:
         logs
     
     main:
+        // Check OSID is available and has the expected species
+        osid = CHECK_OSID(osid_params)
+
         // Extract the genes lists from the annotation event file
         (new_genes, changed_genes) = EXTRACT_GENE_LISTS(events)
 

--- a/pipelines/nextflow/subworkflows/patch_build_post_process/meta.yml
+++ b/pipelines/nextflow/subworkflows/patch_build_post_process/meta.yml
@@ -1,0 +1,72 @@
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/subworkflows/yaml-schema.json
+
+name: "patch_build_post_process"
+description: BRC/Ensembl metazoa pipeline. After a patch build gene_diff and having loaded the data in a core database, this pipeline transfers IDs and metadata if a feature has been updated, and it allocate IDs if it is new. Also updates the event tables.
+keywords:
+  - patch_build
+  - stable_id
+input:
+  - events:
+      type: file
+      description: |
+        MANDATORY param. Annotation events files output from the gene diff.
+  - deleted:
+      type: file
+      description: |
+        MANDATORY param. Lists of deleted genes from the core database before the gene_diff (for the history).
+  - old_registry:
+      type: file
+      description: |
+        MANDATORY param. Ensembl registry containing the old core database of the species to update.
+  - new_registry:
+      type: file
+      description: |
+        MANDATORY param. Ensembl registry containing the new core database of the species to update.
+  - server:
+      type: tuple
+      description: |
+        MANDATORY param. Tuple containing Mysql parameters to the server and core db of the species to update.
+        Must contain the following key=value pairs:
+        host
+        port
+        user
+        password
+        species = this is the production_name for the species to update
+  - osid:
+      type: tuple
+      description: |
+        MANDATORY param. Tuple containing OSID parameters to allocate IDs.
+        Must be either:
+        mock: true = in this case OSID will not be used and the script will generate FAKE IDs, for testing purposes
+        or
+        url
+        user
+        pass
+        species = organism name in OSID (might be different from the production_name)
+  - release:
+      type: tuple
+      description: |
+        MANDATORY param. Release information, to use when adding the events to the core db.
+        Must contain the following keys:
+        name
+        date
+output:
+  - logs:
+    type: files
+    description: |
+    Output files of interest (mapping used, logs).

--- a/pipelines/nextflow/subworkflows/patch_build_post_process/meta.yml
+++ b/pipelines/nextflow/subworkflows/patch_build_post_process/meta.yml
@@ -47,7 +47,7 @@ input:
         user
         password
         species = this is the production_name for the species to update
-  - osid:
+  - osid_params:
       type: tuple
       description: |
         MANDATORY param. Tuple containing OSID parameters to allocate IDs.

--- a/pipelines/nextflow/workflows/patch_build/main.nf
+++ b/pipelines/nextflow/workflows/patch_build/main.nf
@@ -164,12 +164,22 @@ process transfer_metadata {
     label 'local'
 
     input:
+        path(waited_file)
         path(old_registry)
         path(new_registry)
         val(species)
 
     script:
     """
+    perl $params.scripts_dir/transfer_metadata.pl \\
+        --old ./$old_registry \\
+        --new ./$new_registry \\
+        --species $species \\
+        --descriptions \\
+        --versions \\
+        --xrefs \\
+        --verbose \\
+        --update
     """
 }
 
@@ -258,7 +268,7 @@ workflow PATCH_BUILD_PROCESS {
         new_transcripts = transfer_ids(changed_genes, old_registry, new_registry, params.species)
 
         // Transfer metadata (can be done any time after the ids are transfered?)
-        // transfer_metadata(old_registry, new_registry, params.species)
+        transfer_metadata(new_transcripts, old_registry, new_registry, params.species)
 
         // Allocate ids for both the new_genes and the changed_genes new transcripts
         new_genes_map = ALLOCATE_GENE_IDS(new_registry, params.species, osid, new_genes, "gene")
@@ -273,7 +283,6 @@ workflow PATCH_BUILD_PROCESS {
             .concat(new_genes)
             .concat(new_genes_map)
             .concat(new_transcripts)
-            .concat(new_transcripts_map)
             .concat(events_file)
         publish(all_files, params.output_dir)
 }

--- a/pipelines/nextflow/workflows/patch_build/main.nf
+++ b/pipelines/nextflow/workflows/patch_build/main.nf
@@ -53,6 +53,10 @@ if (params.help) {
     exit 0
 }
 
+if (!params.scripts_dir) {
+    exit 1, "Missing scripts_dir"
+}
+
 if (!params.host or !params.port or !params.user or !params.pass) {
     exit 1, "Missing server parameters"
 }
@@ -90,10 +94,6 @@ def create_osid_params() {
     return osid
 }
 
-def create_osid_server_params() {
-
-}
-
 process extract_gene_lists {
     label 'local'
 
@@ -118,8 +118,8 @@ process transfer_ids {
 
     input:
         path(changed_genes)
-        path(old_registry)
-        path(new_registry)
+        path(old_registry, stageAs: "old_registry.pm")
+        path(new_registry, stageAs: "new_registry.pm")
         val(species)
 
     output:
@@ -128,7 +128,13 @@ process transfer_ids {
     script:
     def new_transcripts = "new_transcripts.txt"
     """
-    touch $new_transcripts
+    perl $params.scripts_dir/transfer_ids.pl \\
+        --mapping $changed_genes \\
+        --old ./$old_registry \\
+        --new ./$new_registry \\
+        --species $species \\
+        --out_transcripts $new_transcripts \\
+        --update
     """
 }
 

--- a/pipelines/nextflow/workflows/patch_build/main.nf
+++ b/pipelines/nextflow/workflows/patch_build/main.nf
@@ -157,7 +157,7 @@ process allocate_ids {
     input:
         path(new_registry)
         val(species)
-        val(osid_params)
+        val(osid)
         path(new_genes)
         val(mode)
     
@@ -166,8 +166,19 @@ process allocate_ids {
 
     script:
     def output_map = "output_map.txt"
+    def osid_params = ""
+    if (osid.mock) {
+        osid_params = "--mock_osid"
+    } else {
+        exit 1, "Actual OSID not implemented yet: $osid";
+    }
     """
-    touch $output_map
+    perl $params.scripts_dir/allocate_stable_ids.pl \\
+        --reg ./$new_registry \\
+        --species $species \\
+        --out_gene $output_map \\
+        $osid_params \\
+        --update
     """
 }
 
@@ -235,8 +246,8 @@ workflow PATCH_BUILD_PROCESS {
         // Requires 2 registries and the species name
         new_transcripts = transfer_ids(changed_genes, old_registry, new_registry, params.species)
 
-        // Transfer metadata (can be done any time after the ids are tranfered?)
-        transfer_metadata(old_registry, new_registry, params.species)
+        // Transfer metadata (can be done any time after the ids are transfered?)
+        // transfer_metadata(old_registry, new_registry, params.species)
 
         // Allocate ids for both the new_genes and the changed_genes new transcripts
         new_genes_map = allocate_ids(new_registry, params.species, osid, new_genes, "gene")

--- a/pipelines/nextflow/workflows/patch_build/main.nf
+++ b/pipelines/nextflow/workflows/patch_build/main.nf
@@ -1,0 +1,106 @@
+#!/usr/bin/env nextflow
+// See the NOTICE file distributed with this work for additional information
+// regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// default params
+params.help = false
+
+// Print usage
+def helpMessage() {
+  log.info '''
+        Mandatory arguments:
+        --host
+        --port
+        --user
+        --pass                         Connection parameters to the SQL servers we getting core db(s) from
+        --database                     Database name
+        --events_file                  Annotation event file from gene_diff
+
+        Optional arguments:
+        --output_dir                   Where the process files can be stored
+        --help                         This usage statement
+        '''
+}
+
+// Check mandatory parameters
+if (params.help) {
+    helpMessage()
+    exit 0
+}
+
+def create_server(params) {
+    server = [
+        "host": params.host,
+        "port": params.port,
+        "user": params.user,
+        "password": params.pass,
+        "database": params.database
+    ]
+    return server
+}
+
+if (params.host && params.port && params.user && params.pass) {
+    server = create_server(params)
+} else {
+    exit 1, "Missing server parameters"
+}
+
+process extract_gene_lists {
+    label 'local'
+
+    input:
+        path(events, stageAs: "events.tab")
+
+    output:
+        path("new_genes.tab")
+        path("changed_genes.tab")
+
+    script:
+    def changed_genes = "changed_genes.tab"
+    def new_genes = "new_genes.tab"
+    """
+    grep -v "//" $events | grep -v "=" | grep -v "~" | sed s'/[+><]/\\t/' | cut -f3 | sed 's/:/\\n/g' | sort -u > $new_genes
+    grep "=" $events | cut -f2 | sed -r 's/=[+!-]?/\t/' > $changed_genes
+    """
+}
+
+process publish {
+    label "local"
+    publishDir "$output_dir", mode: "copy"
+
+    input:
+    path(files)
+    val(output_dir)
+
+    output:
+    path(files, includeInputs: true)
+    
+    script:
+    """
+    echo "$output_dir"
+    """
+}
+
+// Run main workflow
+workflow {
+    events = Channel.fromPath(params.events_file, checkIfExists: true)
+
+    // Extract the genes lists from the annotation event file
+    (new_genes, changed_genes) = extract_gene_lists(events)
+
+    // Temporary: get all generated files in one folder
+    all_files = new_genes.concat(changed_genes)
+    publish(all_files, params.output_dir)
+}

--- a/pipelines/nextflow/workflows/patch_build/main.nf
+++ b/pipelines/nextflow/workflows/patch_build/main.nf
@@ -168,6 +168,9 @@ process transfer_metadata {
         path(old_registry)
         path(new_registry)
         val(species)
+    
+    output:
+        path("transfer_metadata.err")
 
     script:
     """
@@ -179,7 +182,7 @@ process transfer_metadata {
         --versions \\
         --xrefs \\
         --verbose \\
-        --update
+        --update 2> transfer_metadata.err
     """
 }
 
@@ -268,7 +271,7 @@ workflow PATCH_BUILD_PROCESS {
         new_transcripts = transfer_ids(changed_genes, old_registry, new_registry, params.species)
 
         // Transfer metadata (can be done any time after the ids are transfered?)
-        transfer_metadata(new_transcripts, old_registry, new_registry, params.species)
+        transfer_log = transfer_metadata(new_transcripts, old_registry, new_registry, params.species)
 
         // Allocate ids for both the new_genes and the changed_genes new transcripts
         new_genes_map = ALLOCATE_GENE_IDS(new_registry, params.species, osid, new_genes, "gene")
@@ -284,6 +287,7 @@ workflow PATCH_BUILD_PROCESS {
             .concat(new_genes_map)
             .concat(new_transcripts)
             .concat(events_file)
+            .concat(transfer_log)
         publish(all_files, params.output_dir)
 }
 

--- a/pipelines/nextflow/workflows/patch_build/main.nf
+++ b/pipelines/nextflow/workflows/patch_build/main.nf
@@ -262,17 +262,18 @@ workflow PATCH_BUILD_PROCESS {
 
         // Allocate ids for both the new_genes and the changed_genes new transcripts
         new_genes_map = ALLOCATE_GENE_IDS(new_registry, params.species, osid, new_genes, "gene")
-        // new_transcripts_map = allocate_transcript_ids(new_registry, species, osid_params, new_transcripts)
+        new_transcripts_map = ALLOCATE_TRANSCRIPT_IDS(new_registry, params.species, osid, new_transcripts, "transcript")
 
         // Format the annotation events file into a compatible event file
         events_file = format_events(events, deleted, new_genes_map, release)
         load_events(server, events_file)
 
         // Temporary: get all generated files in one folder
-        all_files = new_genes
-            .concat(changed_genes)
-            .concat(new_transcripts)
+        all_files = changed_genes
+            .concat(new_genes)
             .concat(new_genes_map)
+            .concat(new_transcripts)
+            .concat(new_transcripts_map)
             .concat(events_file)
         publish(all_files, params.output_dir)
 }

--- a/pipelines/nextflow/workflows/patch_build/nextflow.config
+++ b/pipelines/nextflow/workflows/patch_build/nextflow.config
@@ -1,0 +1,23 @@
+// See the NOTICE file distributed with this work for additional information
+// regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+includeConfig '../nextflow.config'
+
+// Set work directory with the same name as the workflow (without extension)
+workDir = "$NXF_WORK/patch_build"
+
+params {
+    output_dir = "patch_build_output"
+}

--- a/pipelines/nextflow/workflows/patch_build/nextflow.config
+++ b/pipelines/nextflow/workflows/patch_build/nextflow.config
@@ -20,4 +20,5 @@ workDir = "$NXF_WORK/patch_build"
 
 params {
     output_dir = "patch_build_output"
+    scripts_dir = "$ENSEMBL_ROOT_DIR/ensembl-genomio/scripts/brc4/patch_build"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,9 +103,10 @@ manifest_stats = "ensembl.io.genomio.manifest_stats:main"
 db_factory = "ensembl.io.genomio.db_factory:main"
 # Dump
 seq_region_dumper = "ensembl.io.genomio.seq_region_dumper:main"
+# Events
 events_dumper = "ensembl.io.genomio.events_dumper:main"
-# Load
 events_loader = "ensembl.io.genomio.events_loader:main"
+format_events = "ensembl.io.genomio.events.format_events:main"
 
 [tool.setuptools]
 package-dir = {"" = "src/python"}

--- a/scripts/brc4/patch_build/allocate_stable_ids.pl
+++ b/scripts/brc4/patch_build/allocate_stable_ids.pl
@@ -206,9 +206,9 @@ my $default_analysis_name = 'brc4_import';
     my %tr_ids;
     my @tr_ids = ();
     my @prot_ids = ();
-    for my $gene_data(@$map) {
+    for my $gene_data (@$map) {
       my $gene_id = $gene_data->{geneId};
-      my $count = scalar @{$gene_data->{transcripts}};
+      my $count = $gene_data->{transcripts};
       for my $i (1..($count+1)) {
         push @tr_ids, $gene_id . '.R' . $i;
         push @prot_ids, $gene_id . '.P' . $i;
@@ -310,11 +310,11 @@ sub allocate_genes {
     ($set_id) = $osid->get_gene_ids(0);  # Get a set id without asking for gene ids
     for my $gene (@genes) {
       my $gene_id = $gene->stable_id;
-      my $tr_count = $trs_list->{$gene_id};
+      my $trs = $trs_list->{$gene_id};
       # Make content for OSID patch
       push @tran_count, {
         'geneId' => $gene_id,
-        'transcripts' => $tr_count
+        'transcripts' => scalar @$trs
       };
     }
   } else {

--- a/scripts/brc4/patch_build/allocate_stable_ids.pl
+++ b/scripts/brc4/patch_build/allocate_stable_ids.pl
@@ -296,8 +296,9 @@ sub allocate_genes {
   $logger->info(scalar(@genes) . " genes will have a new stable_id allocated");
 
   # Check that all genes have been found
-  if (grep {not defined $_} @genes) {
-    die("Some genes to replace are not defined\n");
+  my $not_defined = scalar(grep {not defined $_} @genes);
+  if ($not_defined) {
+    die("$not_defined genes to replace are not defined\n");
   }
   
   # How to get all the ids

--- a/scripts/brc4/patch_build/allocate_stable_ids.pl
+++ b/scripts/brc4/patch_build/allocate_stable_ids.pl
@@ -345,8 +345,6 @@ sub allocate_genes {
   for my $gene (@genes) {
 
     my $gene_id = $trs_list ? $gene->stable_id : $gene_map{$gene->stable_id};
-    
-    my @transcripts = @{ $gene->get_all_Transcripts };
 
     my $new_tran_ids = $tr_ids->{$gene_id}->{transcripts};
     my $new_prot_ids = $tr_ids->{$gene_id}->{proteins};
@@ -399,9 +397,10 @@ sub allocate_genes {
       if ($update) {
         my $old_tr_id = $tr->stable_id;
         $tr->stable_id($tran_id);
+        $logger->debug("Reset ID from $old_tr_id to $tran_id: " . $tr->stable_id);
 
         if ($update) {
-        $tra->update($tr);
+          $tra->update($tr);
 
           # Xref
           if ($xref_source) {

--- a/scripts/brc4/patch_build/allocate_stable_ids.pl
+++ b/scripts/brc4/patch_build/allocate_stable_ids.pl
@@ -203,19 +203,19 @@ my $default_analysis_name = 'brc4_import';
   sub get_transcripts_ids {
     my ($self, $set_id, $map) = @_;
     
-    my %tr_ids;
-    my @tr_ids = ();
-    my @prot_ids = ();
+    my %tr_ids_out;
     for my $gene_data (@$map) {
+      my @tr_ids = ();
+      my @prot_ids = ();
       my $gene_id = $gene_data->{geneId};
       my $count = $gene_data->{transcripts};
       for my $i (1..($count+1)) {
         push @tr_ids, $gene_id . '.R' . $i;
         push @prot_ids, $gene_id . '.P' . $i;
       }
-      $tr_ids{$gene_id} = {transcripts => \@tr_ids, proteins => \@prot_ids};
+      $tr_ids_out{$gene_id} = {transcripts => \@tr_ids, proteins => \@prot_ids};
     }
-    return \%tr_ids;
+    return \%tr_ids_out;
   }
 }
 

--- a/scripts/brc4/patch_build/allocate_stable_ids.pl
+++ b/scripts/brc4/patch_build/allocate_stable_ids.pl
@@ -378,6 +378,15 @@ sub allocate_genes {
       }
     }
     
+    # Now update the transcripts
+    my @transcripts = @{ $gene->get_all_Transcripts };
+
+    # Restrict to the transcripts in the list
+    if ($trs_list) {
+      my %tr_ids = map { $_ => 1 } @{$trs_list->{$gene_id}};
+      @transcripts = grep { $tr_ids{$_->stable_id} } @transcripts;
+    }
+
     for my $tr (@transcripts) {
       $transcripts_count++;
 

--- a/scripts/brc4/patch_build/allocate_stable_ids.pl
+++ b/scripts/brc4/patch_build/allocate_stable_ids.pl
@@ -188,6 +188,8 @@ my $default_analysis_name = 'brc4_import';
 
   sub get_gene_ids {
     my ($self, $count) = @_;
+
+    return 1, [] if $count == 0;
     
     my $prefix = 'FAKEID_';
     my @ids = ();
@@ -206,7 +208,7 @@ my $default_analysis_name = 'brc4_import';
     my @prot_ids = ();
     for my $gene_data(@$map) {
       my $gene_id = $gene_data->{geneId};
-      my $count =  $gene_data->{transcripts};
+      my $count = scalar @{$gene_data->{transcripts}};
       for my $i (1..($count+1)) {
         push @tr_ids, $gene_id . '.R' . $i;
         push @prot_ids, $gene_id . '.P' . $i;

--- a/scripts/brc4/patch_build/allocate_stable_ids.pl
+++ b/scripts/brc4/patch_build/allocate_stable_ids.pl
@@ -294,6 +294,11 @@ sub allocate_genes {
     $logger->info("Reduce list using date $after_date: from $nold genes to $nnew");
   }
   $logger->info(scalar(@genes) . " genes will have a new stable_id allocated");
+
+  # Check that all genes have been found
+  if (grep {not defined $_} @genes) {
+    die("Some genes to replace are not defined\n");
+  }
   
   # How to get all the ids
 

--- a/scripts/brc4/patch_build/osid_check_organisms.py
+++ b/scripts/brc4/patch_build/osid_check_organisms.py
@@ -17,6 +17,7 @@
 """This script retrieves the organism metadata from an OSID server."""
 
 import argparse
+import sys
 from typing import List
 import json
 import requests
@@ -72,7 +73,7 @@ def main():
     organisms = client.get_organism_data(args.species)
 
     # Display results
-    print(f"{len(organisms)} Organisms in {args.url}:")
+    print(f"{len(organisms)} Organisms in {args.url}:", file=sys.stderr)
     print(json.dumps(organisms, indent=4, sort_keys=True))
 
 

--- a/scripts/brc4/patch_build/osid_check_organisms.py
+++ b/scripts/brc4/patch_build/osid_check_organisms.py
@@ -18,8 +18,8 @@
 
 import argparse
 from typing import List
-import requests
 import json
+import requests
 
 
 class OSIDClient:
@@ -50,12 +50,12 @@ class OSIDClient:
             body["organismName"] = species
 
         get_url = self.url + "/" + OSIDClient.organisms_page
-        result = requests.get(get_url, auth=(self.user, self.key), params=body)
+        result = requests.get(get_url, auth=(self.user, self.key), params=body, timeout=30)
 
         if result and result.status_code == 200:
             organisms = json.loads(result.content)
         else:
-            raise Exception("Could not retrieve organism data from {get_url}")
+            raise ValueError(f"Could not retrieve organism data from {get_url}")
         return organisms
 
 

--- a/scripts/brc4/patch_build/transfer_ids.pl
+++ b/scripts/brc4/patch_build/transfer_ids.pl
@@ -1,0 +1,192 @@
+#!/usr/env perl
+use v5.14.00;
+use strict;
+use warnings;
+use Carp;
+use autodie qw(:all);
+use Readonly;
+use Getopt::Long qw(:config no_ignore_case);
+use Log::Log4perl qw( :easy ); 
+Log::Log4perl->easy_init($WARN); 
+my $logger = get_logger(); 
+
+use Bio::EnsEMBL::Registry;
+use Try::Tiny;
+use File::Path qw(make_path);
+use List::MoreUtils qw(uniq);
+
+###############################################################################
+# MAIN
+# Get command line args
+our %opt = %{ opt_check() };
+
+# First, load the mapping
+my $mapping = load_mapping($opt{mapping})
+my @old_gene_ids = values(%mapping);
+
+my $species = $opt{species};
+
+# Get gene ids and transcript ids from old database
+my $registry = 'Bio::EnsEMBL::Registry';
+my $reg_path = $opt{old_registry};
+$registry->load_all($reg_path);
+
+my $old_genes = get_genes_data($registry, $species, \@old_gene_ids);
+$logger->info(scalar(@$old_genes) . " genes from old database");
+
+# Reload registry, this time for new database
+$reg_path = $opt{new_registry};
+$registry->load_all($reg_path);
+
+# Transfer the IDs to the new genes using the mapping
+transfer_gene_ids($registry, $species, $mapping)
+
+###############################################################################
+sub load_mapping {
+  my ($mapping_file) = @_;
+
+  my %mapping;
+  open my $map_fh, '<', $mapping_file;
+  while (my $line = readline $map_fh) {
+    chomp $line;
+    my ($old_id, $new_id) = split("\t", $line);
+    $mapping{$new_id} = $old_id;
+  }
+
+  return \%mapping;
+}
+
+sub get_genes_data {
+  my ($registry, $species, $gene_ids) = @_;
+  
+  my %genes;
+  my $ga = $registry->get_adaptor($species, "core", 'gene');
+  for my $gene_id (@$gene_ids) {
+    my $gene = $ga->fetch_by_stable_id($gene_id);
+    my $gene_id = $feat->stable_id;
+
+    # Get transcripts
+    my @trs;
+    for my $tr (@{$gene->get_all_Transcripts()}) {
+      my $tr_data = {
+        id => $tr->stable_id,
+        fingerprint => tr_fingerprint($tr),
+        seq_checksum => {},
+      };
+      my $prot = $tr->translation;
+      if ($prot) {
+        $tr_data{protein_id} = $prot->stable_id;
+        my $seq = $prot->seq();
+        $tr_data{seq_checksum}{$seq} = 1;
+      }
+      push @trs, $tr_data;
+    }
+    my %gene_data = (
+      id => $gene_id,
+      transcripts => \@trs,
+    );
+    $genes{$gene_id} = $gene_data;
+  }
+  
+  return \%feats;
+}
+
+sub tr_fingerprint {
+  my ($tr) = @_;
+
+  
+}
+
+sub update_descriptions {
+  my ($registry, $species, $old_genes, $update) = @_;
+  
+  my $update_count = 0;
+  my $empty_count = 0;
+  my $new_count = 0;
+  
+  my $ga = $registry->get_adaptor($species, "core", 'gene');
+  for my $gene (@{$ga->fetch_all}) {
+    my $id = $gene->stable_id;
+    my $description = $gene->description;
+
+    if (not defined $description) {
+      my $old_gene = $old_genes->{$id};
+      if (not $old_gene) {
+        $new_count++;
+        next;
+      }
+      my $old_description = $old_gene->{description};
+
+      if (defined $old_description) {
+        my $new_description = $old_description;
+        $logger->debug("Transfer gene $id description: $new_description");
+        $update_count++;
+
+        if ($update) {
+          $gene->description($new_description);
+          $ga->update($gene);
+        }
+      } else {
+        $empty_count++;
+      }
+    }
+  }
+  
+  $logger->info("$update_count gene descriptions transferred");
+  $logger->info("$empty_count genes without description remain");
+  $logger->info("$new_count new genes, without description");
+  $logger->info("(Use --write to update the descriptions in the database)") if $update_count > 0 and not $update;
+}
+
+###############################################################################
+# Parameters and usage
+sub usage {
+  my $error = shift;
+  my $help = '';
+  if ($error) {
+    $help = "[ $error ]\n";
+  }
+  $help .= <<'EOF';
+    Transfer the gene versions and descriptions to a patched database
+
+    --old_registry <path> : Ensembl registry
+    --new_registry <path> : Ensembl registry
+    --species <str>       : production_name of one species
+    --mapping <path>      : Old gene ids to new gene ids mapping file
+    
+    --update          : Do the actual changes (default is no changes to the database)
+    
+    --help            : show this help message
+    --verbose         : show detailed progress
+    --debug           : show even more information (for debugging purposes)
+EOF
+  print STDERR "$help\n";
+  exit(1);
+}
+
+sub opt_check {
+  my %opt = ();
+  GetOptions(\%opt,
+    "old_registry=s",
+    "new_registry=s",
+    "species=s",
+    "mapping=s",
+    "update",
+    "help",
+    "verbose",
+    "debug",
+  );
+
+  usage("Old registry needed") if not $opt{old_registry};
+  usage("New registry needed") if not $opt{new_registry};
+  usage("Species needed") if not $opt{species};
+  usage("Mapping needed") if not $opt{mapping};
+
+  usage()                if $opt{help};
+  Log::Log4perl->easy_init($INFO) if $opt{verbose};
+  Log::Log4perl->easy_init($DEBUG) if $opt{debug};
+  return \%opt;
+}
+
+__END__
+

--- a/scripts/brc4/patch_build/transfer_ids.pl
+++ b/scripts/brc4/patch_build/transfer_ids.pl
@@ -148,7 +148,7 @@ sub transfer_transcripts {
 
     my $old_tr = $old_gene->{$cur_fingerprint};
     if (not $old_tr) {
-      push @missed_trs, $transcript->stable_id;
+      push @missed_trs, [$gene->stable_id, $transcript->stable_id];
     }
     next if not $old_tr;
 
@@ -170,8 +170,8 @@ sub print_missed {
   my ($list, $out_file) = @_;
 
   open my $out_fh, ">", $out_file;
-  for my $id (@$list) {
-    print $out_fh "$id\n";
+  for my $ids (@$list) {
+    print $out_fh join("\t", @$ids) . "\n";
   }
 }
 

--- a/scripts/brc4/patch_build/transfer_ids.pl
+++ b/scripts/brc4/patch_build/transfer_ids.pl
@@ -83,13 +83,19 @@ sub get_genes_data {
 sub tr_fingerprint {
   my ($tr) = @_;
 
-  my @coords = (
-    $tr->seq_region_name,
-    $tr->seq_region_start,
-    $tr->seq_region_end,
-    $tr->strand,
-  );
-  my $fingerprint = join(":", @coords);
+  my @exon_fingerprints;
+  my $exons = $tr->get_all_Exons();
+  for my $exon (@$exons) {
+    my @exon_coords = (
+      $exon->seq_region_name,
+      $exon->seq_region_start,
+      $exon->seq_region_end,
+      $exon->strand,
+    );
+    my $exon_fingerprint = join(":", @exon_coords);
+    push @exon_fingerprints, $exon;
+  }
+  my $fingerprint = join("__", @exon_fingerprints);
 
   # print("Fingerprint for " . $tr->stable_id . " : $fingerprint\n");
 

--- a/scripts/brc4/patch_build/transfer_ids.pl
+++ b/scripts/brc4/patch_build/transfer_ids.pl
@@ -1,4 +1,24 @@
 #!/usr/env perl
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+
 use v5.14.00;
 use strict;
 use warnings;

--- a/scripts/brc4/patch_build/transfer_metadata.pl
+++ b/scripts/brc4/patch_build/transfer_metadata.pl
@@ -105,27 +105,6 @@ if ($opt{versions}) {
     $logger->info("Versions transfer for $feat:");
     update_versions($registry, $species, $feat, $old_data{$feat}, $opt{update});
   }
-
-  # Blanket version replacement for transcripts, translations, exons
-  if ($opt{update}) {
-    $logger->info("Transcripts, translations and exons version update");
-    my $ga = $registry->get_adaptor($species, "core", 'gene');
-    my $dbc = $ga->dbc;
-
-    # Transfer the versions from genes to transcripts
-    my $transcript_query = "UPDATE transcript LEFT JOIN gene USING(gene_id) SET transcript.version = gene.version";
-    $dbc->do($transcript_query);
-
-    # Also transfer the versions from transcripts to translations
-    my $translation_query = "UPDATE translation LEFT JOIN transcript USING(transcript_id) SET translation.version = transcript.version";
-    $dbc->do($translation_query);
-
-    # And set the exons version to 1
-    my $exon_query = "UPDATE exon SET version = 1";
-    $dbc->do($exon_query);
-  } else {
-    $logger->info("Transcripts, translations and exons init versions were not updated (use --update to do so)");
-  }
 }
 
 ###############################################################################

--- a/scripts/brc4/patch_build/transfer_metadata.pl
+++ b/scripts/brc4/patch_build/transfer_metadata.pl
@@ -1,4 +1,24 @@
 #!/usr/env perl
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+
 use v5.14.00;
 use strict;
 use warnings;

--- a/scripts/brc4/patch_build/transfer_metadata.pl
+++ b/scripts/brc4/patch_build/transfer_metadata.pl
@@ -1,0 +1,723 @@
+#!/usr/env perl
+use v5.14.00;
+use strict;
+use warnings;
+use Carp;
+use autodie qw(:all);
+use Readonly;
+use Getopt::Long qw(:config no_ignore_case);
+use Log::Log4perl qw( :easy ); 
+Log::Log4perl->easy_init($WARN); 
+my $logger = get_logger(); 
+
+use Bio::EnsEMBL::Registry;
+use Try::Tiny;
+use File::Path qw(make_path);
+use List::MoreUtils qw(uniq);
+
+my @current_xrefs = (
+  'BRC4_Community_Annotation',
+  'RefSeq_gene_name',
+  'PUBMED',
+  'EntrezGene',
+);
+my %alias_xrefs = (
+  VB_Community_Annotation => 'BRC4_Community_Annotation',
+);
+
+my %ok_xrefs = map { $_ => $_ } @current_xrefs;
+%ok_xrefs = (%ok_xrefs, %alias_xrefs);
+
+###############################################################################
+# MAIN
+# Get command line args
+our %opt = %{ opt_check() };
+
+my $species = $opt{species};
+
+# Features to transfer versions from
+my @features = qw(gene);
+
+# Get genes and transcripts from old database
+my $registry = 'Bio::EnsEMBL::Registry';
+my $reg_path = $opt{old_registry};
+$registry->load_all($reg_path);
+my $ma = $registry->get_adaptor($species, "core", 'MetaContainer');
+
+my $old_metadata = get_meta($ma);
+my %old_data;
+for my $feat (@features) {
+  $old_data{$feat} = get_feat_data($registry, $species, $feat);
+  $logger->info(scalar(keys %{$old_data{$feat}}) . " ${feat}s from old database");
+}
+
+# Reload registry, this time for new database
+$reg_path = $opt{new_registry};
+$registry->load_all($reg_path);
+$ma = $registry->get_adaptor($species, "core", 'MetaContainer');
+my $new_metadata = get_meta($ma);
+
+my %new_data;
+for my $feat (@features) {
+  $new_data{$feat} = get_feat_data($registry, $species, $feat);
+  $logger->info(scalar(keys %{$new_data{$feat}}) . " ${feat}s from new database");
+}
+
+# Transfer descriptions
+if ($opt{descriptions}) {
+  $logger->info("Gene descriptions transfer:");
+  update_descriptions($registry, $species, $old_data{gene}, $opt{write});
+}
+
+# Transfer xrefs
+if ($opt{xrefs}) {
+  $logger->info("Gene xrefs transfer:");
+  update_xrefs($registry, $species, $old_data{gene}, $opt{write});
+}
+
+if ($opt{events}) {
+  # Get events from features differences
+  my ($old_ids, $new_ids) = diff_events($old_data{gene}, $new_data{gene});
+
+  # Load all events from the file
+  my $del_events = load_deletes($opt{deletes}, $old_ids);
+  my $file_events = load_events($opt{events}, $old_ids, $new_ids);
+
+  my %events = (%$del_events, %$file_events);
+
+  for my $event_type (sort keys %events) {
+    my @feat_events = @{$events{$event_type}};
+    $logger->info("Event: $event_type = " . scalar(@feat_events));
+  }
+
+  # Compile metadata for mapping
+  my $metadata = {
+    old_db_name => $old_metadata->{db_name},
+    new_db_name => $new_metadata->{db_name},
+    old_release => $old_metadata->{release},
+    new_release => $new_metadata->{release},
+    old_assembly => $old_metadata->{assembly},
+    new_assembly => $new_metadata->{assembly},
+  };
+
+  my $ga = $registry->get_adaptor($species, "core", 'gene');
+  my $dbc = $ga->dbc;
+  add_events(\%events, $old_data{gene}, $dbc, $metadata, $opt{write});
+}
+
+# Transfer versions
+if ($opt{versions}) {
+  $logger->info("Gene versions transfer:");
+  # Update the version for the features we want to transfer and update
+  for my $feat (@features) {
+    update_versions($registry, $species, $feat, $old_data{$feat}, $opt{write});
+  }
+
+  # Blanket version replacement for transcripts, translations, exons
+  if ($opt{write}) {
+    $logger->info("Transcripts, translations and exons version update");
+    my $ga = $registry->get_adaptor($species, "core", 'gene');
+    my $dbc = $ga->dbc;
+
+    # Transfer the versions from genes to transcripts
+    my $transcript_query = "UPDATE transcript LEFT JOIN gene USING(gene_id) SET transcript.version = gene.version";
+    $dbc->do($transcript_query);
+
+    # Also transfer the versions from transcripts to translations
+    my $translation_query = "UPDATE translation LEFT JOIN transcript USING(transcript_id) SET translation.version = transcript.version";
+    $dbc->do($translation_query);
+
+    # And set the exons version to 1
+    my $exon_query = "UPDATE exon SET version = 1";
+    $dbc->do($exon_query);
+  } else {
+    $logger->info("Transcripts, translations and exons init versions were not updated (use --write to do so)");
+  }
+}
+
+###############################################################################
+sub load_deletes {
+  my ($deletes_file, $old_ids) = @_;
+
+  if (not $deletes_file) {
+    return {};
+  }
+
+  my %events = (
+    deleted => [],
+  );
+  open(my $deletes_fh, "<", $deletes_file);
+  while (my $line = readline($deletes_fh)) {
+    chomp $line;
+    my $id = $line;
+
+    if ($old_ids->{$id}) {
+      push @{$events{deleted}}, {from => [$id], to => []};
+      delete $old_ids->{$id};
+    } else {
+      $logger->warn("Warning: '$id' in the deletes file, but not deleted in the new core");
+    }
+  }
+
+  return \%events;
+}
+
+sub load_events {
+  my ($events_file, $old_ids, $new_ids) = @_;
+
+  if (not $events_file) {
+    return {};
+  }
+
+  my %events = (
+    change => [],
+    new => [],
+    split => [],
+    merge => [],
+  );
+  my %merge_to = ();
+  my %split_from = ();
+  open(my $events_fh, "<", $events_file);
+  while (my $line = readline($events_fh)) {
+    chomp $line;
+    my ($id1, $event_name, $id2) = split("\t", $line);
+
+    # New gene
+    if ($id1 and not $id2) {
+      push @{$events{new}}, {from => [], to => [$id1]};
+      if ($new_ids->{$id1}) {
+        delete $new_ids->{$id1};
+      }
+    # Changed gene
+    } elsif ($id1 eq $id2) {
+      push @{$events{change}}, {from => [$id1], to => [$id1]};
+    # Merge or split
+    } elsif ($event_name eq 'merge_gene' or $event_name eq 'split_gene') {
+      if (not $merge_to{$id1}) {
+        $merge_to{$id1} = [];
+      }
+      if (not $split_from{$id2}) {
+        $split_from{$id2} = [];
+      }
+      push @{$merge_to{$id1}}, $id2;
+      push @{$split_from{$id2}}, $id1;
+    }
+    else {
+      $logger->warn("Unsupported event '$event_name'? $line");
+    }
+  }
+
+  # Ensure all event ids are unique in their groups
+  for my $merge_id (keys %merge_to) {
+    my @ids = uniq @{ $merge_to{$merge_id} };
+    $merge_to{$merge_id} = \@ids;
+  }
+  for my $split_id (keys %split_from) {
+    my @ids = uniq @{ $split_from{$split_id} };
+    $split_from{$split_id} = \@ids;
+  }
+
+  # Check for merge and splits involving the same ids (multi event)
+  my $multi_events = check_multi_events(\%split_from, \%merge_to);
+
+  for my $event_name (keys %$multi_events) {
+    my @named_events = @{ $multi_events->{$event_name} };
+    for my $named_event (@named_events) {
+      for my $from_id (@{ $named_event->{from} }) {
+        if ($old_ids->{$from_id}) {
+          delete $old_ids->{$from_id};
+        }
+      }
+      for my $to_id (@{ $named_event->{to} }) {
+        if ($new_ids->{$to_id}) {
+          delete $new_ids->{$to_id};
+        }
+      }
+    }
+  }
+  %events = (%events, %$multi_events);
+
+  if (%$new_ids) {
+    $logger->warn(scalar(%$new_ids) . " new ids not in the event file: " . join("; ", sort keys %$new_ids));
+  }
+
+  if (%$old_ids) {
+    $logger->warn(scalar(%$old_ids) . " old ids not in the event file: " . join("; ", sort keys %$old_ids));
+  }
+
+  close($events_fh);
+
+  return \%events;
+}
+
+sub check_multi_events {
+  my ( $from, $to ) = @_;
+
+  my %events = (
+    merge => [],
+    split => [],
+    multi => [],
+  );
+  for my $from_id ( sort keys %$from ) {
+    next if not $from->{$from_id};
+    my @to_ids = @{ $from->{$from_id} };
+    my %group  = ( from => [$from_id], to => [@to_ids] );
+
+    my $extended = 1;
+    while ($extended) {
+      $extended = 0;
+      my %from_ids = map { $_ => 1 } @{$group{from}};
+      my %to_ids = map { $_ => 1 } @{$group{to}};
+
+      # Expand the group in the to ids
+      for my $to_id (sort keys %to_ids) {
+        if ( exists $to->{$to_id} ) {
+          my @to_from_ids = @{ $to->{$to_id} };
+
+          # Add to the from list?
+          my @new_from_ids;
+          for my $to_from_id (@to_from_ids) {
+            if (not $from_ids{$to_from_id}) {
+              push @new_from_ids, $to_from_id;
+            }
+          }
+          if (@new_from_ids) {
+            push @{ $group{from} }, @new_from_ids;
+            $extended = 1;
+          }
+        }
+      }
+      # Expand the group in the from ids
+      for my $from_id (sort keys %from_ids) {
+        if ( exists $from->{$from_id} ) {
+          my @from_to_ids = @{ $from->{$from_id} };
+
+          # Add to the to list?
+          my @new_to_ids;
+          for my $from_to_id (@from_to_ids) {
+            if (not $to_ids{$from_to_id}) {
+              push @new_to_ids, $from_to_id;
+            }
+          }
+          if (@new_to_ids) {
+            push @{ $group{to} }, @new_to_ids;
+            $extended = 1;
+          }
+        }
+      }
+    }
+
+    # We have a group! Clean up and save it
+    for my $from_id (@{ $group{from} }) {
+      delete $from->{$from_id};
+    }
+    for my $to_id (@{ $group{to} }) {
+      delete $to->{$to_id};
+    }
+    
+    # Save the group, guess the event name
+    if (@{ $group{from} } > 1) {
+      if (@{ $group{to} } > 1) {
+        push @{$events{multi}}, \%group;
+      } else {
+        push @{$events{merge}}, \%group;
+      }
+    } else {
+      push @{$events{split}}, \%group;
+    }
+  }
+
+  return \%events;
+}
+
+sub diff_events {
+  my ($old, $new) = @_;
+
+  my %events = (
+    new => [],
+    deleted => [],
+  );
+
+  my %old_ids = map { $_ => 1 } keys %$old;
+  my %new_ids = map { $_ => 1 } keys %$new;
+
+  for my $old_id (keys %old_ids) {
+    if ($new_ids{$old_id}) {
+      delete $old_ids{$old_id};
+      delete $new_ids{$old_id};
+    }
+  }
+
+  return \%old_ids, \%new_ids;
+}
+
+sub get_feat_data {
+  my ($registry, $species, $feature) = @_;
+  
+  my %feats;
+  my $fa = $registry->get_adaptor($species, "core", $feature);
+  for my $feat (@{$fa->fetch_all}) {
+    my $id = $feat->stable_id;
+    my $version = $feat->version // 1;
+    my $description;
+    if ($feature eq 'gene') {
+      $description = $feat->description;
+    }
+    my $xrefs = $feat->get_all_DBEntries();
+    $feats{$id} = { version => $version, description => $description, xrefs => $xrefs };
+  }
+  
+  return \%feats;
+}
+
+sub update_versions {
+  my ($registry, $species, $feature, $old_feats, $update) = @_;
+  
+  my $update_count = 0;
+  my $new_count = 0;
+  
+  my $fa = $registry->get_adaptor($species, "core", $feature);
+  for my $feat (@{$fa->fetch_all}) {
+    my $id = $feat->stable_id;
+    my $version = $feat->version;
+
+    if (not defined $version) {
+      my $old_feat = $old_feats->{$id};
+      
+      if (not $old_feat) {
+        $new_count++;
+        next;
+      }
+      
+      my $old_version = $old_feat->{version};
+      my $new_version = 1;
+
+      if (defined $old_version) {
+        $new_version = $old_version + 1;
+        $logger->debug("Updated $feature $id must be upgraded from $old_version to $new_version");
+        $update_count++;
+      } else {
+        $logger->debug("New $feature $id must be initialized to 1");
+        $new_count++;
+      }
+
+      if ($update) {
+        $feat->version($new_version);
+        $fa->update($feat);
+      }
+    }
+  }
+  
+  $logger->info("$update_count $feature version updated");
+  $logger->info("$new_count $feature version to be initialized");
+  $logger->info("(Use --write to make the changes to the database))") if $update_count + $new_count > 0 and not $update;
+}
+
+sub update_descriptions {
+  my ($registry, $species, $old_genes, $update) = @_;
+  
+  my $update_count = 0;
+  my $empty_count = 0;
+  my $new_count = 0;
+  
+  my $ga = $registry->get_adaptor($species, "core", 'gene');
+  for my $gene (@{$ga->fetch_all}) {
+    my $id = $gene->stable_id;
+    my $description = $gene->description;
+
+    if (not defined $description) {
+      my $old_gene = $old_genes->{$id};
+      if (not $old_gene) {
+        $new_count++;
+        next;
+      }
+      my $old_description = $old_gene->{description};
+
+      if (defined $old_description) {
+        my $new_description = $old_description;
+        $logger->debug("Transfer gene $id description: $new_description");
+        $update_count++;
+
+        if ($update) {
+          $gene->description($new_description);
+          $ga->update($gene);
+        }
+      } else {
+        $empty_count++;
+      }
+    }
+  }
+  
+  $logger->info("$update_count gene descriptions transferred");
+  $logger->info("$empty_count genes without description remain");
+  $logger->info("$new_count new genes, without description");
+  $logger->info("(Use --write to update the descriptions in the database)") if $update_count > 0 and not $update;
+}
+
+sub update_xrefs {
+  # Transfer the xrefs from old gene entries to new gene entries, if those do not exist
+  my ($registry, $species, $old_genes, $update) = @_;
+  
+  my $update_count = 0;
+  my $new_count = 0;
+  my %no_transfer = ();
+  my %yes_transfer = ();
+  my $total_transfer = 0;
+
+  my $aa = $registry->get_adaptor($species, "core", 'analysis');
+  
+  my $ga = $registry->get_adaptor($species, "core", 'gene');
+  my $xa = $registry->get_adaptor($species, "core", 'DBentry');
+  for my $gene (@{$ga->fetch_all}) {
+    my $id = $gene->stable_id;
+
+    my $old_gene = $old_genes->{$id};
+    if (not $old_gene) {
+      $new_count++;
+      next;
+    }
+    my $xrefs = $gene->get_all_DBEntries();
+    my %xref_dict = map { $_->dbname => $_ } @$xrefs;
+
+    my $old_xrefs = $old_gene->{xrefs};
+
+    for my $xref (@$old_xrefs) {
+      my $dbname = $xref->dbname;
+      # We only include dbnames that we expect
+      if (not exists $ok_xrefs{$dbname}) {
+        $logger->debug("NO TRANSFER for gene $id xref:\t$dbname\twith ID " . $xref->primary_id);
+        $no_transfer{$dbname}++;
+        next;
+      }
+      # Rename the dbname in case we need to transfer old xrefs which had their name changed
+      $dbname = $ok_xrefs{$dbname};
+      $xref->dbname($dbname);
+      if (not exists $xref_dict{$dbname}) {
+        $yes_transfer{$dbname}++;
+        $logger->debug("Transfer gene $id xref: $dbname with ID " . $xref->primary_id);
+        $update_count++;
+        if ($update) {
+          # Ensure we use an up to date analysis
+          my $analysis_name = $xref->analysis->logic_name;
+          my $analysis = $aa->fetch_by_logic_name($analysis_name);
+          $xref->analysis($analysis);
+          $xa->store($xref, $gene->dbID, 'Gene', 1); # ignore release
+          $total_transfer++;
+        }
+      }
+    }
+  }
+  
+  $logger->info("$update_count gene xrefs transferred");
+  $logger->info("$new_count new genes, without xref to transfer");
+  for my $dbname (sort keys %yes_transfer) {
+    my $count = $yes_transfer{$dbname};
+    $logger->info("Transfered: $count\t$dbname");
+  }
+  for my $dbname (sort keys %no_transfer) {
+    my $count = $no_transfer{$dbname};
+    $logger->info("NOT transfered: $count from external_db '$dbname'");
+  }
+  $logger->info("$total_transfer written xref transfers") if $total_transfer > 0;
+  if ($update_count > 0) {
+    if (not $update) {
+      $logger->info("(Use --write to update the xrefs in the database)");
+    }
+  } else {
+    $logger->info("(No xrefs to update in the database)");
+  }
+}
+
+sub add_events {
+  my ($events, $data, $dbc, $metadata, $write) = @_;
+
+  my $feat = 'gene';
+  my $mapping_id = add_mapping_session($dbc, $metadata, $write);
+
+  for my $event_name (keys %$events) {
+    my @events = @{$events->{$event_name}};
+    my $nevents = scalar @events;
+    my $msg = "Storing $nevents events $event_name...";
+    $msg = "Fake $msg" unless $write;
+    $logger->info($msg);
+    for my $event (@events) {
+      my @from = @{$event->{from}};
+      my @to = @{$event->{to}};
+
+      if ($event_name eq 'new') {
+        insert_event($dbc, $write, [$mapping_id, $feat, undef, undef, $to[0], 1]);
+      }
+      elsif ($event_name eq 'deleted') {
+        my $id = $from[0];
+        my $version = $data->{$id}->{version} // 1;
+        insert_event($dbc, $write, [$mapping_id, $feat, $id, $version, undef, undef]);
+      }
+      elsif ($event_name eq 'change') {
+        my $id = $from[0];
+        my $old_version = $data->{$id}->{version} // 1;
+        my $new_version = $old_version + 1;
+        insert_event($dbc, $write, [$mapping_id, $feat, $id, $old_version, $id, $new_version]);
+      }
+      elsif ($event_name eq 'split' or $event_name eq 'merge' or $event_name eq 'multi') {
+        for my $merge_id (@from) {
+          my $old_version = $data->{$merge_id}->{version} // 1;
+          for my $split_id (@to) {
+            insert_event($dbc, $write, [$mapping_id, $feat, $merge_id, $old_version, $split_id, 1]);
+          }
+          insert_event($dbc, $write, [$mapping_id, $feat, $merge_id, $old_version, undef, undef]);
+        }
+      } else {
+        $logger->warn("Unsupported event: $event_name");
+      }
+    }
+  }
+}
+
+sub insert_event {
+  my ($dbc, $write, $values) = @_;
+  my $sql = "INSERT INTO stable_id_event(mapping_session_id, type, old_stable_id, old_version, new_stable_id, new_version) VALUES(?,?,?,?,?,?)";
+  my $sth = $dbc->prepare($sql);
+  my $msg = "Insert values: " . join(", ", map { $_ // 'undef' } @$values);
+  if ($write) {
+    $logger->debug($msg);
+    $sth->execute(@$values);
+  } else {
+    $logger->debug("Fake $msg");
+  }
+}
+
+sub get_meta {
+  my ($ma) = @_;
+
+  # Get production name
+  my $prod_name = get_meta_value($ma, 'species.production_name');
+
+  # Get db name
+  my $db_name = $ma->dbc->dbname;
+
+  # Get db release
+  my $release = 0;
+  if ($db_name =~ /_core_(\d+)_\d+_\d+$/) {
+    $release = $1;
+  } else {
+    die("Can't get release from db name: $db_name");
+  }
+
+  # Remove prefix if any
+  if ($db_name =~ /^.+_(${prod_name}.+$)/) {
+    $db_name = $1;
+  }
+
+  # Get db assembly
+  my $assembly = get_meta_value($ma, 'genebuild.version');
+
+  my %meta = (
+    db_name => $db_name,
+    assembly => $assembly,
+    release => $release
+  );
+
+  return \%meta;  
+}
+
+sub get_meta_value {
+  my ($ma, $key) = @_;
+
+  my ($value) = @{ $ma->list_value_by_key($key) };
+
+  return $value;
+}
+
+sub add_mapping_session {
+  my ($dbc, $meta, $write) = @_;
+
+  my $mapping_id = 1;
+  if ($write) {
+    $logger->info("Storing new mapping session...");
+    my @fields = qw(old_db_name new_db_name old_release new_release old_assembly new_assembly);
+    my $sql = "INSERT INTO mapping_session(".join(", ", @fields).", created) VALUES(?,?,?,?,?,?,NOW())";
+    my $sth = $dbc->prepare($sql);
+    my @values = map { $meta->{$_} } @fields;
+    $sth->execute(@values);
+    my $dbh = $dbc->db_handle();
+    $mapping_id = $dbh->last_insert_id;
+  } else {
+    $logger->info("Fake storing new mapping session (set to 1).");
+    use Data::Dumper;
+    $logger->debug(Dumper($meta));
+  }
+
+  return $mapping_id;
+}
+
+###############################################################################
+# Parameters and usage
+sub usage {
+  my $error = shift;
+  my $help = '';
+  if ($error) {
+    $help = "[ $error ]\n";
+  }
+  $help .= <<'EOF';
+    Transfer the gene versions and descriptions to a patched database
+
+    --old_registry <path> : Ensembl registry
+    --new_registry <path> : Ensembl registry
+    --species <str>   : production_name of one species
+
+    You can do 2 things:
+    - Update the history
+    - Transfer the descriptions and version
+    (you can do both at the same time)
+
+    History (use both events and deletes at the same time to make them part of the same session):
+    --events <path>   : Path to an events file, to update the history and versions
+    --deletes <path>  : Path to a list of deleted genes (to use with the events file)
+
+    NB: only run the history update once (otherwise you will have duplicates).
+    
+    Transfer:
+    --descriptions : Transfer the gene descriptions
+    --versions     : Transfer and increment the gene versions, and init the others
+    --xrefs        : Transfer the xrefs associated with genes
+    
+    Use this to make actual changes:
+    --write           : Do the actual changes (default is no changes to the database)
+    
+    --help            : show this help message
+    --verbose         : show detailed progress
+    --debug           : show even more information (for debugging purposes)
+EOF
+  print STDERR "$help\n";
+  exit(1);
+}
+
+sub opt_check {
+  my %opt = ();
+  GetOptions(\%opt,
+    "old_registry=s",
+    "new_registry=s",
+    "species=s",
+    "descriptions",
+    "versions",
+    "xrefs",
+    "events=s",
+    "deletes=s",
+    "write",
+    "help",
+    "verbose",
+    "debug",
+  );
+
+  usage("Old registry needed") if not $opt{old_registry};
+  usage("New registry needed") if not $opt{new_registry};
+  usage("Species needed") if not $opt{species};
+
+  usage()                if $opt{help};
+  Log::Log4perl->easy_init($INFO) if $opt{verbose};
+  Log::Log4perl->easy_init($DEBUG) if $opt{debug};
+  return \%opt;
+}
+
+__END__
+

--- a/scripts/brc4/patch_build/transfer_metadata.pl
+++ b/scripts/brc4/patch_build/transfer_metadata.pl
@@ -258,9 +258,17 @@ sub update_xrefs {
         $update_count++;
         if ($update) {
           # Ensure we use an up to date analysis
-          my $analysis_name = $xref->analysis->logic_name;
-          my $analysis = $aa->fetch_by_logic_name($analysis_name);
-          $xref->analysis($analysis);
+          my $analysis = $xref->analysis;
+
+          # No analysis attached? Give it a default one...
+          if (not $analysis) {
+            $logger->debug("No analysis for $analysis_name");
+          } else {
+            # Reload the analysis from this db
+            my $analysis_name = $analysis->logic_name;
+            $analysis = $aa->fetch_by_logic_name($analysis_name);
+            $xref->analysis($analysis);
+          }
           $xa->store($xref, $feat->dbID, $feature, 1); # ignore release
           $total_transfer++;
         }

--- a/src/python/ensembl/io/genomio/events/format_events.py
+++ b/src/python/ensembl/io/genomio/events/format_events.py
@@ -45,7 +45,10 @@ class IdsMapper:
             for line in map_fh:
                 if line == "":
                     continue
-                (from_id, to_id) = line.split("\t")[0:2]
+                items = line.split("\t")
+                if len(items) < 2:
+                    raise ValueError(f"Not 2 elements in {line}")
+                (from_id, to_id) = items[0:2]
                 mapping[from_id] = to_id
 
         return mapping

--- a/src/python/ensembl/io/genomio/events_loader.py
+++ b/src/python/ensembl/io/genomio/events_loader.py
@@ -46,6 +46,11 @@ class IdEvent:
     def __str__(self) -> str:
         fields = [self.from_id, self.to_id, self.event, self.release, self.release_date]
         return "\t".join(fields)
+    
+    def is_change(self) -> bool:
+        """If the event is an update of an existing gene."""
+        changed_events = ("iso_gain", "iso_loss", "broken", "changed")
+        return self.event in changed_events
 
 
 class MapSession:
@@ -100,7 +105,6 @@ class EventCollection:
         self, input_file: PathLike, release_name: str = "release_name", release_date: str = "release_date"
     ):
         """Load events from input file from gene_diff."""
-        event_name = "event"
         loaded_event = set()
 
         with Path(input_file).open("r") as events_fh:
@@ -109,7 +113,9 @@ class EventCollection:
                     continue
                 (_, event_string, _) = line.split("\t")
                 for pair in self._parse_gene_diff_event(event_string):
-                    (from_id, to_id) = pair
+                    (from_id, to_id, event_name) = pair
+                    if event_name == "identical":
+                        continue
                     fingerprint = f"{from_id} {to_id}"
                     if fingerprint in loaded_event:
                         print(f"Duplicated event, skipped: {fingerprint}")
@@ -124,21 +130,31 @@ class EventCollection:
                     )
                     self.events.append(event)
 
-    def _parse_gene_diff_event(self, event_string: str) -> Generator[Tuple[str, str], None, None]:
+    def _parse_gene_diff_event(self, event_string: str) -> Generator[Tuple[str, str, str], None, None]:
         """Gets all the pairs of IDs from an event string from gene diff."""
-        splitter = re.compile(r"(~|\+|=\+|=-|=!|=|>|<)")
+        event_symbol = {
+            "~": "identical",
+            "=+": "iso_gain",
+            "=-": "iso_loss",
+            "=!": "broken",
+            "=": "changed",
+            ">": "merge",
+            "<": "split",
+            "+": "new",
+        }
+        event_sep = r"|".join([symbol.replace(r"+", r"\+") for symbol in event_symbol]);
+        splitter = f"({event_sep})"
         parts = re.split(splitter, event_string)
         if len(parts) != 3:
+            print(f"Wrong partition: from '{event_string}' to '{parts}'")
             return
         [from_ids, sep, to_ids] = parts
+        event_name = event_symbol[sep]
 
         # Identical gene: no need to keep in the history
-        if sep == "~":
-            return
-
         for from_id in from_ids.split(":"):
             for to_id in to_ids.split(":"):
-                yield (from_id, to_id)
+                yield (from_id, to_id, event_name)
 
     def remap_to_ids(self, map_dict: Dict[str, str]):
         """Using a mapping dict, remap the to_id of all events."""
@@ -147,7 +163,9 @@ class EventCollection:
         for event in self.events:
             if not event.to_id:
                 continue
-            if event.to_id in map_dict:
+            elif event.is_change():
+                event.to_id = event.from_id
+            elif event.to_id in map_dict:
                 event.to_id = map_dict[event.to_id]
             else:
                 print(f"No map for to_id {event.to_id}")

--- a/src/python/ensembl/io/genomio/events_loader.py
+++ b/src/python/ensembl/io/genomio/events_loader.py
@@ -205,10 +205,16 @@ class EventCollection:
                 session.flush()
                 session.refresh(map_session)
                 for event in mapping.events:
+                    from_id = event.from_id
+                    if from_id == "":
+                        from_id = None
+                    to_id = event.to_id
+                    if to_id == "":
+                        to_id = None
                     id_event = StableIdEvent(
                         mapping_session_id=map_session.mapping_session_id,
-                        old_stable_id=event.from_id,
-                        new_stable_id=event.to_id,
+                        old_stable_id=from_id,
+                        new_stable_id=to_id,
                         id_type="gene",
                         old_version=1,
                         new_version=1,

--- a/src/python/ensembl/io/genomio/events_loader.py
+++ b/src/python/ensembl/io/genomio/events_loader.py
@@ -23,7 +23,7 @@ from dataclasses import dataclass
 from os import PathLike
 from pathlib import Path
 import re
-from typing import Dict, Generator, List, Tuple
+from typing import Dict, Generator, List, Optional, Tuple
 
 import argschema
 from sqlalchemy.engine import URL
@@ -46,7 +46,7 @@ class IdEvent:
     def __str__(self) -> str:
         fields = [self.from_id, self.to_id, self.event, self.release, self.release_date]
         return "\t".join(fields)
-    
+
     def is_change(self) -> bool:
         """If the event is an update of an existing gene."""
         changed_events = ("iso_gain", "iso_loss", "broken", "changed")
@@ -142,7 +142,7 @@ class EventCollection:
             "<": "split",
             "+": "new",
         }
-        event_sep = r"|".join([symbol.replace(r"+", r"\+") for symbol in event_symbol]);
+        event_sep = r"|".join([symbol.replace(r"+", r"\+") for symbol in event_symbol])
         splitter = f"({event_sep})"
         parts = re.split(splitter, event_string)
         if len(parts) != 3:
@@ -163,7 +163,7 @@ class EventCollection:
         for event in self.events:
             if not event.to_id:
                 continue
-            elif event.is_change():
+            if event.is_change():
                 event.to_id = event.from_id
             elif event.to_id in map_dict:
                 event.to_id = map_dict[event.to_id]
@@ -205,10 +205,10 @@ class EventCollection:
                 session.flush()
                 session.refresh(map_session)
                 for event in mapping.events:
-                    from_id = event.from_id
+                    from_id: Optional[str] = event.from_id
                     if from_id == "":
                         from_id = None
-                    to_id = event.to_id
+                    to_id: Optional[str] = event.to_id
                     if to_id == "":
                         to_id = None
                     id_event = StableIdEvent(


### PR DESCRIPTION
A whole new pipeline, but limited in scope: it's only to be used to update a core database after a patch build from VEuPathDB using the gene_diff script. It is using some older perl scripts, and some updated.

The pipeline goal is to do the following:
- Replace the stable ids by the old ones if the genes have been updated. Do the same for transcripts/translations if an updated gene still has some of the older transcripts.
- Transfer metadata from the previous database for those genes that have been updated, namely:
    - Description
    - Xrefs (excluding those from xref pipeline and protein features)
    - Version (incremented)
- Allocate stable ids to new genes and new transcripts using the OSID service.
- Load the events in the mapping_session and stable_id_event table (using the allocated IDs).
- Create standard exon stable ids and set the version for all features.
