### PR TITLE
Update stable id pattern in OSID

### DIFF
--- a/scripts/brc4/patch_build/osid_add_organisms.py
+++ b/scripts/brc4/patch_build/osid_add_organisms.py
@@ -47,7 +47,7 @@ def get_organism(url: str, user: str, key: str, org_data: Dict[str, str]) -> Opt
         if len(organisms) == 0:
             return None
         raise ValueError(f"Found several organisms for the name '{species}'")
-    print("Error: " + str(result))
+    print(f"Error: {result}")
     return None
 
 
@@ -70,7 +70,7 @@ def add_organism(url: str, user: str, key: str, org_data: Dict[str, str]) -> Non
         print(json.dumps(json.loads(result.content), indent=4))
 
 
-def update_organism(url: str, user: str, key: str, org_data: Dict[str, str], organism_id: int):
+def update_organism(url: str, user: str, key: str, org_data: Dict[str, str], organism_id: int) -> None:
     """Update an organism in OSID."""
 
     del org_data["organismName"]

--- a/scripts/brc4/patch_build/osid_add_organisms.py
+++ b/scripts/brc4/patch_build/osid_add_organisms.py
@@ -43,6 +43,11 @@ def get_organism(url, user, key, org_data):
 
 
 def add_organism(url, user, key, org_data):
+    # Species is new, check we have all the keys
+    expected = { "organismName", "template", "geneIntStart", "transcriptIntStart" }
+    if set(expected) != set(org_data):
+        raise ValueError(f"Missing values expected for a new organism: {org_data}")
+
     add_org_url = url + "/organisms"
     headers = {"Content-type": "application/json", "Accept": "application/json"}
     result = requests.post(add_org_url, auth=(user, key), headers=headers, json=org_data)
@@ -93,17 +98,18 @@ def main():
 
     parser.add_argument("--name", type=str, required=True, help="Species name to add")
     parser.add_argument("--template", type=str, required=True, help="Stable_id template")
-    parser.add_argument("--gene_start", type=str, required=True, help="Start of gene numbering")
-    parser.add_argument("--transcript_start", type=str, required=True, help="Start of transcript numbering")
+    parser.add_argument("--gene_start", type=str, help="Start of gene numbering")
+    parser.add_argument("--transcript_start", type=str, help="Start of transcript numbering")
 
     args = parser.parse_args()
 
     organism_data = {
         "organismName": args.name,
         "template": args.template,
-        "geneIntStart": args.gene_start,
-        "transcriptIntStart": args.transcript_start,
     }
+    if args.gene_start and args.transcript_start:
+        organism_data["geneIntStart"] = args.gene_start
+        organism_data["transcriptIntStart"] = args.transcript_start
 
     add_or_update_organism(args.url, args.user, args.key, organism_data, args.update)
 


### PR DESCRIPTION
This script can now be used to update the pattern of stable_ids stored in OSID: it can do so as long as we do not also include start for gene and transcript (because in this case it will not work, otherwise it would change what has already been allocated).

With some clean up.
