### PR TITLE
Enable trace file by default with useful field information

### DIFF
--- a/pipelines/nextflow/workflows/nextflow.config
+++ b/pipelines/nextflow/workflows/nextflow.config
@@ -25,6 +25,12 @@ params {
     brc_mode = 0
 }
 
+trace {
+    enabled = true
+    fields = 'task_id,name,process,hash,status,exit,attempt,submit,time,realtime,cpus,%cpu,memory,%mem'
+//    filter = 'name =~ /foo.*/ && status == "FAILED"'
+}
+
 profiles {
 
     standard {


### PR DESCRIPTION
With the inclusion of a logging system, this information is not stored in `.nextflow.log` but in each process' `.command.log` file (for the "default" StreamHandler, i.e. stderr). Thus I believe we need to enable the trace by default (will generate a `trace-<timestamp>.txt` by default where `nextflow run` is being executed) so we have an easy way to access a given process' working directory (and log file).

I have also left a comment with guidelines in how to use filters, in case we believe we want to only generate traces for failed tasks and/or specific modules for some pipelines.

There is also a full detail HTML report option ([nextflow run ... -with-report](https://www.nextflow.io/docs/latest/tracing.html#execution-report)) but I believe this may be a little bit overkilling in most cases (still useful to analyse a production run and see if we can refine some resources allocations).