### PR TITLE
Add javascript to always have the Copyright up to date in the documentation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,7 +16,7 @@ site_name: Ensembl-GenomIO
 site_url: "https://ensembl.github.io/ensembl-genomio"
 repo_url: "https://github.com/Ensembl/ensembl-genomio"
 repo_name: "Ensembl-GenomIO"
-copyright: Copyright &copy; [2016-2023] EMBL-European Bioinformatics Institute
+copyright: "Copyright &copy; [2016-<script>document.write(new Date().getFullYear())</script>] EMBL-European Bioinformatics Institute"
 
 theme:
   name: "material"


### PR DESCRIPTION
Followed the suggestion found in https://stackoverflow.com/questions/67983304/how-to-use-build-date-utc-for-copyright-year-in-mkdocs-yml