### PR TITLE
Prepare genome publish to BRC dir structure

### DIFF
--- a/pipelines/nextflow/modules/files/publish_output.nf
+++ b/pipelines/nextflow/modules/files/publish_output.nf
@@ -16,7 +16,7 @@
 process PUBLISH_DIR {
     tag "publish_${meta.accession}"
     label 'default'
-    publishDir "$out_dir/${meta.accession}", mode: 'copy', overwrite: false
+    publishDir "$out_dir/${meta.publish_dir}", mode: 'copy', overwrite: false
     time '5min'
 
     input:

--- a/pipelines/nextflow/tests/workflows/test_genome_prepare_brc_mode_on.yml
+++ b/pipelines/nextflow/tests/workflows/test_genome_prepare_brc_mode_on.yml
@@ -29,22 +29,22 @@
   # Check that all the expected files are produced
   # Make sure to update those if the processing of the files changes!
   files:
-    - path: ./test_genome_prepare_output/GCA_017607445.1/fasta_dna.fa
+    - path: ./test_genome_prepare_output/OrganismDB/organAbrev123/fasta_dna.fa
       md5sum: 68d26226b04950883edecd6095d1db1f
-    - path: ./test_genome_prepare_output/GCA_017607445.1/fasta_pep.fa
+    - path: ./test_genome_prepare_output/OrganismDB/organAbrev123/fasta_pep.fa
       md5sum: d3be87e392cc53ded62987c28952cc3d
-    - path: ./test_genome_prepare_output/GCA_017607445.1/functional_annotation.json
+    - path: ./test_genome_prepare_output/OrganismDB/organAbrev123/functional_annotation.json
       md5sum: eb834948fb9363dd71d02cb591848345
-    - path: ./test_genome_prepare_output/GCA_017607445.1/gene_models.gff3
+    - path: ./test_genome_prepare_output/OrganismDB/organAbrev123/gene_models.gff3
       md5sum: ade9ac036023c48dd490056457027468
     # Genome contains fields that depend on the date, so can't check md5sum
-    - path: ./test_genome_prepare_output/GCA_017607445.1/genome.json
+    - path: ./test_genome_prepare_output/OrganismDB/organAbrev123/genome.json
       contains:
         - GCA_017607445.1
         - organAbrev123
         - OrganismDB
     # Manifest depends on the genome checksum, so also date dependent
-    - path: ./test_genome_prepare_output/GCA_017607445.1/manifest.json
-    - path: ./test_genome_prepare_output/GCA_017607445.1/seq_region.json
+    - path: ./test_genome_prepare_output/OrganismDB/organAbrev123/manifest.json
+    - path: ./test_genome_prepare_output/OrganismDB/organAbrev123/seq_region.json
       md5sum: 585da9f97f094e83702860ce43da652f
-    - path: ./test_genome_prepare_output/GCA_017607445.1/stats.txt
+    - path: ./test_genome_prepare_output/OrganismDB/organAbrev123/stats.txt

--- a/pipelines/nextflow/workflows/genome_prepare/main.nf
+++ b/pipelines/nextflow/workflows/genome_prepare/main.nf
@@ -41,15 +41,19 @@ def meta_from_genome_json(json_path) {
     data = read_json(json_path)
 
     prod_name = data.assembly.accession
-    if ( data.species && data.species.production_name ) {
-        prod_name = data.species.production_name
-    } else if ( data.BRC4 && data.BRC4.organism_abbrev ){
+    publish_dir = data.assembly.accession
+    if (params.brc_mode) {
         prod_name = data.BRC4.organism_abbrev
+        publish_dir = "${data.BRC4.component}/${data.BRC4.organism_abbrev}"
+    } else if ( data.species && data.species.production_name ) {
+        prod_name = data.species.production_name
+        publish_dir = "${prod_name}"
     }
 
     return [
         accession: data.assembly.accession,
         production_name: prod_name,
+        publish_dir: publish_dir,
         prefix: "",
     ]
 }


### PR DESCRIPTION
Change the output directory structure of the genome prepare pipeline for brc mode: use the subfolders `component/organismAbbrev/` instead of just GCA accession.

Without brc mode, the subfolder is still the GCA accession, or the `species.production_name` if that is defined in the genome metadata json file.
