### PR TITLE
argparser equivalent to current argschema

### DIFF
--- a/src/python/ensembl/io/genomio/fastaprep/process_fasta.py
+++ b/src/python/ensembl/io/genomio/fastaprep/process_fasta.py
@@ -15,11 +15,10 @@
 # limitations under the License.
 """Takes a FASTA file (DNA or peptide), cleans it up and optionally excludes some IDs."""
 
+import argparse
 from pathlib import Path
 from os import PathLike
 from typing import List, Optional, Set
-
-import argschema
 
 from Bio import SeqIO
 
@@ -53,22 +52,22 @@ def get_peptides_to_exclude(genbank_path: PathLike, seqr_to_exclude: Set[str]) -
 
 def prep_fasta_data(
     fasta_infile: PathLike,
-    genebank_infile: PathLike,
     fasta_outfile: PathLike,
-    peptide_mode: Optional[int] = 0,
+    peptide_mode: bool = False,
+    genbank_infile: Optional[PathLike] = None,
 ) -> None:
     """
     Args:
         fasta_file: Input fasta file - DNA / Protein
-        genbank_infile: Input genBank GBFF file (Optional)
         output_dir: Output folder for the fasta sequence file.
-        peptide_mode: Process proteins not DNA (Optional)
+        peptide_mode: Process proteins not DNA
+        genbank_infile: Input GenBank GBFF file
     """
     file_path = Path(fasta_infile)
 
     seqr_to_exclude = set(exclude_seq_regions)
     if peptide_mode:
-        genbank_path = Path(genebank_infile)
+        genbank_path = Path(genbank_infile)
         to_exclude = get_peptides_to_exclude(genbank_path, seqr_to_exclude)
     else:
         to_exclude = seqr_to_exclude
@@ -77,43 +76,34 @@ def prep_fasta_data(
     records = []
 
     # Final path
-    with open_gz_file(file_path) as in_fasta:
-        for record in SeqIO.parse(in_fasta, "fasta"):
-            if record.id in to_exclude:
-                print(f"Skip record ${record.id}")
-            else:
-                records.append(record)
+    try:
+        with open_gz_file(file_path) as in_fasta:
+            for record in SeqIO.parse(in_fasta, "fasta"):
+                if record.id in to_exclude:
+                    print(f"Skip record ${record.id}")
+                else:
+                    records.append(record)
+    except FileNotFoundError:
+        raise FileNotFoundError(f"{file_path} does not exist")
+
     with Path(fasta_outfile).open("w") as out_fasta:
         SeqIO.write(records, out_fasta, "fasta")
 
 
-class InputSchema(argschema.ArgSchema):
-    """Input arguments expected by the entry point of this module."""
-
-    fasta_infile = argschema.fields.InputFile(
-        required=True,
-        metadata={"description": "Input fasta file - DNA / Protein"},
-    )
-    genbank_infile = argschema.fields.InputFile(
-        required=False,
-        metadata={"description": "Input genbank GBFF file (Optional)"},
-    )
-    fasta_outfile = argschema.fields.OutputFile(
-        required=True,
-        metadata={"description": "Output fasta file path"},
-    )
-    peptide_mode = argschema.fields.Int(
-        required=False,
-        metadata={"description": "Process proteins not DNA (Optional)"},
-    )
-
-
 def main() -> None:
     """Module's entry-point."""
-    mod = argschema.ArgSchemaParser(schema_type=InputSchema)
-    prep_fasta_data(
-        fasta_infile=mod.args["fasta_infile"],
-        genebank_infile=mod.args["genbank_infile"],
-        fasta_outfile=mod.args["fasta_outfile"],
-        peptide_mode=mod.args["peptide_mode"],
+    parser = argparse.ArgumentParser(
+        description=("Expand the genome metadata with information about the provider, assembly and gene"
+                     "build version, and taxonomy."),
     )
+    parser.add_argument("--fasta_infile", required=True, type=Path, help="Input FASTA file - DNA / Protein")
+    parser.add_argument("--genbank_infile", type=Path, help="Input GenBank GBFF file (Optional)")
+    parser.add_argument(
+        "--fasta_outfile", type=Path, default=Path("output.fasta"), help="Output FASTA file path"
+    )
+    parser.add_argument(
+        "--peptide_mode", type=bool, default=False, help="Process proteins not DNA (default: False)"
+    )
+    args = parser.parse_args()
+
+    prep_fasta_data(**vars(args))


### PR DESCRIPTION
This is an example of an `argparse` code equivalent to `argschema`, going to the extent of having the same input file check functionality and also making the type being `pathlib.Path` instead of string (which is not a bad additional feature).

Whilst a functionality to check (and if not create) output directories makes sense, that is not the case for input files/directories: the Python's mantra of "ask for forgiveness not for permission" states that you should assume the input parameters are correct and handle the exception "beautifully" if that is not the case. Thus, checking input files/directories exists in the parsing step may be a functionality we may not want to pursue anymore. The only part that we definitely need to sit down and evaluate is when we have taken advantage of `--output_json` from `argschema`.