### PR TITLE
Change on event to push not PR

### DIFF
--- a/.github/workflows/sphinx_doc_generation.yaml
+++ b/.github/workflows/sphinx_doc_generation.yaml
@@ -1,7 +1,7 @@
 name: Documentation_deploy
 run-name: ${{ github.actor }} triggered doc generation
 on: 
-  pull_request:
+  push:
     branches:
       - main
       - '!jalvarez/**'


### PR DESCRIPTION
Single small change on workflow config to change:
Workflow Trigger event from pull_request to push. 

This was done as it wasn't clear wether simply opening a PR to main would trigger the workflow. Given a push is performed upon merging said PR, perhaps this is the activity we actually need. 
 