### PR TITLE
Bugfixes and code updated on GenomIO utils

### DIFF
--- a/src/python/ensembl/io/genomio/utils/archive_utils.py
+++ b/src/python/ensembl/io/genomio/utils/archive_utils.py
@@ -61,6 +61,7 @@ def extract_file(src_file: PathLike, dst_dir: PathLike) -> None:
 
     """
     src_file = Path(src_file)
+    # Create a set of all the possible "right-side suffixes", e.g. from "myfile.tar.gz" you get {".tar.gz", ".gz"}
     extensions = {"".join(src_file.suffixes[i:]) for i in range(0, len(src_file.suffixes))}
     dst_dir = Path(dst_dir)
 

--- a/src/python/ensembl/io/genomio/utils/archive_utils.py
+++ b/src/python/ensembl/io/genomio/utils/archive_utils.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Utils to deal with archived files (gzip)."""
+"""Utils to deal with archive files."""
 
 __all__ = ["SUPPORTED_ARCHIVE_FORMATS", "extract_file"]
 
@@ -32,14 +32,13 @@ SUPPORTED_ARCHIVE_FORMATS = [ext for elem in shutil.get_unpack_formats() for ext
 
 @contextmanager
 def open_gz_file(file_path: PathLike) -> Generator[TextIO, None, None]:
-    """Open a file that is optionally compressed with gz.
+    """Yields an open file object, even if the file is compressed with gzip.
+
     The file is expected to contain a text, and this can be used with the usual "with".
 
     Args:
-        file_path (PathLike): A file path to open.
+        file_path: A file path to open.
 
-    Yields:
-        Generator[TextIO, None, None]: A generator for the file.
     """
     this_file = Path(file_path)
     if this_file.suffix == ".gz":
@@ -53,7 +52,8 @@ def open_gz_file(file_path: PathLike) -> Generator[TextIO, None, None]:
 def extract_file(src_file: PathLike, dst_dir: PathLike) -> None:
     """Extracts the `src_file` into `dst_dir`.
 
-    If the file is not an archive, it will only be copied to `dst_dir`.
+    If the file is not an archive, it will be copied to `dst_dir`. `dst_dir` will be created if it
+    does not exist.
 
     Args:
         src_file: Path to the file to unpack.

--- a/src/python/ensembl/io/genomio/utils/archive_utils.py
+++ b/src/python/ensembl/io/genomio/utils/archive_utils.py
@@ -61,7 +61,7 @@ def extract_file(src_file: PathLike, dst_dir: PathLike) -> None:
 
     """
     src_file = Path(src_file)
-    extensions = set(["".join(src_file.suffixes[i:]) for i in range(0, len(src_file.suffixes))])
+    extensions = {"".join(src_file.suffixes[i:]) for i in range(0, len(src_file.suffixes))}
     file_base = src_file.stem
     dst_dir = Path(dst_dir)
     final_path = dst_dir / file_base

--- a/src/python/ensembl/io/genomio/utils/archive_utils.py
+++ b/src/python/ensembl/io/genomio/utils/archive_utils.py
@@ -62,9 +62,7 @@ def extract_file(src_file: PathLike, dst_dir: PathLike) -> None:
     """
     src_file = Path(src_file)
     extensions = {"".join(src_file.suffixes[i:]) for i in range(0, len(src_file.suffixes))}
-    file_base = src_file.stem
     dst_dir = Path(dst_dir)
-    final_path = dst_dir / file_base
 
     if extensions.intersection(SUPPORTED_ARCHIVE_FORMATS):
         shutil.unpack_archive(src_file, dst_dir)
@@ -72,6 +70,7 @@ def extract_file(src_file: PathLike, dst_dir: PathLike) -> None:
         # Replicate the functionality of shutil.unpack_archive() by creating `dst_dir`
         dst_dir.mkdir(parents=True, exist_ok=True)
         if extensions.intersection([".gz"]):
+            final_path = dst_dir / src_file.stem
             with gzip.open(src_file, "rb") as f_in:
                 with final_path.open("wb") as f_out:
                     shutil.copyfileobj(f_in, f_out)

--- a/src/python/ensembl/io/genomio/utils/archive_utils.py
+++ b/src/python/ensembl/io/genomio/utils/archive_utils.py
@@ -26,6 +26,10 @@ from typing import Generator, TextIO
 import argschema
 
 
+# Each registered format is a tuple, `(name, extensions, description)`
+SUPPORTED_ARCHIVE_FORMATS = [ext for elem in shutil.get_unpack_formats() for ext in elem[1]]
+
+
 @contextmanager
 def open_gz_file(file_path: PathLike) -> Generator[TextIO, None, None]:
     """Open a file that is optionally compressed with gz.
@@ -44,10 +48,6 @@ def open_gz_file(file_path: PathLike) -> Generator[TextIO, None, None]:
     else:
         with this_file.open("rt") as fh:
             yield fh
-
-
-# Each registered format is a tuple, `(name, extensions, description)`
-SUPPORTED_ARCHIVE_FORMATS = [ext for elem in shutil.get_unpack_formats() for ext in elem[1]]
 
 
 def extract_file(src_file: PathLike, dst_dir: PathLike) -> None:

--- a/src/python/ensembl/io/genomio/utils/archive_utils.py
+++ b/src/python/ensembl/io/genomio/utils/archive_utils.py
@@ -61,7 +61,7 @@ def extract_file(src_file: PathLike, dst_dir: PathLike) -> None:
 
     """
     src_file = Path(src_file)
-    # Create a set of all the possible "right-side suffixes", e.g. from "myfile.tar.gz" you get {".tar.gz", ".gz"}
+    # Create a set of all the possible "right-side suffixes", e.g. "myfile.tar.gz" produces {".tar.gz", ".gz"}
     extensions = {"".join(src_file.suffixes[i:]) for i in range(0, len(src_file.suffixes))}
     dst_dir = Path(dst_dir)
 

--- a/src/python/ensembl/io/genomio/utils/json_utils.py
+++ b/src/python/ensembl/io/genomio/utils/json_utils.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""TODO"""
+"""Utils to deal with JSON files."""
 
 __all__ = ["get_json", "print_json"]
 
@@ -22,24 +22,24 @@ from pathlib import Path
 from typing import Any
 
 
-def get_json(json_path: PathLike) -> Any:
+def get_json(src_path: PathLike) -> Any:
     """Generic data JSON loader.
 
     Args:
-        path: Path to the JSON file to load.
+        src_path: Path to the JSON file to load.
 
     """
-    with Path(json_path).open("r") as json_file:
+    with Path(src_path).open("r") as json_file:
         return json.load(json_file)
 
 
-def print_json(json_path: PathLike, data: Any) -> None:
+def print_json(dst_path: PathLike, data: Any) -> None:
     """Generic data JSON dumper to a file.
 
     Args:
-        path: Path to the JSON to create.
+        dst_path: Path to the JSON to create.
         data: Any data to store into the file.
 
     """
-    with Path(json_path).open("w") as json_file:
+    with Path(dst_path).open("w") as json_file:
         json_file.write(json.dumps(data, sort_keys=True, indent=4))


### PR DESCRIPTION
- ".gz" can also be found in ".tar.gz" for instance, so the latter needs to be checked always first
- `Path.suffix` would only grab the last ".*", ignoring cases such as ".tar.gz"
- `shutil.unpack_archive()` creates the destination if it does not exist, so this behaviour has been replicated in the other cases for consistency