### PR TITLE
Addition of workflow config for sphinx doc generation

### DIFF
--- a/.github/workflows/sphinx_doc_generation.yaml
+++ b/.github/workflows/sphinx_doc_generation.yaml
@@ -1,0 +1,49 @@
+name: Documentation_deploy
+run-name: ${{ github.actor }} triggered doc generation
+on: 
+  pull_request:
+    branches:
+      - main
+      - '!jalvarez/**'
+      - '!mbarba/**'
+      - '!disha/**'
+      - '!vsitnik/**'
+      - '!lcampbell/**'
+    paths:
+      - 'src/python/'
+      - 'docs/'
+    page_build:
+permissions:
+    contents: write
+jobs:
+  Sphinx_Doc_generation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+          allow-prereleases: false
+          cache: 'pip'
+          cache-dependency-path: '**/pip'
+          run: echo '${{ steps.cp38.outputs.cache-hit }}'
+
+      - name: Install Dependencies
+        run: |
+          pip install -e .[doc]
+
+      - name: Sphinx Build
+        run: |
+          sh scripts/setup/docs/build_docs_gh-pages.sh
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        if: ${{ github.event_name == 'pull_request' && github.ref == 'refs/heads/main' }}
+        with:
+          publish_branch: gh-pages
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs/build/html
+          force_orphan: true

--- a/scripts/setup/docs/Makefile_ghpages
+++ b/scripts/setup/docs/Makefile_ghpages
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = docs/source
+BUILDDIR      = docs/build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%:
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/scripts/setup/docs/build_docs_gh-pages.sh
+++ b/scripts/setup/docs/build_docs_gh-pages.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+sphinx-apidoc -Mf --implicit-namespaces -o source ./src/python/ensembl
+
+SPHINX_MAKEFILE="./scripts/setup/docs/Makefile"
+make -f $SPHINX_MAKEFILE clean && make -f $SPHINX_MAKEFILE html text

--- a/scripts/setup/docs/build_docs_gh-pages.sh
+++ b/scripts/setup/docs/build_docs_gh-pages.sh
@@ -15,5 +15,5 @@
 
 sphinx-apidoc -Mf --implicit-namespaces -o source ./src/python/ensembl
 
-SPHINX_MAKEFILE="./scripts/setup/docs/Makefile"
+SPHINX_MAKEFILE="./scripts/setup/docs/Makefile_ghpages"
 make -f $SPHINX_MAKEFILE clean && make -f $SPHINX_MAKEFILE html text


### PR DESCRIPTION
Contents of PR:
- single YAML file to set up config of workflow. This workflow is restricted to trigger only when a PR is made to main. PR includes main as accepted branch, and excludes any branch linked to current Ensmetazoa team members. 
- Slight modification to sphinx build script (addition of new script called in context of workflow.)
- Workflow includes params set to reuse python installation deps with -cache to speed up re workflow after initial run. 