### PR TITLE
Add unit test for ensembl.io.genomio.genome_stats.dump module

### DIFF
--- a/src/python/ensembl/io/genomio/genome_stats/dump.py
+++ b/src/python/ensembl/io/genomio/genome_stats/dump.py
@@ -32,6 +32,7 @@ from ensembl.utils.logging import init_logging_with_args
 @dataclass
 class StatsGenerator:
     """Interface to extract genome stats from a core database."""
+
     session: Session
 
     def get_assembly_stats(self) -> Dict[str, Any]:

--- a/src/python/ensembl/io/genomio/genome_stats/dump.py
+++ b/src/python/ensembl/io/genomio/genome_stats/dump.py
@@ -117,13 +117,13 @@ class StatsGenerator:
         }
         return feat_stats
 
-    def get_stats(self) -> Dict[str, Any]:
+    def get_genome_stats(self) -> Dict[str, Any]:
         """Returns a dict of stats about the assembly and annotation."""
-        all_stats = {
+        genome_stats = {
             "assembly_stats": self.get_assembly_stats(),
             "annotation_stats": self.get_annotation_stats(),
         }
-        return all_stats
+        return genome_stats
 
 
 def main() -> None:
@@ -135,13 +135,7 @@ def main() -> None:
     init_logging_with_args(args)
 
     dbc = DBConnection(args.url)
-
     with dbc.session_scope() as session:
         generator = StatsGenerator(session)
-        all_stats = generator.get_stats()
-
-    print(json.dumps(all_stats, indent=2, sort_keys=True))
-
-
-if __name__ == "__main__":
-    main()
+        all_stats = generator.get_genome_stats()
+        print(json.dumps(all_stats, indent=2, sort_keys=True))

--- a/src/python/ensembl/io/genomio/genome_stats/dump.py
+++ b/src/python/ensembl/io/genomio/genome_stats/dump.py
@@ -101,7 +101,7 @@ class StatsGenerator:
         session = self.session
         totals_st = select(func.count(table.stable_id))
         (total,) = session.execute(totals_st).one()
-        no_desc_st = select(func.count(table.stable_id)).filter(table.description is None)
+        no_desc_st = select(func.count(table.stable_id)).filter(table.description == None)
         (no_desc,) = session.execute(no_desc_st).one()
         xref_desc_st = select(func.count(table.stable_id)).where(table.description.like("%[Source:%"))
         (xref_desc,) = session.execute(xref_desc_st).one()

--- a/src/python/ensembl/io/genomio/genome_stats/dump.py
+++ b/src/python/ensembl/io/genomio/genome_stats/dump.py
@@ -102,6 +102,7 @@ class StatsGenerator:
         session = self.session
         totals_st = select(func.count(table.stable_id))
         (total,) = session.execute(totals_st).one()
+        # pylint: disable-next=singleton-comparison
         no_desc_st = select(func.count(table.stable_id)).filter(table.description == None)
         (no_desc,) = session.execute(no_desc_st).one()
         xref_desc_st = select(func.count(table.stable_id)).where(table.description.like("%[Source:%"))

--- a/src/python/ensembl/io/genomio/genome_stats/dump.py
+++ b/src/python/ensembl/io/genomio/genome_stats/dump.py
@@ -41,7 +41,6 @@ class StatsGenerator:
             "locations": self.get_attrib_counts("sequence_location"),
             "codon_table": self.get_attrib_counts("codon_table"),
         }
-
         # Special: rename supercontigs to scaffolds for homogeneity
         stats = self._fix_scaffolds(stats)
         return stats
@@ -76,38 +75,31 @@ class StatsGenerator:
 
     def get_annotation_stats(self) -> Dict[str, Any]:
         """Returns a dict of stats about the coordinate systems (number of biotypes, etc.)."""
-
         stats = {
             "genes": self.get_feature_stats(Gene),
             "transcripts": self.get_feature_stats(Transcript),
         }
-
         return stats
 
-    def get_biotypes(self, table) -> Dict[str, int]:
+    def get_biotypes(self, table: Any) -> Dict[str, int]:
         """Returns a dict of stats about the feature biotypes."""
         seqs_st = select(table.biotype, func.count()).group_by(table.biotype)
-
         biotypes = {}
         for row in self.session.execute(seqs_st):
             (biotype, count) = row
             biotypes[biotype] = count
-
         return biotypes
 
-    def get_feature_stats(self, table) -> Dict[str, int]:
+    def get_feature_stats(self, table: Any) -> Dict[str, int]:
         """Returns a dict of stats about a given feature."""
         session = self.session
-
         totals_st = select(func.count(table.stable_id))
         (total,) = session.execute(totals_st).one()
         no_desc_st = select(func.count(table.stable_id)).filter(table.description is None)
         (no_desc,) = session.execute(no_desc_st).one()
         xref_desc_st = select(func.count(table.stable_id)).where(table.description.like("%[Source:%"))
         (xref_desc,) = session.execute(xref_desc_st).one()
-
         left_over = total - no_desc - xref_desc
-
         feat_stats = {
             "total": total,
             "biotypes": self.get_biotypes(table),
@@ -130,9 +122,7 @@ class StatsGenerator:
 
 def main() -> None:
     """Main script entry-point."""
-    parser = ArgumentParser(
-        description="Fetch all the sequence regions from a core database and print them in JSON format."
-    )
+    parser = ArgumentParser(description=__doc__)
     parser.add_server_arguments(include_database=True)
     parser.add_log_arguments(add_log_file=True)
     args = parser.parse_args()

--- a/src/python/ensembl/io/genomio/genome_stats/dump.py
+++ b/src/python/ensembl/io/genomio/genome_stats/dump.py
@@ -42,17 +42,23 @@ class StatsGenerator:
             "codon_table": self.get_attrib_counts("codon_table"),
         }
         # Special: rename supercontigs to scaffolds for homogeneity
-        stats = self._fix_scaffolds(stats)
+        StatsGenerator._fix_scaffolds(stats)
         return stats
 
-    def _fix_scaffolds(self, stats: Dict[str, Any]) -> Dict[str, Any]:
-        """Rename supercontigs to scaffolds in a stats dict and return it."""
+    @staticmethod
+    def _fix_scaffolds(stats: Dict[str, Any]) -> None:
+        """Renames supercontigs to scaffolds in the provided stats.
+
+        If scaffolds are present already, nothing is done.
+
+        Args:
+            stats: Statistics dictionary.
+
+        """
         coords = stats.get("coord_system", {})
-        if "supercontig" in coords:
-            if "scaffold" not in coords:
-                coords["scaffold"] = coords["supercontig"]
-                del coords["supercontig"]
-        return stats
+        if "supercontig" in coords and "scaffold" not in coords:
+            coords["scaffold"] = coords["supercontig"]
+            del coords["supercontig"]
 
     def get_attrib_counts(self, code: str) -> Dict[str, Any]:
         """Returns a dict of count for each value counted with the attrib_type code provided.

--- a/src/python/tests/genome_stats/test_dump.py
+++ b/src/python/tests/genome_stats/test_dump.py
@@ -37,6 +37,7 @@ from ensembl.io.genomio.utils import get_json
 @dataclass
 class MockResult:
     """Mocker of `sqlalchemy.engine.Result` class."""
+
     rows: List
 
     def __iter__(self) -> Any:

--- a/src/python/tests/genome_stats/test_dump.py
+++ b/src/python/tests/genome_stats/test_dump.py
@@ -1,0 +1,235 @@
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit testing of `ensembl.io.genomio.genome_stats.dump` module.
+
+Typical usage example::
+    $ pytest test_dump.py
+
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from string import Template
+from typing import Any, Callable, Dict, List, Tuple
+from unittest.mock import MagicMock, patch
+
+import pytest
+from sqlalchemy.orm import Session
+from sqlalchemy.sql.expression import Executable
+
+from ensembl.core.models import Gene, Transcript
+from ensembl.io.genomio.genome_stats import dump
+from ensembl.io.genomio.utils import get_json
+
+
+@dataclass
+class MockResult:
+    """Mocker of `sqlalchemy.engine.Result` class."""
+    rows: List
+
+    def __iter__(self) -> Any:
+        """Iterates over the elements in `rows` attribute."""
+        for row in self.rows:
+            yield row
+
+    def one(self) -> Tuple:
+        """Returns the first element in `rows` attribute."""
+        return self.rows[0]
+
+
+# Define templates for all expected queries
+ATTRIB_COUNTS_QUERY = Template(
+    "SELECT seq_region_attrib.value, count(seq_region_attrib.value) AS count_1 "
+    "FROM seq_region_attrib JOIN attrib_type ON attrib_type.attrib_type_id = seq_region_attrib.attrib_type_id"
+    " WHERE attrib_type.code = '${code}' GROUP BY seq_region_attrib.value"
+)
+BIOTYPES_QUERY = Template(
+    "SELECT ${table}.biotype, count(*) AS count_1 FROM ${table} GROUP BY ${table}.biotype"
+)
+FEATURE_STATS_TOTAL_QUERY = Template("SELECT count(${table}.stable_id) AS count_1 FROM ${table}")
+FEATURE_STATS_NULL_QUERY = Template(
+    "SELECT count(${table}.stable_id) AS count_1 FROM ${table} WHERE ${table}.description IS NULL"
+)
+FEATURE_STATS_SOURCE_QUERY = Template(
+    "SELECT count(${table}.stable_id) AS count_1 FROM ${table} WHERE ${table}.description LIKE '%[Source:%'"
+)
+
+
+class MockSession(Session):
+    """Mocker of `sqlalchemy.orm.Session` class that replaces its `execute()` method for testing."""
+
+    def execute(self, statement: Executable, *args, **kwargs) -> MockResult:
+        """TODO"""
+        compiled_statement = str(statement.compile(compile_kwargs={"literal_binds": True}))
+        query = compiled_statement.replace("\n", "")
+        # Expected statements for test_get_attrib_counts()
+        if query == ATTRIB_COUNTS_QUERY.substitute(code="coord_system_tag"):
+            return MockResult([["chromosome", 7], ["scaffold", 2]])
+        if query in (
+            ATTRIB_COUNTS_QUERY.substitute(code="sequence_location"),
+            ATTRIB_COUNTS_QUERY.substitute(code="codon_table"),
+        ):
+            return MockResult([])
+        # Expected statements for test_get_biotypes()
+        if query == BIOTYPES_QUERY.substitute(table="gene"):
+            return MockResult([["protein_coding", 40], ["pseudogene", 1]])
+        if query == BIOTYPES_QUERY.substitute(table="transcript"):
+            return MockResult([])
+        # Expected statements for test_get_feature_stats()
+        if query == FEATURE_STATS_TOTAL_QUERY.substitute(table="gene"):
+            return MockResult([[10]])
+        if query == FEATURE_STATS_NULL_QUERY.substitute(table="gene"):
+            return MockResult([[2]])
+        if query == FEATURE_STATS_SOURCE_QUERY.substitute(table="gene"):
+            return MockResult([[1]])
+        if query in (
+            FEATURE_STATS_TOTAL_QUERY.substitute(table="transcript"),
+            FEATURE_STATS_NULL_QUERY.substitute(table="transcript"),
+            FEATURE_STATS_SOURCE_QUERY.substitute(table="transcript"),
+        ):
+            return MockResult([[0]])
+        # Fail test if the provided statement is not expected
+        raise RuntimeError()
+
+
+class TestStatsGenerator:
+    """Tests for the `StatsGenerator` class."""
+
+    stats_gen: dump.StatsGenerator = None
+
+    @pytest.fixture(scope="class", autouse=True)
+    def setup(self, data_dir: Path) -> None:
+        """Loads the required fixtures and values as class attributes.
+
+        Args:
+            data_dir: Module's test data directory fixture.
+
+        """
+        type(self).stats_gen = dump.StatsGenerator(MockSession())
+        type(self).genome_stats = get_json(data_dir / "genome_stats.json")
+
+    @pytest.mark.parametrize(
+        "stats, output",
+        [
+            ({}, {}),
+            (
+                {"coord_system": {"supercontig": 2, "scaffold": 3}},
+                {"coord_system": {"supercontig": 2, "scaffold": 3}},
+            ),
+            ({"coord_system": {"supercontig": 5}}, {"coord_system": {"scaffold": 5}}),
+        ],
+    )
+    @pytest.mark.dependency(name="fix_scaffolds")
+    def test_fix_scaffolds(self, stats: Dict, output: Dict) -> None:
+        """Tests the `StatsGenerator._fix_scaffolds()` static method.
+
+        Args:
+            stats: Input statistic dictionary.
+            output: Expected output.
+
+        """
+        dump.StatsGenerator._fix_scaffolds(stats)
+        assert stats == output
+
+    @pytest.mark.parametrize(
+        "code, attribute",
+        [
+            ("coord_system_tag", "coord_system"),
+            ("sequence_location", "locations"),
+        ],
+    )
+    @pytest.mark.dependency(name="get_attrib_counts")
+    def test_get_attrib_counts(self, code: str, attribute: str) -> None:
+        """Tests the `StatsGenerator.get_attrib_counts()` method.
+
+        Args:
+            code: Core database attribute type code.
+            attribute: Core database attribute name.
+
+        """
+        attrib_counts = self.stats_gen.get_attrib_counts(code)
+        assert attrib_counts == self.genome_stats["assembly_stats"][attribute]
+
+    @pytest.mark.parametrize(
+        "table, table_name",
+        [
+            (Gene, "genes"),
+            (Transcript, "transcripts"),
+        ],
+    )
+    @pytest.mark.dependency(name="get_biotypes")
+    def test_get_biotypes(self, table: Any, table_name: str) -> None:
+        """Tests the `StatsGenerator.get_biotypes()` method.
+
+        Args:
+            table: Core database table model class.
+            table_name: Core database table name.
+
+        """
+        biotypes = self.stats_gen.get_biotypes(table)
+        assert biotypes == self.genome_stats["annotation_stats"][table_name]["biotypes"]
+
+    @pytest.mark.parametrize(
+        "table, table_name",
+        [
+            (Gene, "genes"),
+            (Transcript, "transcripts"),
+        ],
+    )
+    @pytest.mark.dependency(name="get_feature_stats", depends=["get_biotypes"])
+    def test_get_feature_stats(self, table: Any, table_name: str) -> None:
+        """Tests the `StatsGenerator.get_feature_stats()` method.
+
+        Args:
+            table: Core database table model class.
+            table_name: Core database table name.
+
+        """
+        biotypes = self.stats_gen.get_feature_stats(table)
+        assert biotypes == self.genome_stats["annotation_stats"][table_name]
+
+    @pytest.mark.dependency(name="get_assembly_stats", depends=["fix_scaffolds", "get_attrib_counts"])
+    def test_get_assembly_stats(self) -> None:
+        """Tests the `StatsGenerator.get_assembly_stats()` method."""
+        assembly_stats = self.stats_gen.get_assembly_stats()
+        assert assembly_stats == self.genome_stats["assembly_stats"]
+
+    @pytest.mark.dependency(name="get_annotation_stats", depends=["get_feature_stats"])
+    def test_get_annotation_stats(self) -> None:
+        """Tests the `StatsGenerator.get_annotation_stats()` method."""
+        annotation_stats = self.stats_gen.get_annotation_stats()
+        assert annotation_stats == self.genome_stats["annotation_stats"]
+
+    @pytest.mark.dependency(name="get_genome_stats", depends=["get_assembly_stats", "get_annotation_stats"])
+    def test_get_genome_stats(self) -> None:
+        """Tests the `StatsGenerator.get_genome_stats()` method."""
+        genome_stats = self.stats_gen.get_genome_stats()
+        assert genome_stats == self.genome_stats
+
+
+@pytest.mark.dependency(depends=["get_genome_stats"])
+@patch("ensembl.io.genomio.genome_stats.dump.DBConnection")
+def test_dump_genome_stats(mock_dbconnection: MagicMock, json_data: Callable) -> None:
+    """Tests the `dump_genome_stats()` method.
+
+    Args:
+        mock_dbconnection: Mock of DBConnection to avoid needing an actual core database.
+        json_data: JSON test file parsing fixture.
+
+    """
+    mock_dbconnection.return_value.session_scope.return_value = MockSession()
+    stats = dump.dump_genome_stats("")
+    expected_output = json_data("genome_stats.json")
+    assert stats == expected_output

--- a/src/python/tests/genome_stats/test_dump.py
+++ b/src/python/tests/genome_stats/test_dump.py
@@ -71,8 +71,14 @@ FEATURE_STATS_SOURCE_QUERY = Template(
 class MockSession(Session):
     """Mocker of `sqlalchemy.orm.Session` class that replaces its `execute()` method for testing."""
 
-    def execute(self, statement: Executable, *args, **kwargs) -> MockResult:
-        """TODO"""
+    # pylint: disable-next=too-many-return-statements
+    def execute(self, statement: Executable) -> MockResult:
+        """Returns a `MockResult` object representing results of the statement execution.
+
+        Args:
+            statement: An executable statement.
+
+        """
         compiled_statement = str(statement.compile(compile_kwargs={"literal_binds": True}))
         query = compiled_statement.replace("\n", "")
         # Expected statements for test_get_attrib_counts()
@@ -108,7 +114,8 @@ class MockSession(Session):
 class TestStatsGenerator:
     """Tests for the `StatsGenerator` class."""
 
-    stats_gen: dump.StatsGenerator = None
+    stats_gen: dump.StatsGenerator
+    genome_stats: Dict[str, Any]
 
     @pytest.fixture(scope="class", autouse=True)
     def setup(self, data_dir: Path) -> None:
@@ -141,7 +148,7 @@ class TestStatsGenerator:
             output: Expected output.
 
         """
-        dump.StatsGenerator._fix_scaffolds(stats)
+        dump.StatsGenerator._fix_scaffolds(stats)  # pylint: disable=protected-access
         assert stats == output
 
     @pytest.mark.parametrize(

--- a/src/python/tests/genome_stats/test_dump/genome_stats.json
+++ b/src/python/tests/genome_stats/test_dump/genome_stats.json
@@ -1,0 +1,19 @@
+{
+  "annotation_stats": {
+    "genes": {
+      "biotypes": {"protein_coding": 40, "pseudogene": 1},
+      "description": {"empty": 2, "normal": 7, "source_xref": 1},
+      "total": 10
+    },
+    "transcripts": {
+      "biotypes": {},
+      "description": {"empty": 0, "normal": 0, "source_xref": 0},
+      "total": 0
+    }
+  },
+  "assembly_stats": {
+    "codon_table": {},
+    "coord_system": {"chromosome": 7, "scaffold": 2},
+    "locations": {}
+  }
+}


### PR DESCRIPTION
This unit tests is designed to avoid needed a database connection and, therefore, a core database. However, to be able to test the code correctly the queries have been hardcoded in the test file. I will produce an alternative without the mocking and an actual test core db in a separate PR.

I have also taken the opportunity to refactor the source module in some points to make the code more readable.

_Coverage:_ 100% of the module tested.