### PR TITLE
Additional B67 updates

### DIFF
--- a/pipelines/nextflow/modules/files/publish_output.nf
+++ b/pipelines/nextflow/modules/files/publish_output.nf
@@ -14,9 +14,9 @@
 // limitations under the License.
 
 process PUBLISH_DIR {
-    publishDir "$out_dir/${meta.accession}", mode: 'copy', overwrite: false
-    tag "Publish_${meta.accession}"
+    tag "publish_${meta.accession}"
     label 'default'
+    publishDir "$out_dir/${meta.accession}", mode: 'copy', overwrite: false
     time '5min'
 
     input:

--- a/pipelines/nextflow/modules/genbank/extract_from_gb.nf
+++ b/pipelines/nextflow/modules/genbank/extract_from_gb.nf
@@ -21,10 +21,10 @@ process EXTRACT_FROM_GB {
         tuple val(meta), path(gb_file)
 
     output:
-        tuple val(meta), path("*.gff"), emit: gene_gff
-        tuple val(meta), path("genome.json"), emit: genome 
+        tuple val(meta), path("genome.json"), emit: genome
         tuple val(meta), path("seq_region.json"), emit: seq_regions
         tuple val(meta), path("dna.fasta"), emit: dna_fasta
+        tuple val(meta), path("*.gff"), emit: gene_gff, optional: true
         tuple val(meta), path("pep.fasta"), emit: pep_fasta, optional: true
 
     shell:

--- a/pipelines/nextflow/modules/gff3/gff3_validation.nf
+++ b/pipelines/nextflow/modules/gff3/gff3_validation.nf
@@ -30,7 +30,7 @@ process GFF3_VALIDATION {
   out_gff = "gene_models.gff3"
   '''
   cp !{gene_models} temp.gff3
-  gt gff3 -tidy -sort -retainids -force -o !{out_gff} temp.gff3 
+  gt gff3 -tidy -sort -retainids -force -o !{out_gff} temp.gff3
   gt gff3validator !{out_gff}
   '''
 }

--- a/pipelines/nextflow/subworkflows/additional_seq_prepare/main.nf
+++ b/pipelines/nextflow/subworkflows/additional_seq_prepare/main.nf
@@ -36,7 +36,12 @@ workflow additional_seq_prepare {
         gb_file = DOWNLOAD_GENBANK(meta)
 
         // Parse data from GB file into GFF3 and json files
-        (gff_genome, gb_genome, gb_seq_regions, gb_dna_fasta, gb_pep_fasta) = EXTRACT_FROM_GB(gb_file)
+        EXTRACT_FROM_GB(gb_file)
+        gb_genome = EXTRACT_FROM_GB.out.genome
+        gb_seq_regions = EXTRACT_FROM_GB.out.seq_regions
+        gb_dna_fasta = EXTRACT_FROM_GB.out.dna_fasta
+        gff_genome = EXTRACT_FROM_GB.out.gene_gff
+        gb_pep_fasta = EXTRACT_FROM_GB.out.pep_fasta
 
         // Process the GB and GFF3 files into a cleaned GFF3 and a functional_annotation files
         genome_gff_files = gb_genome.join(gff_genome)

--- a/pipelines/nextflow/workflows/additional_seq_prepare/main.nf
+++ b/pipelines/nextflow/workflows/additional_seq_prepare/main.nf
@@ -19,7 +19,7 @@ params.help = false
 // Mandatory params
 params.accession = null
 params.prefix = null
-params.PROD_NAME = null
+params.production_name = null
 
 // Print usage
 def helpMessage() {

--- a/pipelines/nextflow/workflows/additional_seq_prepare/main.nf
+++ b/pipelines/nextflow/workflows/additional_seq_prepare/main.nf
@@ -13,32 +13,33 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//default params
+// Default params
 params.help = false
 
-// mandatory params
+// Mandatory params
 params.accession = null
 params.prefix = null
 params.PROD_NAME = null
 
 // Print usage
 def helpMessage() {
-  log.info """
-        Usage:
-        The typical command for running the pipeline is as follows:
-        nextflow run add_seq_prepare.nf --accession "GENBANK_ACCESSION" --prefix "PREFIX_" --production_name "species_name"
+    log.info """
+Usage:
+  The typical command for running the pipeline is as follows:
+    nextflow run add_seq_prepare/main.nf --accession "GB_ACCESSION" \\
+      --prefix "PREFIX_" --production_name "SPECIES_PROD_NAME"
 
-        Mandatory arguments:
-        --accession                    A GenBank accession of the sequence you are adding
-        --prefix                       Required a string to add to the gene ids, to ensure that they are unique (include  PREFIX_)
-        --production_name              Production name of the species
+Mandatory arguments:
+  --accession        GenBank accession of the sequence you are adding
+  --prefix           String to prepend to the gene IDs to ensure that they are unique
+  --production_name  Production name of the species
 
-       Optional arguments:
-        --output_dir                   Output directory to place final output
-        --cache_dir                    Cache directory for downloaded files
-        --help                         This usage statement.
-        --brc_mode                     Set to 1 to use with BRC data (default: ${params.brc_mode})
-        """
+Optional arguments:
+  --help             Show this help message and exit
+  --output_dir       Output directory to place final formatted files
+  --cache_dir        Cache directory for downloaded files
+  --brc_mode         Set to 1 to use with BRC data (default: ${params.brc_mode})
+    """
 }
 
 // Show help message

--- a/src/perl/Bio/EnsEMBL/Pipeline/PipeConfig/BRC4_genome_loader_conf.pm
+++ b/src/perl/Bio/EnsEMBL/Pipeline/PipeConfig/BRC4_genome_loader_conf.pm
@@ -148,7 +148,7 @@ sub default_options {
     # if loaded from RefSeq(GCF) change seq_region names to GenBank(GCA)
     swap_gcf_gca => 0,
 
-    # defautl xref display_db
+    # default xref display_db
     xref_display_db_default => 'BRC4_Community_Annotation',
     xref_load_logic_name => 'brc4_import',
 
@@ -158,17 +158,17 @@ sub default_options {
     # run ProdDBsync parts before adding ad-hoc sequences (add_sequence  mode on)
     prod_db_sync_before_adding => 1,
 
-    # default resoutce class name for Manifest_integrity
+    # default resource class name for Manifest_integrity
     manifest_integrity_rc_name => '8GB',
 
     # default resource class for 'LoadSequenceData' and 'AddSequence' steps
     load_sequence_data_rc_name => '8GB',
 
-    # defaul resource class for LoadFunctionalAnnotation step
+    # default resource class for LoadFunctionalAnnotation step
     load_func_ann_rc_name => '8GB',
 
     # size of chunks to split contigs into (0 -- no splitting)
-    sequence_data_chunck => 0,
+    sequence_data_chunk => 0,
     # coord system name for chunks
     chunk_cs_name => 'ensembl_internal',
   };
@@ -234,7 +234,7 @@ sub pipeline_wide_parameters {
     load_sequence_data_rc_name => $self->o('load_sequence_data_rc_name'),
     load_func_ann_rc_name => $self->o('load_func_ann_rc_name'),
 
-    sequence_data_chunck => $self->o('sequence_data_chunck'),
+    sequence_data_chunk => $self->o('sequence_data_chunk'),
     chunk_cs_name        => $self->o('chunk_cs_name'),
   };
 }
@@ -462,7 +462,7 @@ sub pipeline_analyses {
         work_dir => $self->o('pipeline_dir') . '/#db_name#/add_sequence',
         load_additional_sequences => $self->o('add_sequence'),
         # N.B. chunking will work correctly only if it was used for initial loading
-        sequence_data_chunck => $self->o('sequence_data_chunck'),
+        sequence_data_chunk => $self->o('sequence_data_chunk'),
         chunk_cs_name        => $self->o('chunk_cs_name'),
       },
       -analysis_capacity   => 10,
@@ -542,7 +542,7 @@ sub pipeline_analyses {
         cs_tag_for_ordered => $self->o('cs_tag_for_ordered'),
         no_contig_ena_attrib => $self->o('no_contig_ena_attrib'),
         swap_gcf_gca => $self->o('swap_gcf_gca'),
-        sequence_data_chunck => $self->o('sequence_data_chunck'),
+        sequence_data_chunk => $self->o('sequence_data_chunk'),
         chunk_cs_name        => $self->o('chunk_cs_name'),
       },
       -analysis_capacity   => 10,

--- a/src/python/ensembl/io/genomio/genbank/extract_from_genbank.py
+++ b/src/python/ensembl/io/genomio/genbank/extract_from_genbank.py
@@ -169,17 +169,20 @@ class FormattedFilesGenerator:
 
         for record in self.seq_records:
             new_record, rec_ids, rec_peptides = self._parse_record(record)
-            records.append(new_record)
+            if new_record.features:
+                records.append(new_record)
             all_ids += rec_ids
             peptides += rec_peptides
 
-        # Write those records to a clean GFF
-        with self.files["gene_models"].open("w") as gff_fh:
-            GFF.write(records, gff_fh)
+        # Write the annotated records to a clean GFF
+        if records:
+            with self.files["gene_models"].open("w") as gff_fh:
+                GFF.write(records, gff_fh)
 
-        # Write the peptide sequences to a fasta file
-        with self.files["fasta_pep"].open("w") as fasta_fh:
-            SeqIO.write(peptides, fasta_fh, "fasta")
+        # Write the peptide sequences to a FASTA file
+        if peptides:
+            with self.files["fasta_pep"].open("w") as fasta_fh:
+                SeqIO.write(peptides, fasta_fh, "fasta")
 
         # Warn if some IDs are not unique
         count = dict(Counter(all_ids))


### PR DESCRIPTION
The main change is to avoid generating an empty GFF3 file early in the pipeline if there are no records to avoid `gt` to fail later on (cannot handle empty GFF3 files). I have opted for this approach because it makes more sense to not flow anything when there is nothing to process (saving compute) than handling empty files, i.e. it requires more manual intervention to asses if the GFF3 was supposed to be empty at that point.