### PR TITLE
replace when by if, clearer structure

### DIFF
--- a/pipelines/nextflow/modules/database/dump_db.nf
+++ b/pipelines/nextflow/modules/database/dump_db.nf
@@ -26,9 +26,6 @@ process DUMP_DB {
     output:
         path "*.sql.gz"
 
-    when:
-        "sql" in db.dump_selection
-
     script:
         """
         db_pass=""

--- a/pipelines/nextflow/modules/events/dump_events.nf
+++ b/pipelines/nextflow/modules/events/dump_events.nf
@@ -25,9 +25,6 @@ process DUMP_EVENTS {
     output:
         tuple val(db), val("events"), path("ids_events.tab")
 
-    when:
-        "events" in db.dump_selection
-
     script:
         output = "ids_events.tab"
         """

--- a/pipelines/nextflow/modules/fasta/dump_fasta_dna.nf
+++ b/pipelines/nextflow/modules/fasta/dump_fasta_dna.nf
@@ -24,9 +24,6 @@ process DUMP_FASTA_DNA {
     output:
         tuple val(db), val("fasta_dna"), path("*.fasta")
 
-    when:
-        "fasta_dna" in db.dump_selection
-
     script:
         output = "${db.species}_fasta_dna.fasta"
         """

--- a/pipelines/nextflow/modules/fasta/dump_fasta_peptides.nf
+++ b/pipelines/nextflow/modules/fasta/dump_fasta_peptides.nf
@@ -24,9 +24,6 @@ process DUMP_FASTA_PEPTIDES {
     output:
         tuple val(db), val("fasta_pep"), path("*.fasta")
 
-    when:
-        "fasta_dna" in db.dump_selection
-
     script:
         output = "${db.species}_fasta_pep.fasta"
         """

--- a/pipelines/nextflow/modules/genome_metadata/dump_genome_meta.nf
+++ b/pipelines/nextflow/modules/genome_metadata/dump_genome_meta.nf
@@ -25,9 +25,6 @@ process DUMP_GENOME_META {
     output:
         tuple val(db), val("genome"), path("*_genome.json")
 
-    when:
-        "genome_metadata" in db.dump_selection
-
     script:
         output = "${db.species}_genome.json"
         schema = params.json_schemas["genome"]

--- a/pipelines/nextflow/modules/genome_metadata/dump_ncbi_stats.nf
+++ b/pipelines/nextflow/modules/genome_metadata/dump_ncbi_stats.nf
@@ -25,9 +25,6 @@ process DUMP_NCBI_STATS {
     output:
         tuple val(db), path("ncbi_stats.json")
 
-    when:
-        "stats" in db.dump_selection
-
     shell:
         output = "ncbi_stats.json"
         '''

--- a/pipelines/nextflow/modules/genome_stats/dump_genome_stats.nf
+++ b/pipelines/nextflow/modules/genome_stats/dump_genome_stats.nf
@@ -25,9 +25,6 @@ process DUMP_GENOME_STATS {
     output:
         tuple val(db), path("core_stats.json")
 
-    when:
-        "stats" in db.dump_selection
-
     script:
         """
         genome_stats_dump --host '${db.server.host}' \

--- a/pipelines/nextflow/modules/seq_region/dump_seq_regions.nf
+++ b/pipelines/nextflow/modules/seq_region/dump_seq_regions.nf
@@ -24,9 +24,6 @@ process DUMP_SEQ_REGIONS {
     output:
         tuple val(db), val("seq_region"), path("*_seq_region.json")
 
-    when:
-        "seq_regions" in db.dump_selection
-
     script:
         output = "${db.species}_seq_region.json"
         schema = params.json_schemas["seq_region"]

--- a/pipelines/nextflow/subworkflows/dump_files/main.nf
+++ b/pipelines/nextflow/subworkflows/dump_files/main.nf
@@ -64,7 +64,6 @@ workflow DUMP_FILES {
         // }
         
         // Events
-
         if ("events" in selection) {
             events = DUMP_EVENTS(db)
             db_files = db_files.concat(events)

--- a/pipelines/nextflow/subworkflows/dump_files/main.nf
+++ b/pipelines/nextflow/subworkflows/dump_files/main.nf
@@ -30,6 +30,8 @@ include { PUBLISH_DIR } from '../../modules/files/publish_output_dump.nf'
 workflow DUMP_FILES {
     take:
         db
+        selection
+        selection_number
 
     emit:
         db
@@ -38,41 +40,56 @@ workflow DUMP_FILES {
         db_files = Channel.of()
 
         // Seq regions
-        seq_regions = DUMP_SEQ_REGIONS(db)
-        db_files = db_files.concat(seq_regions)
+        if ("seq_regions" in selection) {
+            seq_regions = DUMP_SEQ_REGIONS(db)
+            db_files = db_files.concat(seq_regions)
+        }
 
         // Dump DNA sequences
-        fasta_dna = DUMP_FASTA_DNA(db)
-        db_files = db_files.concat(fasta_dna)
+        if ("fasta_dna" in selection) {
+            fasta_dna = DUMP_FASTA_DNA(db)
+            db_files = db_files.concat(fasta_dna)
+        }
 
         // Dump protein sequences
-        fasta_pep = DUMP_FASTA_PEPTIDES(db)
-        db_files = db_files.concat(fasta_pep)
+        if ("fasta_pep" in selection) {
+            fasta_pep = DUMP_FASTA_PEPTIDES(db)
+            db_files = db_files.concat(fasta_pep)
+        }
 
         // Dump gene models
-        // gff3 = DUMP_GFF3(db)
-        // db_files = db_files.concat(gff3)
+        // if ("gff3" in selection) {
+            // gff3 = DUMP_GFF3(db)
+            // db_files = db_files.concat(gff3)
+        // }
         
         // Events
-        events = DUMP_EVENTS(db)
-        db_files = db_files.concat(events)
+
+        if ("events" in selection) {
+            events = DUMP_EVENTS(db)
+            db_files = db_files.concat(events)
+        }
 
         // Genome metadata
-        genome_meta = DUMP_GENOME_META(db)
-        db_files = db_files.concat(genome_meta)
+        if ("genome_metadata" in selection) {
+            genome_meta = DUMP_GENOME_META(db)
+            db_files = db_files.concat(genome_meta)
+        }
 
         // Genome stats
-        genome_stats = DUMP_GENOME_STATS(db)
-        ncbi_stats = DUMP_NCBI_STATS(db)
-        stats = ncbi_stats.join(genome_stats)
-        stats_files = COMPARE_GENOME_STATS(stats).transpose()
-        db_files = db_files.concat(stats_files)
+        if ("stats" in selection) {
+            genome_stats = DUMP_GENOME_STATS(db)
+            ncbi_stats = DUMP_NCBI_STATS(db)
+            stats = ncbi_stats.join(genome_stats)
+            stats_files = COMPARE_GENOME_STATS(stats).transpose()
+            db_files = db_files.concat(stats_files)
+        }
 
         // Group the files by db species (use the db object as key)
         // Only keep the files so they are easy to collect
         db_files = db_files
-            .map{ db, name, file_name -> tuple(groupKey(db, db["dump_number"]), file_name) }
-            .groupTuple()
+            .map{ db, name, file_name -> tuple(db, file_name) }
+            .groupTuple(size: selection_number)
 
         // Collect, create manifest, and publish
         manifested_dir = MANIFEST(db_files)

--- a/pipelines/nextflow/workflows/dumper_pipeline/main.nf
+++ b/pipelines/nextflow/workflows/dumper_pipeline/main.nf
@@ -109,7 +109,6 @@ if (params.host && params.port && params.user && params.output_dir) {
 dump_selection = default_selection
 dump_number = 8
 if (params.select_dump) {
-    dump_selection = []
     dump_number = 0
     dump_selection = params.select_dump.split(/,/).collect().unique()
     for (item in dump_selection) {


### PR DESCRIPTION
- Use if in the workflows instead of when in the processes
- Pass the selection of files to dump directly instead of as part of the db metadata
