### PR TITLE
Lcampbell/genome metadata

### DIFF
--- a/docs/gen_ref_pages.py
+++ b/docs/gen_ref_pages.py
@@ -1,3 +1,17 @@
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Generate the code reference pages for mkdocs."""
 
 from pathlib import Path

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # [Ensembl GenomIO](https://github.com/Ensembl/ensembl-genomio)
 
-*Ensembl-genomIO Base Library Documentation*
+*Ensembl GenomIO Base Library Documentation*
 
 A repository dedicated to pipelines used to turn basic genomic data into formatted 
 Ensembl core databases. Also allow users to dump core databases into various formats.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ doc = [
 [project.urls]
 homepage = "https://www.ensembl.org"
 repository = "https://github.com/Ensembl/ensembl-genomio"
+documentation = "https://ensembl.github.io/ensembl-genomio"
 
 [project.scripts]
 # Assembly


### PR DESCRIPTION
Updated mkdocs:
-pyproject URL for doc gh-pages was added
-Added missing license header to mkdocs src gen script
-Update docs banner name in site index.md 