### PR TITLE
Adjust GitLab CI/CD based on documentation

### DIFF
--- a/cicd/gitlab/parts/python.gitlab-ci.yml
+++ b/cicd/gitlab/parts/python.gitlab-ci.yml
@@ -21,10 +21,10 @@
 .python:
   stage: test
   image: python:3.8
-  only:
-    changes:
+  rules:
+    - changes:
       - cicd/gitlab/parts/python.gitlab-ci.yml
-      - pyproject.toml
+      - "pyproject.toml"
       - "*.py"
       - src/python/**/*.py
 


### PR DESCRIPTION
The file changes suggests to not use `only` anymore as it is not under active development, and use `rules` instead. Furthermore, I've seen a few examples where root files are surrounded by `"`, so I've done so for `pyproject.toml`, just in case.