### PR TITLE
Mbarba/less check procs

### DIFF
--- a/pipelines/nextflow/modules/genbank/extract_from_gb.nf
+++ b/pipelines/nextflow/modules/genbank/extract_from_gb.nf
@@ -34,5 +34,8 @@ process EXTRACT_FROM_GB {
         --prod_name !{meta.production_name} \
         --gb_file !{gb_file} \
         --debug
+
+    schemas_json_validate --json_file "genome.json" --json_schema "genome"
+    schemas_json_validate --json_file "seq_region.json" --json_schema "seq_region"
     '''
 }

--- a/pipelines/nextflow/modules/genome_metadata/amend_genome_data.nf
+++ b/pipelines/nextflow/modules/genome_metadata/amend_genome_data.nf
@@ -25,10 +25,13 @@ process AMEND_GENOME_DATA {
         tuple val(meta), path ("genome.json"), emit: amended_json
     
     shell:
+        output = "genome.json"
         '''
         genome_metadata_extend --genome_infile !{genome_json} \
             --report_file !{asm_report} \
             --genbank_infile !{genbank_gbff} \
-            --genome_outfile genome.json
+            --genome_outfile !{output}
+        
+        schemas_json_validate --json_file !{output} --json_schema genome
         '''
 }

--- a/pipelines/nextflow/modules/gff3/process_gff3.nf
+++ b/pipelines/nextflow/modules/gff3/process_gff3.nf
@@ -32,5 +32,7 @@ process PROCESS_GFF3 {
         gff3_process --genome_data !{genome} --in_gff_path !{gff3} --out_gff_path !{out_gff} \
             --out_func_path !{out_func} -v \
             --log_file gff3_process.log
+        
+        schemas_json_validate --json_file !{out_func} --json_schema functional_annotation
         '''
 }

--- a/pipelines/nextflow/modules/manifest/manifest_maker.nf
+++ b/pipelines/nextflow/modules/manifest/manifest_maker.nf
@@ -26,5 +26,6 @@ process MANIFEST {
     shell:
         '''
         manifest_generate --manifest_dir .
+        schemas_json_validate --json_file manifest.json --json_schema "manifest"
         '''
 }

--- a/pipelines/nextflow/modules/seq_region/process_seq_region.nf
+++ b/pipelines/nextflow/modules/seq_region/process_seq_region.nf
@@ -25,16 +25,19 @@ process PROCESS_SEQ_REGION {
             path (genomic_gbff)
 
     output:
-        tuple val(meta), path("*/seq_region.json"), emit: seq_region
+        tuple val(meta), path("seq_region.json"), emit: seq_region
 
     shell:
         brc_mode = params.brc_mode ? '--brc_mode' : ''
+        output = "seq_region.json"
         '''
         seq_region_prepare \
             --genome_file !{genome_json} \
             --report_file !{assembly_report} \
             --gbff_file !{genomic_gbff} \
-            --dst_dir !{meta.accession} \
+            --dst_file !{output} \
             !{brc_mode}
+        
+        schemas_json_validate --json_file !{output} --json_schema seq_region
         '''
 }

--- a/pipelines/nextflow/subworkflows/additional_seq_prepare/main.nf
+++ b/pipelines/nextflow/subworkflows/additional_seq_prepare/main.nf
@@ -18,7 +18,6 @@ include { DOWNLOAD_GENBANK } from '../../modules/download/download_genbank.nf'
 include { EXTRACT_FROM_GB } from '../../modules/genbank/extract_from_gb.nf'
 include { PROCESS_GFF3 } from '../../modules/gff3/process_gff3.nf'
 include { GFF3_VALIDATION } from '../../modules/gff3/gff3_validation.nf'
-include { CHECK_JSON_SCHEMA } from '../../modules/schema/check_json_schema.nf'
 include { MANIFEST } from '../../modules/manifest/manifest_maker.nf'
 include { CHECK_INTEGRITY } from '../../modules/manifest/integrity.nf'
 include { MANIFEST_STATS } from '../../modules/manifest/manifest_stats.nf'
@@ -57,12 +56,9 @@ workflow additional_seq_prepare {
             gb_seq_regions,
             new_functional_annotation
         )
-        
-        // Verify schemas 
-        checked_json_files = CHECK_JSON_SCHEMA(json_files)
 
         // Gather json and fasta files and reduce to unique input accession
-        all_files = checked_json_files.concat(
+        all_files = json_files.concat(
             gene_models,
             gb_dna_fasta,
             gb_pep_fasta

--- a/pipelines/nextflow/subworkflows/genome_prepare/main.nf
+++ b/pipelines/nextflow/subworkflows/genome_prepare/main.nf
@@ -18,8 +18,6 @@
 
 // Import modules/subworkflows
 include { CHECK_JSON_SCHEMA as CHECK_JSON_SCHEMA_GENOME } from '../../modules/schema/check_json_schema.nf'
-include { CHECK_JSON_SCHEMA as CHECK_JSON_SCHEMA_SEQREG } from '../../modules/schema/check_json_schema.nf'
-include { CHECK_JSON_SCHEMA as CHECK_JSON_SCHEMA_FUNCT } from '../../modules/schema/check_json_schema.nf'
 include { DOWNLOAD_ASM_DATA } from '../../modules/download/download_asm_data.nf'
 include { UNPACK_GFF3 } from '../../modules/gff3/unpack_gff3.nf'
 include { PROCESS_GFF3 } from '../../modules/gff3/process_gff3.nf'
@@ -57,11 +55,8 @@ workflow GENOME_PREPARE {
         // Process the GB and GFF3 files into a cleaned GFF3 and a functional_annotation files
         genome_gff_files = checked_genome.join(unpacked_gff, failOnDuplicate: true)
         PROCESS_GFF3(genome_gff_files)
-        new_functional_annotation = PROCESS_GFF3.out.functional_annotation
+        functional_annotation = PROCESS_GFF3.out.functional_annotation
         new_gene_models = PROCESS_GFF3.out.gene_models
-
-        // Verify functional_annotation.json schema
-        functional_annotation = CHECK_JSON_SCHEMA_FUNCT(new_functional_annotation).verified_json
 
         // Tidy and validate gff3 using gff3validator
         gene_models = GFF3_VALIDATION(new_gene_models).gene_models
@@ -73,10 +68,7 @@ workflow GENOME_PREPARE {
         genome_data_files = checked_genome.join(download_min, failOnDuplicate: true, failOnMismatch: true)
 
         // Generate seq_region.json
-        new_seq_region = PROCESS_SEQ_REGION(genome_data_files).seq_region
-
-        // Verify seq_region.json schema
-        seq_region = CHECK_JSON_SCHEMA_SEQREG(new_seq_region).verified_json
+        seq_region = PROCESS_SEQ_REGION(genome_data_files).seq_region
 
         // Process genomic fna
         fasta_dna = PROCESS_FASTA_DNA(download_min, 0).processed_fasta

--- a/src/python/ensembl/io/genomio/seq_region/prepare.py
+++ b/src/python/ensembl/io/genomio/seq_region/prepare.py
@@ -449,10 +449,10 @@ def prepare_seq_region_metadata(
     defined in "src/python/ensembl/io/genomio/data/schemas/seq_region.json".
 
     Args:
-        dst_file: JSON file output for the processed sequence regions JSON.
         genome_file: Genome metadata JSON file path.
         report_file: INSDC/RefSeq sequences report file path to parse.
         gbff_file: INSDC/RefSeq GBFF file path to parse.
+        dst_file: JSON file output for the processed sequence regions JSON.
         brc_mode: Include INSDC sequence region names.
         to_exclude: Sequence region names to exclude.
 
@@ -505,10 +505,10 @@ def main() -> None:
     init_logging_with_args(args)
 
     prepare_seq_region_metadata(
-        dst_file=args.dst_file,
         genome_file=args.genome_file,
         report_file=args.report_file,
         gbff_file=args.gbff_file,
+        dst_file=args.dst_file,
         brc_mode=args.brc_mode,
         to_exclude=args.to_exclude,
     )

--- a/src/python/ensembl/io/genomio/seq_region/prepare.py
+++ b/src/python/ensembl/io/genomio/seq_region/prepare.py
@@ -435,9 +435,9 @@ def report_to_csv(report_path: PathLike) -> Tuple[str, Dict]:
 
 
 def prepare_seq_region_metadata(
-    dst_file: PathLike,
     genome_file: PathLike,
     report_file: PathLike,
+    dst_file: PathLike,
     gbff_file: Optional[PathLike] = None,
     brc_mode: bool = False,
     to_exclude: Optional[List[str]] = None,
@@ -507,8 +507,8 @@ def main() -> None:
     prepare_seq_region_metadata(
         genome_file=args.genome_file,
         report_file=args.report_file,
-        gbff_file=args.gbff_file,
         dst_file=args.dst_file,
+        gbff_file=args.gbff_file,
         brc_mode=args.brc_mode,
         to_exclude=args.to_exclude,
     )


### PR DESCRIPTION
Simply check the json files when they are created: this means less jobs to run, and if something is wrong the generator process is the one that fails.

NB: not possible to do the same with the gff3 validation, because it uses `gt` from a container, and I don't think it's possible to have both the current environment (e.g. to use `gff3_process`) and a container in the same process script (or at least, not as simply).