### PR TITLE
Fix to genome_stats compare + json utils

### DIFF
--- a/src/python/ensembl/io/genomio/genome_stats/compare.py
+++ b/src/python/ensembl/io/genomio/genome_stats/compare.py
@@ -191,15 +191,13 @@ def main() -> None:
     )
     parser.add_argument_src_path("--ncbi_stats", required=True, help="NCBI dataset JSON file")
     parser.add_argument_src_path("--core_stats", required=True, help="Core database JSON file")
-    parser.add_argument("-v", "--verbose", action="store_true", required=False,
-        help="Verbose level logging")
-    parser.add_argument("-d", "--debug", action="store_true", required=False,
-        help="Debug level logging")
+    parser.add_argument("-v", "--verbose", action="store_true", required=False, help="Verbose level logging")
+    parser.add_argument("-d", "--debug", action="store_true", required=False, help="Debug level logging")
     args = parser.parse_args()
 
     # Configure logging
-    date_format='%Y/%m/%d_%I:%M:%S(%p)'
-    logging_format='%(asctime)s - %(levelname)s - %(message)s'
+    date_format = "%Y/%m/%d_%I:%M:%S(%p)"
+    logging_format = "%(asctime)s - %(levelname)s - %(message)s"
     reload(logging)
     log_level = None
     if args.debug:
@@ -207,16 +205,13 @@ def main() -> None:
     elif args.verbose:
         log_level = logging.INFO
 
-    logging.basicConfig(
-        format=logging_format, datefmt=date_format,
-        filemode="w", level=log_level
-        )
+    logging.basicConfig(format=logging_format, datefmt=date_format, filemode="w", level=log_level)
 
     try:
         ncbi_stats = get_json(args.ncbi_stats)["reports"][0]
         logging.info(f"{args.ncbi_stats} JSON .'reports' obtained")
-    except KeyError:
-        logging.warning(f"{args.ncbi_stats} JSON is empty")
+    except (json.decoder.JSONDecodeError, KeyError):
+        logging.warning(f"{args.ncbi_stats} JSON file is empty")
         ncbi_stats = {}
     core_stats = get_json(args.core_stats)
     all_stats = compare_stats(ncbi_stats, core_stats)

--- a/src/python/ensembl/io/genomio/genome_stats/compare.py
+++ b/src/python/ensembl/io/genomio/genome_stats/compare.py
@@ -22,6 +22,8 @@ __all__ = ["compare_assembly", "compare_annotation", "compare_stats"]
 import json
 import re
 from typing import Any, Dict
+import logging
+from importlib import reload
 
 from ensembl.io.genomio.utils import get_json
 from ensembl.utils.argparse import ArgumentParser
@@ -189,11 +191,32 @@ def main() -> None:
     )
     parser.add_argument_src_path("--ncbi_stats", required=True, help="NCBI dataset JSON file")
     parser.add_argument_src_path("--core_stats", required=True, help="Core database JSON file")
+    parser.add_argument("-v", "--verbose", action="store_true", required=False,
+        help="Verbose level logging")
+    parser.add_argument("-d", "--debug", action="store_true", required=False,
+        help="Debug level logging")
     args = parser.parse_args()
+
+    # Configure logging
+    date_format='%Y/%m/%d_%I:%M:%S(%p)'
+    logging_format='%(asctime)s - %(levelname)s - %(message)s'
+    reload(logging)
+    log_level = None
+    if args.debug:
+        log_level = logging.DEBUG
+    elif args.verbose:
+        log_level = logging.INFO
+
+    logging.basicConfig(
+        format=logging_format, datefmt=date_format,
+        filemode="w", level=log_level
+        )
 
     try:
         ncbi_stats = get_json(args.ncbi_stats)["reports"][0]
+        logging.info(f"{args.ncbi_stats} JSON .'reports' obtained")
     except KeyError:
+        logging.warning(f"{args.ncbi_stats} JSON is empty")
         ncbi_stats = {}
     core_stats = get_json(args.core_stats)
     all_stats = compare_stats(ncbi_stats, core_stats)

--- a/src/python/ensembl/io/genomio/utils/json_utils.py
+++ b/src/python/ensembl/io/genomio/utils/json_utils.py
@@ -29,11 +29,7 @@ def get_json(src_path: PathLike, **kwargs) -> Any:
 
     """
     with Path(src_path).open("r") as json_file:
-        try:
-            return json.load(json_file, **kwargs)
-        # Empty JSON file
-        except:
-            return {}
+        return json.load(json_file, **kwargs)
 
 
 def print_json(dst_path: PathLike, data: Any, **kwargs) -> None:

--- a/src/python/ensembl/io/genomio/utils/json_utils.py
+++ b/src/python/ensembl/io/genomio/utils/json_utils.py
@@ -21,7 +21,6 @@ from os import PathLike
 from pathlib import Path
 from typing import Any
 
-
 def get_json(src_path: PathLike, **kwargs) -> Any:
     """Generic data JSON loader.
 
@@ -30,7 +29,11 @@ def get_json(src_path: PathLike, **kwargs) -> Any:
 
     """
     with Path(src_path).open("r") as json_file:
-        return json.load(json_file, **kwargs)
+        try:
+            return json.load(json_file, **kwargs)
+        # Empty JSON file
+        except:
+            return {}
 
 
 def print_json(dst_path: PathLike, data: Any, **kwargs) -> None:


### PR DESCRIPTION
Noticed that genome_stats.compare was failing when operating over organ_abbrevs with empty ncbi_stats JSON files.

- Implemented logging in genome_stats.compare 
- Added try block to get_json, returns an empty json instead of just failing 