### PR TITLE
Don't fail but write a stats error file

### DIFF
--- a/src/python/ensembl/io/genomio/manifest/check_integrity.py
+++ b/src/python/ensembl/io/genomio/manifest/check_integrity.py
@@ -79,7 +79,7 @@ class Manifest:
 
     def has_lengths(self, name: str) -> bool:
         """Check if a given name has lengths records.
-        
+
         Raise KeyError if the name is not supported.
 
         """
@@ -89,7 +89,6 @@ class Manifest:
             return False
         except KeyError as err:
             raise KeyError(f"There is no length record for {name}") from err
-
 
     def get_lengths(self, name: str) -> Dict[str, Any]:
         """Returns a dict associating IDs with their length from a given file name."""

--- a/src/python/ensembl/io/genomio/manifest/compute_stats.py
+++ b/src/python/ensembl/io/genomio/manifest/compute_stats.py
@@ -70,7 +70,7 @@ class manifest_stats:
         self.manifest = f"{manifest_dir}/manifest.json"
         self.accession: Optional[str] = accession
         self.errors: List[str] = []
-        self.errors_file = f"{manifest_dir}/stats_diff.json"
+        self.errors_file = Path(manifest_dir) / "stats_diff.log"
         if datasets_bin is None:
             datasets_bin = "datasets"
         self.datasets_bin = datasets_bin
@@ -103,7 +103,7 @@ class manifest_stats:
 
         # Die if there were errors in stats comparison
         if self.errors:
-            with open(self.errors_file, "w") as errors_fh:
+            with self.errors_file.open("w") as errors_fh:
                 for error_line in self.errors:
                     errors_fh.write(error_line)
 

--- a/src/python/ensembl/io/genomio/manifest/compute_stats.py
+++ b/src/python/ensembl/io/genomio/manifest/compute_stats.py
@@ -69,7 +69,8 @@ class manifest_stats:
     def __init__(self, manifest_dir: str, accession: Optional[str], datasets_bin: Optional[str]):
         self.manifest = f"{manifest_dir}/manifest.json"
         self.accession: Optional[str] = accession
-        self.error = False
+        self.errors: List[str] = []
+        self.errors_file = f"{manifest_dir}/stats_diff.json"
         if datasets_bin is None:
             datasets_bin = "datasets"
         self.datasets_bin = datasets_bin
@@ -101,8 +102,10 @@ class manifest_stats:
             stats_out.write("\n".join(stats))
 
         # Die if there were errors in stats comparison
-        if self.error:
-            raise StatsError(f"Stats count errors, check the file {stats_path}")
+        if self.errors:
+            with open(self.errors_file, "w") as errors_fh:
+                for error_line in self.errors:
+                    errors_fh.write(error_line)
 
     def get_manifest(self) -> Dict:
         """Get the files metadata from the manifest json file.
@@ -378,8 +381,7 @@ class manifest_stats:
 
             if prep_count != ncbi_count:
                 diff = prep_count - ncbi_count
-                stats.append(f"DIFF gene count for {count_map}: {prep_count} - {ncbi_count} = {diff}")
-                self.error = True
+                self.errors.append(f"DIFF gene count for {count_map}: {prep_count} - {ncbi_count} = {diff}")
             else:
                 stats.append(f"Same count for {count_map}: {prep_count}")
 


### PR DESCRIPTION
Instead of dying when stats do not match, simply create a stats error file that we can easily see after the script (and the prepare genome pipeline) is over.
