### PR TITLE
Mbarba/genbank logging

### DIFF
--- a/pipelines/nextflow/modules/download/download_genbank.nf
+++ b/pipelines/nextflow/modules/download/download_genbank.nf
@@ -27,6 +27,6 @@ process DOWNLOAD_GENBANK {
     shell:
     output_file = "output.gb"
     '''
-    genbank_download --accession !{meta.accession} --output_file !{output_file}
+    genbank_download --accession !{meta.accession} --output_file !{output_file} -d
     '''
 }

--- a/pipelines/nextflow/modules/genbank/extract_from_gb.nf
+++ b/pipelines/nextflow/modules/genbank/extract_from_gb.nf
@@ -29,7 +29,6 @@ process EXTRACT_FROM_GB {
 
     shell:
     '''
-    genbank_extract_data --prefix !{meta.prefix} --prod_name !{meta.production_name} --gb_file !{gb_file}
+    genbank_extract_data --prefix !{meta.prefix} --prod_name !{meta.production_name} --gb_file !{gb_file} -d
     '''
 }
-

--- a/src/python/ensembl/io/genomio/genbank/download.py
+++ b/src/python/ensembl/io/genomio/genbank/download.py
@@ -73,13 +73,16 @@ def main() -> None:
     parser.add_argument("-d", "--debug", action="store_true", help="Debug level logging")
     args = parser.parse_args()
 
+    # Logging setup
+    log_level = None
+    if args.debug:
+        log_level = logging.DEBUG
+    elif args.verbose:
+        log_level = logging.INFO
     logging_format = "%(asctime)s\t%(levelname)s\t%(message)s"
     date_format = r"%Y-%m-%d_%H:%M:%S"
     reload(logging)
-    if args.verbose:
-        logging.basicConfig(format=logging_format, datefmt=date_format, level=logging.INFO)
-    if args.debug:
-        logging.basicConfig(format=logging_format, datefmt=date_format, level=logging.DEBUG)
+    logging.basicConfig(format=logging_format, datefmt=date_format, level=log_level)
 
     download_genbank(accession=args.accession, output_file=args.output_file)
 

--- a/src/python/ensembl/io/genomio/genbank/extract_data.py
+++ b/src/python/ensembl/io/genomio/genbank/extract_data.py
@@ -481,13 +481,16 @@ def main() -> None:
     parser.add_argument("-d", "--debug", action="store_true", help="Debug level logging")
     args = parser.parse_args()
 
+    # Logging setup
+    log_level = None
+    if args.debug:
+        log_level = logging.DEBUG
+    elif args.verbose:
+        log_level = logging.INFO
     logging_format = "%(asctime)s\t%(levelname)s\t%(message)s"
     date_format = r"%Y-%m-%d_%H:%M:%S"
     reload(logging)
-    if args.verbose:
-        logging.basicConfig(format=logging_format, datefmt=date_format, level=logging.INFO)
-    if args.debug:
-        logging.basicConfig(format=logging_format, datefmt=date_format, level=logging.DEBUG)
+    logging.basicConfig(format=logging_format, datefmt=date_format, level=log_level)
 
     gb_extractor = FormattedFilesGenerator(prefix=args.prefix, prod_name=args.prod_name, gb_file=args.gb_file)
     gb_extractor.extract_gb(args.out_dir)


### PR DESCRIPTION
Implement 2 levels of logging (verbose and debug) in both genbank files.

I've set the nextflow processes to use the debug option for now.

Example of the format I used for the logging messages:
`2023-11-09_11:52:00     DEBUG   Organella loaded: {'NC_035159.1': 'mitochondrion'}`