### PR TITLE
Added CI/CD flat file tests

### DIFF
--- a/cicd/gitlab/dot.gitlab-ci.yml
+++ b/cicd/gitlab/dot.gitlab-ci.yml
@@ -37,6 +37,8 @@ include:
   - local: cicd/gitlab/parts/python.gitlab-ci.yml
   # License checks
   - local: cicd/gitlab/parts/license.gitlab-ci.yml
+  # Flat file checks
+  - local: cicd/gitlab/parts/flatfile.gitlab-ci.yml
 
 
 # External pipelines

--- a/cicd/gitlab/parts/flatfile.gitlab-ci.yml
+++ b/cicd/gitlab/parts/flatfile.gitlab-ci.yml
@@ -1,0 +1,63 @@
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# License-related part of the Ensembl/ensembl-genomio CI/CD pipeline
+
+# A generic job to be used by all License jobs with the "extends" mechanism
+# (https://docs.gitlab.com/ee/ci/yaml/#extends)
+.flatfile:
+  stage: test
+  image: python:3.11
+  variables:
+    CMD: python cicd/scripts/check_flatfile.py
+
+flatfile:prepare_venv:
+  extends: .flatfile
+  artifacts:
+    paths:
+      - $RUN_DIR
+  before_script:
+    - python --version  # for debugging
+    - python -m venv $RUN_DIR/venv
+    - source $RUN_DIR/venv/bin/activate
+  script:
+    - pip install pyyaml
+
+.flatfile:test:
+  extends: .flatfile
+  needs:
+    # Using `needs` as it allows to depend on jobs from the same stage
+    # (https://docs.gitlab.com/ee/ci/yaml/#needs)
+    - job: flatfile:prepare_venv
+      artifacts: true
+  before_script:
+    - source $RUN_DIR/venv/bin/activate
+
+
+flatfile:json:
+  extends: .flatfile:test
+  script:
+    - $CMD json
+  only:
+    changes:
+      - "*.json"
+
+flatfile:yaml:
+  extends: .flatfile:test
+  script:
+    - $CMD yaml
+  only:
+    changes:
+      - "*.yml"
+      - "*.yaml"

--- a/cicd/gitlab/parts/flatfile.gitlab-ci.yml
+++ b/cicd/gitlab/parts/flatfile.gitlab-ci.yml
@@ -51,7 +51,7 @@ flatfile:json:
     - $CMD json
   only:
     changes:
-      - "*.json"
+      - "**/*.json"
 
 flatfile:yaml:
   extends: .flatfile:test
@@ -59,5 +59,5 @@ flatfile:yaml:
     - $CMD yaml
   only:
     changes:
-      - "*.yml"
-      - "*.yaml"
+      - "**/*.yml"
+      - "**/*.yaml"

--- a/cicd/scripts/check_flatfile.py
+++ b/cicd/scripts/check_flatfile.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Checks if every flat file of a given format in the repository is valid."""
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+import yaml
+
+
+# Do not show traceback for an easier error readability
+sys.tracebacklimit = 0
+
+
+_ROOT_PATH = Path(__file__).absolute().parents[2]
+_FORMAT_CONFIG = {
+    "json": {
+        "function": json.load,
+        "kwargs": {},
+        "exception": json.JSONDecodeError,
+        "extensions": set(["json"]),
+    },
+    "yaml": {
+        "function": yaml.load,
+        "kwargs": {
+            "Loader": yaml.Loader,
+        },
+        "exception": yaml.YAMLError,
+        "extensions": set(["yml", "yaml"]),
+    },
+}
+
+
+# Add GitLab's "!reference" tag to yaml.Loader class
+class _ReferenceTag(yaml.YAMLObject):
+    yaml_tag = "!reference"
+
+    def __init__(self, ref_var):
+        self.ref_var = ref_var
+
+    @classmethod
+    def from_yaml(cls, loader, node):
+        return _ReferenceTag(node.value)
+
+
+yaml.Loader.add_constructor("!reference", _ReferenceTag.from_yaml)
+
+
+def check_flatfile(file_format: str) -> None:
+    """Checks if every flat file in the repository for the given format is valid.
+
+    Args:
+        file_format: Flat file format to validate.
+
+    Raises:
+        RuntimeError: If at least one file is not valid.
+
+    """
+    config = _FORMAT_CONFIG[file_format]
+    file_extensions = config["extensions"]
+    report_files = []
+    for file_path in _ROOT_PATH.rglob("*.*"):
+        if file_path.is_file() and (file_path.suffix[1:] in file_extensions):
+            with file_path.open() as fp:
+                try:
+                    config["function"](fp, **config["kwargs"])
+                except config["exception"] as exc:
+                    print(exc, file=sys.stderr)
+                    report_files.append(str(file_path))
+    if report_files:
+        report = "\n".join(report_files)
+        raise RuntimeError(f"{len(report_files)} flat files are not well formatted\n\n{report}")
+    else:
+        print(f"Every {file_format.upper()} file in the repository is well formatted")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Validates all the repository flat files for the selected format."
+    )
+    parser.add_argument("file_format", choices=_FORMAT_CONFIG.keys(), help="Flat file format to validate")
+    args = parser.parse_args()
+    check_flatfile(args.file_format)

--- a/pipelines/nextflow/subworkflows/patch_build_post_process/meta.yml
+++ b/pipelines/nextflow/subworkflows/patch_build_post_process/meta.yml
@@ -67,6 +67,5 @@ input:
         date
 output:
   - logs:
-    type: files
-    description: |
-    Output files of interest (mapping used, logs).
+      type: files
+      description: Output files of interest (mapping used, logs).


### PR DESCRIPTION
For now I have only included JSON and YAML, but I have tried to design the script to be expanded to other formats as we see fit.

_Note:_ I have expanded the accepted YAML format to ensure it does not complain to the current GitLab tags we are using in our CI/CD pipelines. More might need to be added in the future.