### PR TITLE
Use module doc for parser description

### DIFF
--- a/cicd/gitlab/dot.gitlab-ci.yml
+++ b/cicd/gitlab/dot.gitlab-ci.yml
@@ -25,6 +25,7 @@ workflow:
     - if: $CI_COMMIT_BRANCH =~ /hackathon\/.+/
 
 variables:
+  PYTHON_IMAGE: python:3.8
   RUN_DIR: ./cicd/runtime
 
 # Using default stages (https://docs.gitlab.com/ee/ci/yaml/#stages): .pre > build > test > deploy > .post

--- a/cicd/gitlab/parts/python.gitlab-ci.yml
+++ b/cicd/gitlab/parts/python.gitlab-ci.yml
@@ -20,7 +20,7 @@
 # (https://docs.gitlab.com/ee/ci/yaml/#extends)
 .python:
   stage: test
-  image: python:3.8
+  image: $PYTHON_IMAGE
   only:
     changes:
       - cicd/gitlab/parts/python.gitlab-ci.yml

--- a/src/python/ensembl/io/genomio/manifest/check_integrity.py
+++ b/src/python/ensembl/io/genomio/manifest/check_integrity.py
@@ -79,7 +79,7 @@ class Manifest:
 
     def has_lengths(self, name: str) -> bool:
         """Check if a given name has lengths records.
-        
+
         Raise KeyError if the name is not supported.
 
         """
@@ -89,7 +89,6 @@ class Manifest:
             return False
         except KeyError as err:
             raise KeyError(f"There is no length record for {name}") from err
-
 
     def get_lengths(self, name: str) -> Dict[str, Any]:
         """Returns a dict associating IDs with their length from a given file name."""
@@ -737,9 +736,7 @@ class IntegrityTool:
 
 def main() -> None:
     """Main entrypoint."""
-    parser = ArgumentParser(
-        description="Compare the genomic data between the files present in a manifest file."
-    )
+    parser = ArgumentParser(description=__doc__)
     parser.add_argument_src_path("--manifest_file", required=True, help="Manifest file for the data to check")
     parser.add_argument("--brc_mode", action="store_true", help="Enable BRC mode")
     parser.add_argument(


### PR DESCRIPTION
A quick PR to both apply black and show how to use the __doc__ for the parser description to avoid redundancy.