### PR TITLE
Remove @classmethod from GFFMeta

### DIFF
--- a/src/python/ensembl/io/genomio/gff3/common.py
+++ b/src/python/ensembl/io/genomio/gff3/common.py
@@ -27,29 +27,23 @@ import ensembl.io.genomio.data.gff3
 
 
 class GFFMeta:
-    """Heritable class to share the list of feature types supported or ignored by the parser"""
+    """Class to share the list of feature types supported or ignored by the parser."""
 
-    _biotypes: Dict[str, Dict[str, str]] = {}
+    _biotypes: Dict[str, Dict[str, List[str]]] = {}
 
-    @classmethod
-    def _load_biotypes(cls) -> None:
+    def __init__(self) -> None:
         biotype_json = files(ensembl.io.genomio.data.gff3) / "biotypes.json"
-        logging.debug(f"Import data from {biotype_json}")
-        cls._biotypes = get_json(biotype_json)
+        self._biotypes = get_json(biotype_json)
+        logging.debug(f"Imported data from {biotype_json}")
 
-    @classmethod
-    def get_biotypes(cls, gene_type: str, supported: bool = True) -> List[str]:
+    def get_biotypes(self, gene_type: str, supported: bool = True) -> List[str]:
         """Returns a list of biotypes supported or ignored.
 
         Args:
             gene_type: Gene type among "gene", "non_gene" or "transcript".
-            supported: The biotypes are supported (otherwise it's the list of biotypes that are ignored).
+            supported: Fetch supported biotypes (otherwise returns the list of ignored biotypes).
+
         """
-        if not cls._biotypes:
-            cls._load_biotypes()
-
-        biotypes: Dict[str, Any] = cls._biotypes
-
         if supported:
-            return biotypes[gene_type]["supported"]
-        return biotypes[gene_type]["ignored"]
+            return self._biotypes[gene_type]["supported"]
+        return self._biotypes[gene_type]["ignored"]

--- a/src/python/ensembl/io/genomio/gff3/gene_merger.py
+++ b/src/python/ensembl/io/genomio/gff3/gene_merger.py
@@ -30,6 +30,9 @@ from .common import GFFMeta
 class GFFGeneMerger:
     """Specialized class to merge split genes in a GFF3 file, prior to further parsing."""
 
+    def __init__(self) -> None:
+        self._biotypes = GFFMeta()
+
     def merge(self, in_gff_path: PathLike, out_gff_path: PathLike) -> List[str]:
         """
         Merge genes in a gff that are split in multiple lines.
@@ -60,7 +63,7 @@ class GFFGeneMerger:
                         attrs[key] = value
 
                     # Check this is a gene to merge; cache it then
-                    if fields[2] in GFFMeta.get_biotypes("gene") and (
+                    if fields[2] in self._biotypes.get_biotypes("gene") and (
                         "part" in attrs or "is_ordered" in attrs
                     ):
                         to_merge.append(fields)

--- a/src/python/ensembl/io/genomio/gff3/simplifier.py
+++ b/src/python/ensembl/io/genomio/gff3/simplifier.py
@@ -72,6 +72,7 @@ class GFFSimplifier:
     current_stable_id_number: int = 0
 
     def __init__(self, genome_path: Optional[PathLike] = None, make_missing_stable_ids: bool = False):
+        self._biotypes = GFFMeta()
         self.records = Records()
         self.annotations = FunctionalAnnotations()
         self.genome = {}
@@ -86,10 +87,10 @@ class GFFSimplifier:
         and also write a functional_annotation file
         """
 
-        allowed_gene_types = GFFMeta.get_biotypes("gene")
-        ignored_gene_types = GFFMeta.get_biotypes("gene", supported=False)
-        transcript_types = GFFMeta.get_biotypes("transcript")
-        allowed_non_gene_types = GFFMeta.get_biotypes("non_gene")
+        allowed_gene_types = self._biotypes.get_biotypes("gene")
+        ignored_gene_types = self._biotypes.get_biotypes("gene", supported=False)
+        transcript_types = self._biotypes.get_biotypes("transcript")
+        allowed_non_gene_types = self._biotypes.get_biotypes("non_gene")
         skip_unrecognized = self.skip_unrecognized
         to_exclude = self.exclude_seq_regions
 
@@ -267,8 +268,8 @@ class GFFSimplifier:
     def _normalize_transcripts(self, gene: SeqFeature, fail_types) -> SeqFeature:
         """Returns a normalized transcript."""
 
-        allowed_transcript_types = GFFMeta.get_biotypes("transcript")
-        ignored_transcript_types = GFFMeta.get_biotypes("transcript", supported=False)
+        allowed_transcript_types = self._biotypes.get_biotypes("transcript")
+        ignored_transcript_types = self._biotypes.get_biotypes("transcript", supported=False)
         skip_unrecognized = self.skip_unrecognized
 
         transcripts_to_delete = []
@@ -316,7 +317,7 @@ class GFFSimplifier:
         self, gene: SeqFeature, transcript: SeqFeature, fail_types
     ) -> SeqFeature:
         """Returns a transcript with normalized sub-features."""
-        ignored_transcript_types = GFFMeta.get_biotypes("transcript", supported=False)
+        ignored_transcript_types = self._biotypes.get_biotypes("transcript", supported=False)
         cds_found = False
         exons_to_delete = []
         for tcount, feat in enumerate(transcript.sub_features):

--- a/src/python/tests/gff3/test_common.py
+++ b/src/python/tests/gff3/test_common.py
@@ -12,9 +12,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Unit testing of `ensembl.io.genomio.gff3.common` module."""
+"""Unit testing of `ensembl.io.genomio.gff3.common` module.
 
-from typing import Optional
+Typical usage example::
+    $ pytest test_common.py
+
+"""
+
 import pytest
 
 from ensembl.io.genomio.gff3 import GFFMeta
@@ -23,10 +27,16 @@ from ensembl.io.genomio.gff3 import GFFMeta
 class TestGFF3Merge:
     """Tests for the GFF3GeneMerger module."""
 
+    biotypes = None  # type: GFFMeta
+
+    @pytest.fixture(scope='class', autouse=True)
+    def setup(self) -> None:
+        """Loads the required fixtures and values as class attributes."""
+        type(self).biotypes = GFFMeta()
+
     @pytest.mark.parametrize(
         "gene_type, supported, expected_contain",
         [
-            ("gene", None, "pseudogene"),
             ("gene", True, "pseudogene"),
             ("gene", False, "gap"),
             ("non_gene", True, "transposable_element"),
@@ -34,10 +44,7 @@ class TestGFF3Merge:
             ("transcript", False, "3'UTR"),
         ],
     )
-    def test_get_biotypes(self, gene_type: str, supported: Optional[bool], expected_contain: str) -> None:
+    def test_get_biotypes(self, gene_type: str, supported: bool, expected_contain: str) -> None:
         """Tests get_biotypes method."""
-        if supported is None:
-            result = GFFMeta.get_biotypes(gene_type)
-        else:
-            result = GFFMeta.get_biotypes(gene_type, supported=supported)
+        result = self.biotypes.get_biotypes(gene_type, supported=supported)
         assert expected_contain in result


### PR DESCRIPTION
This PR is a comprehensive alternative of the current proposed implementation of GFFMeta done in #254.

In this approach the JSON file `biotypes.json` is only read twice per call to `gff3_process` entry point. Since this file is rather small I do not see any concerns regarding performance (or compute waste). I'm also happy to do the changes to read the file only once (it is rather simple) if you believe this is required/useful.