### PR TITLE
Remove --verbose option for black

### DIFF
--- a/cicd/gitlab/parts/python.gitlab-ci.yml
+++ b/cicd/gitlab/parts/python.gitlab-ci.yml
@@ -90,7 +90,7 @@ python:black:
   extends: .python:test
   allow_failure: true
   script:
-    - black --config pyproject.toml --verbose --check .
+    - black --config pyproject.toml --check .
 
 ## Unit tests and coverage
 


### PR DESCRIPTION
With the current approach is quite difficult to see the files that would be changed (if any). Removing this argument should resolve this issue. E.g. https://gitlab.ebi.ac.uk/vectorbase/ensembl-genomio/-/jobs/1555497