### PR TITLE
Fix GFF3 parsing for naked transcripts and CDSs

### DIFF
--- a/src/python/ensembl/io/genomio/data/gff3/biotypes.json
+++ b/src/python/ensembl/io/genomio/data/gff3/biotypes.json
@@ -35,6 +35,7 @@
     },
     "non_gene": {
         "supported": [
+            "mobile_genetic_element",
             "transposable_element"
         ]
     },

--- a/src/python/ensembl/io/genomio/gff3/simplifier.py
+++ b/src/python/ensembl/io/genomio/gff3/simplifier.py
@@ -139,13 +139,6 @@ class GFFSimplifier:
         # From here we expect only genes
         gene = feat
 
-        # What to do with unsupported gene types
-        if gene.type not in allowed_gene_types:
-            self.fail_types["gene=" + gene.type] = 1
-            logging.debug(f"Unsupported gene type: {gene.type} (for {gene.id})")
-            if self.skip_unrecognized:
-                return None
-
         if gene.type == "protein_coding_gene":
             gene.type = "gene"
 
@@ -154,6 +147,13 @@ class GFFSimplifier:
             gene = self.transcript_gene(gene)
         elif gene.type == "CDS":
             gene = self.cds_gene(gene)
+
+        # What to do with unsupported gene types
+        if gene.type not in allowed_gene_types:
+            self.fail_types["gene=" + gene.type] = 1
+            logging.debug(f"Unsupported gene type: {gene.type} (for {gene.id})")
+            if self.skip_unrecognized:
+                return None
         
         # Normalize, store annotation, and return the cleaned up gene
         gene = self.normalize_gene(gene)

--- a/src/python/ensembl/io/genomio/gff3/simplifier.py
+++ b/src/python/ensembl/io/genomio/gff3/simplifier.py
@@ -154,7 +154,7 @@ class GFFSimplifier:
             logging.debug(f"Unsupported gene type: {gene.type} (for {gene.id})")
             if self.skip_unrecognized:
                 return None
-        
+
         # Normalize, store annotation, and return the cleaned up gene
         gene = self.normalize_gene(gene)
         self.store_gene_annotations(gene)


### PR DESCRIPTION
The GFF3 part of the hackthon branch introduce some changes that break how features are handled (because of a change in the order of operations). This is some code in the simplifier module which doesn't have tests yet.

Details:
In the current (faulty) order of operation, the features that have a biotype mRNA, transcripts, etc. or CDS without a gene parent are deemed unsupported and the GFF3 parsing fails. We do have two operations `transcript_gene()` and `CDS_gene()` that move the mRNA, CDS etc. under a gene parent, but right now they are done after checking for the biotype.

In this patch I reorder the operations with clearer labels, and put back the two operations that add a gene parent before the check for unsupported gene features.

NB: I recommend looking at the full simpler_gff3_feature method before and after, instead of the line by line diff.