### PR TITLE
download_single_file mock suggestion

### DIFF
--- a/src/python/tests/assembly/test_download/test_ftp_file.txt
+++ b/src/python/tests/assembly/test_download/test_ftp_file.txt
@@ -1,0 +1,1 @@
+LoremIpsum


### PR DESCRIPTION
One way I made it work: I mocked `FTP` and replaced its `retrbinary()` method by a function that copies the expected file content