### PR TITLE
Do not create an accession subfolder

### DIFF
--- a/src/python/ensembl/io/genomio/assembly/download.py
+++ b/src/python/ensembl/io/genomio/assembly/download.py
@@ -236,8 +236,7 @@ def retrieve_assembly_data(
         max_redo: Set max number of times to retry downloading a file
 
     """
-    download_path = Path(download_dir)
-    download_dir = download_path / accession
+    download_dir = Path(download_dir)
 
     # Configure logging
     log_file = f"{accession}_download.log"
@@ -260,7 +259,6 @@ def retrieve_assembly_data(
                 version = int(accession[-1])
                 version += 1
                 accession = accession[:-1] + str(version)
-                download_dir = download_path / accession
                 download_dir.mkdir(parents=True, exist_ok=True)
             download_files(accession, download_dir, max_redo)
 


### PR DESCRIPTION
Fix a bug from a discrepancy between what the script does (create a subdir within the output dir) and what the Nextflow process expects (no subfolder)
