### PR TITLE
Fix to Sphinx build - Failing to find modules.rst 

### DIFF
--- a/.github/workflows/sphinx_doc_generation.yaml
+++ b/.github/workflows/sphinx_doc_generation.yaml
@@ -18,7 +18,7 @@ permissions:
     contents: write
 
 jobs:
-  if_merged:
+  Sphinx_Doc_generation:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -1,0 +1,7 @@
+ensembl
+=======
+
+.. toctree::
+   :maxdepth: 4
+
+   ensembl


### PR DESCRIPTION
I've noticed that for some reason, Im not sure why but sphinx build was not able to locate the modules.rst file upon building. Meaning a broken 404 link. I've manually added this file to docs/source to see if this fixes this issue. 

Also updated the docs yaml to update the job name banner. 