### PR TITLE
Update BRC4_genome_loader_conf.pm

### DIFF
--- a/src/perl/Bio/EnsEMBL/Pipeline/PipeConfig/BRC4_genome_loader_conf.pm
+++ b/src/perl/Bio/EnsEMBL/Pipeline/PipeConfig/BRC4_genome_loader_conf.pm
@@ -358,7 +358,7 @@ sub pipeline_analyses {
       -module      => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
       -parameters  => {
         cmd => 'mkdir -p #log_path#; '
-             . 'check_integrity --brc_mode #brc4_mode# --ignore_final_stops #ignore_final_stops# --manifest_file #manifest# '
+             . 'manifest_check_integrity --brc_mode #brc4_mode# --ignore_final_stops #ignore_final_stops# --manifest_file #manifest# '
              . '   > #log_path#/check.log 2>&1 ',
         log_path => $self->o('pipeline_dir') . '/check_integrity',
       },


### PR DESCRIPTION
Update entry point to manifest integrity check. 

Pipeline for e113 loading was failing, due to old 'check_integrity' entry point being used in BRC4_genome_loader_conf. 

# Change:
- Simple one line change to update this entry point. 