### PR TITLE
Make a explicit CI/CD tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Though, this bit is in constant development. Some documentatin can be found in [
 See [docs](docs)
 
 ## Unit testing
-The Python part of the codebase has now unit tests available to test each module. Make sure you have installed this repository's `[dev]` dependencies (via `pip install ensembl-genomio[dev]`) before continuing.
+The Python part of the codebase has now unit tests available to test each module. Make sure you have installed this repository's `[cicd]` dependencies (via `pip install ensembl-genomio[cicd]`) before continuing.
 
 Running all the tests in one go is as easy as running `pytest` **from the root of the repository**. If you also want to measure, collect and report the code coverage, you can do:
 ```bash

--- a/README.md
+++ b/README.md
@@ -43,16 +43,16 @@ If you need to install "editable" python package use '-e' option
 pip install -e ./ensembl-genomio
 ```
 
-To install additional dependencies (e.g. `[doc]` or `[dev]`) provide `[<tag>]` string. I.e.
+To install additional dependencies (e.g. `[doc]` or `[cicd]`) provide `[<tag>]` string. I.e.
 ```
-pip install -e ./ensembl-genomio[dev]
+pip install -e ./ensembl-genomio[doc]
 ```
 
 For the list of tags see `[project.optional-dependencies]` in [pyproject.toml](./pyproject.toml). 
 
 
 ### Additional steps to use automated generation of the documentation (part of it)
-Install python part with the `[doc]` or `[dev]` tag.
+Install python part with the `[doc]` tag.
 Change into repo dir
 Run doc build script.
 

--- a/cicd/gitlab/parts/python.gitlab-ci.yml
+++ b/cicd/gitlab/parts/python.gitlab-ci.yml
@@ -40,7 +40,7 @@ python:prepare_venv:
     - python -m venv $RUN_DIR/venv
     - source $RUN_DIR/venv/bin/activate
   script:
-    - pip install -e .[dev]
+    - pip install -e .[cicd]
 
 
 .python:test:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,17 +58,15 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = [
+cicd = [
     "black",
     "coverage",
     "ensembl-py @ git+https://github.com/Ensembl/ensembl-py.git",
     "genbadge[coverage]",
-    "mock",
     "mypy",
     "pylint",
     "pytest",
     "pytest-workflow",
-    "Sphinx",
     "types-requests",
 ]
 doc = [


### PR DESCRIPTION
This is the best course of action if we want to ensure only the bare minimum tools used in CI/CD are included (but no other libraries that may ease development work). If we want to support a `dev` tag as well that holds `cicd` and `doc` together without explicitly duplicating everything, the best option at the moment is to have a script that can automatically create a `requirements-dev.txt` file every time `pyproject.toml` is updated (so it can be installed with `pip install -r requirements-dev.txt`).

_Note 1:_ not sure if needed, not sure if useful, but worth flagging this up.
_Note 2:_ I have left `ensembl-py` where it is since this is being addressed in another PR.