### PR TITLE
Make the Python image a CI/CD variable

### DIFF
--- a/cicd/gitlab/dot.gitlab-ci.yml
+++ b/cicd/gitlab/dot.gitlab-ci.yml
@@ -25,6 +25,7 @@ workflow:
     - if: $CI_COMMIT_BRANCH =~ /hackathon\/.+/
 
 variables:
+  PYTHON_IMAGE: python:3.8
   RUN_DIR: ./cicd/runtime
 
 # Using default stages (https://docs.gitlab.com/ee/ci/yaml/#stages): .pre > build > test > deploy > .post

--- a/cicd/gitlab/parts/python.gitlab-ci.yml
+++ b/cicd/gitlab/parts/python.gitlab-ci.yml
@@ -20,7 +20,7 @@
 # (https://docs.gitlab.com/ee/ci/yaml/#extends)
 .python:
   stage: test
-  image: python:3.8
+  image: $PYTHON_IMAGE
   only:
     changes:
       - cicd/gitlab/parts/python.gitlab-ci.yml


### PR DESCRIPTION
Instead of setting only the version as the environment variable content I have opted for the whole image information in case we want to use a different source in the future.