### PR TITLE
Include transcript ids to allocate

### DIFF
--- a/pipelines/nextflow/subworkflows/patch_build_post_process/main.nf
+++ b/pipelines/nextflow/subworkflows/patch_build_post_process/main.nf
@@ -74,6 +74,7 @@ workflow PATCH_BUILD_PROCESS {
         logs = changed_genes
             .concat(new_genes)
             .concat(new_genes_map)
+            .concat(new_transcripts_map)
             .concat(new_transcripts)
             .concat(events_file)
             .concat(transfer_log)


### PR DESCRIPTION
Include a useful intermediate file, containing the IDs of the new transcripts for genes where the stable ID is conserved.