### PR TITLE
Add Perl to our CI/CD

### DIFF
--- a/cicd/gitlab/dot.gitlab-ci.yml
+++ b/cicd/gitlab/dot.gitlab-ci.yml
@@ -33,6 +33,8 @@ variables:
 include:
   # CI/CD debugging
   - local: cicd/gitlab/parts/debug.gitlab-ci.yml
+  # Perl checks
+  - local: cicd/gitlab/parts/perl.gitlab-ci.yml
   # Python checks
   - local: cicd/gitlab/parts/python.gitlab-ci.yml
   # License checks

--- a/cicd/gitlab/parts/perl.gitlab-ci.yml
+++ b/cicd/gitlab/parts/perl.gitlab-ci.yml
@@ -1,0 +1,37 @@
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Perl related part of the Ensembl/ensembl-genomio CI/CD pipeline
+
+# Test stage instances
+
+# A generic job to be used by all Perl jobs with the "extends" mechanism
+# (https://docs.gitlab.com/ee/ci/yaml/#extends)
+.perl:
+  stage: test
+  image: perl:5.26
+  only:
+    changes:
+      - cicd/gitlab/parts/perl.gitlab-ci.yml
+      - scripts/**/*.pl
+      - src/perl/**/*.pm
+
+## Static analyses
+
+perl:critic:
+  extends: .perl
+  before_script:
+    - cpan -T -i Perl::Critic
+  script:
+    - perlcritic scripts src/perl

--- a/scripts/load_fann.pl
+++ b/scripts/load_fann.pl
@@ -430,8 +430,8 @@ sub db_name_for_feature {
   # check if there's a specific ignore rule
   if ($ignore_feature) {
     my $pat = $ignore_feature->{pat};
-    return undef if (!defined $pat);
-    return undef if ($xref_id =~ m/$pat/);
+    return if (!defined $pat);
+    return if ($xref_id =~ m/$pat/);
   }
 
   # check if there's a specific valid rule
@@ -442,10 +442,10 @@ sub db_name_for_feature {
   }
 
   # check if mentioned anywhere else and no global validness; no pattern checked
-  return undef if ($valid_other and !$valid_any);
+  return if ($valid_other and !$valid_any);
 
   # check global ignore
-  return undef if ($ignore_any);
+  return if ($ignore_any);
   # then check global validness
   return $valid_any->{val} if ($valid_any);
 

--- a/src/perl/Bio/EnsEMBL/Pipeline/Runnable/BRC4/DumpSeqRegionJson.pm
+++ b/src/perl/Bio/EnsEMBL/Pipeline/Runnable/BRC4/DumpSeqRegionJson.pm
@@ -209,10 +209,10 @@ sub load_external_db_map {
 sub get_attribute_single_val {
   my ($self, $obj, $name) = @_;
 
-  return undef if (!$obj);
+  return if (!$obj);
 
   my ($attr) = @{ $obj->get_all_Attributes($name) };
-  return undef if (!$attr);
+  return if (!$attr);
 
   return $attr->value();
 }
@@ -247,7 +247,7 @@ sub get_added_sequence {
   my ($self, $slice) = @_;
 
   my $added_seq_accession = $self->get_attribute_single_val($slice, 'added_seq_accession');
-  return undef if (!$added_seq_accession);
+  return if (!$added_seq_accession);
 
   my $added_sequence = {
     accession => $added_seq_accession,
@@ -263,7 +263,7 @@ sub get_added_sequence {
   $self->update_from_attribute_single_val($slice, 'added_seq_ann_pr_url', $added_sequence, 'annotation_provider/url');
 
   # panic perhaps?
-  return undef if (!exists $added_sequence->{assembly_provider}->{name});
+  return if (!exists $added_sequence->{assembly_provider}->{name});
 
   return $added_sequence;
 }

--- a/src/perl/Bio/EnsEMBL/Pipeline/Runnable/EG/LoadGFF3/AnalysisSetup.pm
+++ b/src/perl/Bio/EnsEMBL/Pipeline/Runnable/EG/LoadGFF3/AnalysisSetup.pm
@@ -179,7 +179,7 @@ sub production_updates {
   ));
   $sth->fetch();
   
-  $properties{'web_data'} = eval ($properties{'web_data'}) if defined $properties{'web_data'};
+  $properties{'web_data'} = eval ({$properties{'web_data'}}) if defined $properties{'web_data'};
   
   # Explicitly passed parameters do not get overwritten.
   foreach my $property (keys %properties) {

--- a/src/perl/Bio/EnsEMBL/Pipeline/Runnable/EG/LoadGFF3/AnalysisSetup.pm
+++ b/src/perl/Bio/EnsEMBL/Pipeline/Runnable/EG/LoadGFF3/AnalysisSetup.pm
@@ -179,7 +179,7 @@ sub production_updates {
   ));
   $sth->fetch();
   
-  $properties{'web_data'} = eval {print $properties{'web_data'}} if defined $properties{'web_data'};
+  $properties{'web_data'} = eval { $properties{'web_data'} } if defined $properties{'web_data'};
   
   # Explicitly passed parameters do not get overwritten.
   foreach my $property (keys %properties) {

--- a/src/perl/Bio/EnsEMBL/Pipeline/Runnable/EG/LoadGFF3/AnalysisSetup.pm
+++ b/src/perl/Bio/EnsEMBL/Pipeline/Runnable/EG/LoadGFF3/AnalysisSetup.pm
@@ -179,7 +179,7 @@ sub production_updates {
   ));
   $sth->fetch();
   
-  $properties{'web_data'} = eval ({$properties{'web_data'}}) if defined $properties{'web_data'};
+  $properties{'web_data'} = eval {print $properties{'web_data'}} if defined $properties{'web_data'};
   
   # Explicitly passed parameters do not get overwritten.
   foreach my $property (keys %properties) {

--- a/src/perl/Bio/EnsEMBL/Pipeline/Runnable/EG/LoadGFF3/Base.pm
+++ b/src/perl/Bio/EnsEMBL/Pipeline/Runnable/EG/LoadGFF3/Base.pm
@@ -95,10 +95,10 @@ sub load_fasta {
   my ($self, $fasta_file) = @_;
   my %fasta;
   
-  open(FASTA, $fasta_file);
+  open(my $fasta_fh, '<', $fasta_file);
   
   my $id;
-  while (my $row = <FASTA>) {
+  while (my $row = <$fasta_fh>) {
     if ($row =~ /^>(\S+)/) {
       $id = $1;
     } else {
@@ -107,7 +107,7 @@ sub load_fasta {
     }
   }
   
-  close(FASTA);
+  close($fasta_fh);
   
   return %fasta;
 }


### PR DESCRIPTION
Although temporary, I believe it is still important to have `perlcritic` running as part of our CI/CD for the time being, since there is still debugging/small dev happening.

After running `perlcritic` I have tried to address all the issues raised. I believe none should produce a different outcome with the exception of the `eval` line change in `src/perl/Bio/EnsEMBL/Pipeline/Runnable/EG/LoadGFF3/AddSynonyms.pm`, since I'm not sure where the `{}` should be introduced (). Exact message error:
```
[BuiltinFunctions::ProhibitStringyEval] Expression form of "eval" at line 182, column 29.  (Severity: 5)
```
And its extended version:
```
The string form of `eval' is recompiled every time it is executed,
whereas the block form is only compiled once. Also, the string form
doesn't give compile-time warnings.

    eval "print $foo";        # not ok
    eval {print $foo};        # ok
```