### PR TITLE
Annotation script to update descriptions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,8 @@ genome_stats_dump = "ensembl.io.genomio.genome_stats.dump:main"
 # GFF3
 gff3_extract_annotation = "ensembl.io.genomio.gff3.extract_annotation:main"
 gff3_process = "ensembl.io.genomio.gff3.process:main"
+# annotation
+annotation_load = "ensembl.io.genomio.annotation.load:main"
 # Manifest
 manifest_check_integrity = "ensembl.io.genomio.manifest.check_integrity:main"
 manifest_compute_stats = "ensembl.io.genomio.manifest.compute_stats:main"

--- a/src/python/ensembl/io/genomio/annotation/load.py
+++ b/src/python/ensembl/io/genomio/annotation/load.py
@@ -158,7 +158,7 @@ def _get_features_to_update(
     for new_feat in feat_func:
         # Check we can find that feature in the core db
         try:
-            current_feat = feat_data[new_feat["id"]]
+            cur_feat = feat_data[new_feat["id"]]
         except KeyError:
             logging.debug(f"Not found: {table} '{new_feat['id']}'")
             stats["not_found"] += 1
@@ -167,7 +167,7 @@ def _get_features_to_update(
         # Prepare some data to compare
         new_stable_id = new_feat["id"]
         new_desc = new_feat.get("description")
-        (row_id, cur_stable_id, cur_desc) = current_feat
+        (row_id, cur_stable_id, cur_desc) = cur_feat
 
         # No description: replace unless the current description is from an Xref
         if not cur_desc:

--- a/src/python/ensembl/io/genomio/annotation/load.py
+++ b/src/python/ensembl/io/genomio/annotation/load.py
@@ -58,6 +58,8 @@ def get_core_data(session: Session, table: str) -> Dict[str, Tuple[str, str, str
             .outerjoin(ObjectXref, and_(Transcript.gene_id == ObjectXref.ensembl_id, ObjectXref.ensembl_object_type == "transcript"))
             .outerjoin(Xref)
         )
+    else:
+        raise ValueError(f"Table {table} is not supported")
 
     feat_data = {}
     for row in session.execute(stmt):

--- a/src/python/ensembl/io/genomio/annotation/load.py
+++ b/src/python/ensembl/io/genomio/annotation/load.py
@@ -12,8 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Load functional annotation from a file into a core database.
-"""
+"""Loads functional annotation from a file into a core database."""
 
 import logging
 from pathlib import Path
@@ -36,7 +35,12 @@ FEAT_TABLE = {
 
 
 def get_core_data(session: Session, table: str) -> Dict[str, Tuple[str, str, str]]:
-    """Load descriptions from a core."""
+    """Returns the table descriptions from a core database.
+
+    Args:
+        session: Session open on a core database.
+        table: "Gene" or "Trancript" table from the core database.
+    """
 
     if table == "gene":
         stmt = (
@@ -69,7 +73,14 @@ def get_core_data(session: Session, table: str) -> Dict[str, Tuple[str, str, str
 def load_descriptions(
     session: Session, func_file: Path, report: bool = False, do_update: bool = False
 ) -> None:
-    """Load gene and transcript descriptions in a core database."""
+    """Loads gene and transcript descriptions into a core database.
+
+    Args:
+        session: Session open on a core database.
+        func_file: JSON file with the annotation information.
+        report: Print the mapping of changes to perform in the standard output?
+        do_update: Update core database?
+    """
     func = get_json(func_file)
     logging.info(f"{len(func)} annotations from {func_file}")
     tables_to_lookup = ("gene", "transcript")
@@ -172,7 +183,7 @@ def main() -> None:
     """Main script entry-point."""
     parser = ArgumentParser(description=__doc__)
     parser.add_server_arguments(include_database=True)
-    parser.add_argument_src_path("--func_file", required=True, help="Input Functional annotation json")
+    parser.add_argument_src_path("--func_file", required=True, help="Input functional annotation JSON")
     parser.add_argument("--report", action="store_true", help="Show what change would be made")
     parser.add_argument("--update", action="store_true", help="Make the changes to the database")
     parser.add_log_arguments(add_log_file=True)
@@ -183,6 +194,3 @@ def main() -> None:
     with dbc.session_scope() as session:
         load_descriptions(session, args.func_file, args.report, args.update)
 
-
-if __name__ == "__main__":
-    main()

--- a/src/python/ensembl/io/genomio/annotation/load.py
+++ b/src/python/ensembl/io/genomio/annotation/load.py
@@ -1,0 +1,155 @@
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Load functional annotation from a file into a core database.
+"""
+
+import logging
+from pathlib import Path
+from typing import Dict, Tuple
+
+from ensembl.core.models import Gene, Transcript, ObjectXref, Xref
+from ensembl.database import DBConnection
+from ensembl.io.genomio.utils import get_json
+from ensembl.utils.argparse import ArgumentParser
+from ensembl.utils.logging import init_logging_with_args
+from sqlalchemy.orm import Session
+
+
+FEAT_TABLE = {
+    "gene": "gene",
+    "mobile_element": "gene",
+    "transcript": "transcript",
+}
+
+
+def get_core_data(session: Session, table: str) -> Dict[str, Tuple[str, str, str]]:
+    """Load descriptions from a core."""
+
+    if table == "gene":
+        stmt = (
+            session.query(Gene.gene_id, Gene.stable_id, Gene.description, Xref.dbprimary_acc)
+            .select_from(Gene)
+            .outerjoin(ObjectXref, Gene.gene_id == ObjectXref.ensembl_id)
+            .outerjoin(Xref)
+            .where(ObjectXref.ensembl_object_type == "gene")
+        )
+    elif table == "transcript":
+        stmt = (
+            session.query(Transcript.transcript_id, Transcript.stable_id, Transcript.description, Xref.dbprimary_acc)
+            .select_from(Transcript)
+            .outerjoin(ObjectXref, Transcript.transcript_id == ObjectXref.ensembl_id)
+            .outerjoin(Xref)
+            .where(ObjectXref.ensembl_object_type == "transcript")
+        )
+
+    feat_data = {}
+    for row in session.execute(stmt):
+        (feat_id, stable_id, desc, xref_name) = row
+        feat_struct = (feat_id, stable_id, desc)
+        feat_data[stable_id] = feat_struct
+        if xref_name:
+            feat_data[xref_name] = feat_struct
+    
+    return feat_data
+
+
+def load_descriptions(
+    session: Session, func_file: Path, report: bool = False, do_update: bool = False
+) -> None:
+    """Load gene and transcript descriptions in a core database."""
+    func = get_json(func_file)
+    logging.info(f"{len(func)} annotations from {func_file}")
+    tables_to_lookup = ("gene", "transcript")
+    for table in tables_to_lookup:
+        logging.info(f"Checking {table} descriptions")
+        feat_func = [feat for feat in func if feat["object_type"] == table]
+        logging.info(f"{len(feat_func)} {table} annotations from {func_file}")
+        feat_data = get_core_data(session, table)
+        logging.info(f"Loaded {len(feat_data)} {table} data")
+
+        stats = {
+            "not_supported": 0,
+            "not_found": 0,
+            "differs": 0,
+            "same": 0,
+            "no_new": 0,
+        }
+        # Compare, only keep the descriptions that have changed
+        to_update = []
+        for new_feat in feat_func:
+            if "description" not in new_feat:
+                stats["no_new"] += 1
+                continue
+            try:
+                current_feat = feat_data[new_feat["id"]]
+            except KeyError:
+                logging.debug(f"Not found: {table} '{new_feat['id']}'")
+                stats["not_found"] += 1
+                continue
+
+            new_stable_id = new_feat["id"]
+            new_desc = new_feat["description"]
+            (row_id, cur_stable_id, cur_desc) = current_feat
+            if not cur_desc:
+                cur_desc = ""
+
+            if new_desc == cur_desc:
+                stats["same"] += 1
+                continue
+
+            stats["differs"] += 1
+            if report:
+                line = (table, new_stable_id, cur_stable_id, cur_desc, new_desc)
+                print("\t".join(line))
+            if do_update:
+                update_key = f"{table}_id"
+                to_update.append({update_key: row_id, "description": new_desc})
+
+        # Show stats for this feature type
+        for stat, count in stats.items():
+            if count == 0:
+                continue
+            logging.info(f"{stat} = {count}")
+        
+        if do_update:
+            logging.info(f"Now updating {len(to_update)} rows...")
+            if table == "gene":
+                # session.execute(update(Gene), to_update)
+                session.bulk_update_mappings(Gene, to_update)
+                session.commit()
+            elif table == "transcript":
+                # session.execute(update(Transcript), to_update)
+                session.bulk_update_mappings(Transcript, to_update)
+                session.commit()
+
+
+def main() -> None:
+    """Main script entry-point."""
+    parser = ArgumentParser(description=__doc__)
+    parser.add_server_arguments(include_database=True)
+    parser.add_argument_src_path("--func_file", required=True, help="Input Functional annotation json")
+    parser.add_argument("--report", action="store_true", help="Show what change would be made")
+    parser.add_argument("--update", action="store_true", help="Make the changes to the database")
+    parser.add_log_arguments(add_log_file=True)
+    args = parser.parse_args()
+    init_logging_with_args(args)
+
+    dbc = DBConnection(args.url)
+    with dbc.session_scope() as session:
+        load_descriptions(session, args.func_file, args.report, args.update)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/python/ensembl/io/genomio/annotation/load.py
+++ b/src/python/ensembl/io/genomio/annotation/load.py
@@ -25,6 +25,7 @@ from ensembl.io.genomio.utils import get_json
 from ensembl.utils.argparse import ArgumentParser
 from ensembl.utils.logging import init_logging_with_args
 from sqlalchemy.orm import Session
+from sqlalchemy import and_
 
 
 FEAT_TABLE = {
@@ -41,9 +42,8 @@ def get_core_data(session: Session, table: str) -> Dict[str, Tuple[str, str, str
         stmt = (
             session.query(Gene.gene_id, Gene.stable_id, Gene.description, Xref.dbprimary_acc)
             .select_from(Gene)
-            .outerjoin(ObjectXref, Gene.gene_id == ObjectXref.ensembl_id)
+            .outerjoin(ObjectXref, and_(Gene.gene_id == ObjectXref.ensembl_id, ObjectXref.ensembl_object_type == "gene"))
             .outerjoin(Xref)
-            .where(ObjectXref.ensembl_object_type == "gene")
         )
     elif table == "transcript":
         stmt = (
@@ -51,9 +51,8 @@ def get_core_data(session: Session, table: str) -> Dict[str, Tuple[str, str, str
                 Transcript.transcript_id, Transcript.stable_id, Transcript.description, Xref.dbprimary_acc
             )
             .select_from(Transcript)
-            .outerjoin(ObjectXref, Transcript.transcript_id == ObjectXref.ensembl_id)
+            .outerjoin(ObjectXref, and_(Transcript.gene_id == ObjectXref.ensembl_id, ObjectXref.ensembl_object_type == "transcript"))
             .outerjoin(Xref)
-            .where(ObjectXref.ensembl_object_type == "transcript")
         )
 
     feat_data = {}

--- a/src/python/ensembl/io/genomio/annotation/load.py
+++ b/src/python/ensembl/io/genomio/annotation/load.py
@@ -83,11 +83,11 @@ def load_descriptions(
         stats = {
             "not_supported": 0,
             "not_found": 0,
-            "differs": 0,
             "same": 0,
-            "no_new": 0,
-            "no_new_xref": 0,
-            "no_new_remove": 0,
+            "same_empty": 0,
+            "empty_but_xref": 0,
+            "to_update_replace": 0,
+            "to_update_remove": 0,
         }
         # Compare, only keep the descriptions that have changed
         features_to_update = _get_features_to_update(table, feat_func, feat_data, stats, report, do_update)
@@ -137,18 +137,21 @@ def _get_features_to_update(
         if not cur_desc:
             cur_desc = ""
         if not new_desc:
-            if "[Source:" in cur_desc:
-                stats["no_new_xref"] += 1
+            if cur_desc == "":
+                stats["same_empty"] += 1
                 continue
-            stats["no_new_remove"] += 1
+            if "[Source:" in cur_desc:
+                stats["empty_but_xref"] += 1
+                continue
+            stats["to_update_remove"] += 1
 
         # Compare the descriptions
-        if new_desc == cur_desc:
+        elif new_desc == cur_desc:
             stats["same"] += 1
             continue
-
         # At this point, we have a new description to update
-        stats["differs"] += 1
+        else:
+            stats["to_update_replace"] += 1
 
         # Directly print the mapping
         if report:

--- a/src/python/ensembl/io/genomio/annotation/load.py
+++ b/src/python/ensembl/io/genomio/annotation/load.py
@@ -39,7 +39,7 @@ def get_core_data(session: Session, table: str) -> Dict[str, Tuple[str, str, str
 
     Args:
         session: Session open on a core database.
-        table: "Gene" or "Trancript" table from the core database.
+        table: "gene" or "trancript" table from the core database.
     """
 
     if table == "gene":
@@ -129,6 +129,19 @@ def _get_features_to_update(
     report: bool,
     do_update: bool,
 ) -> List[Dict[str, Any]]:
+    """Checks a list of features and returns those whose description we want to update.
+
+    Args:
+        table: "gene" or "transcript" table for the features.
+        feat_func: The features to check.
+        feat_data: The features in the database.
+        stats: Record the number of features checked in different cases.
+        report: Print a report line for each feature to standard output.
+        do_update: Actually update the database.
+
+    Returns:
+        The list of features with their operation changed to update or insert.
+    """
     to_update = []
     for new_feat in feat_func:
         # Check we can find that feature in the core db


### PR DESCRIPTION
This script is to be used to compare the descriptions between a core database and a functional_annotation.json file generated by the prepare genome pipeline.

If there are differences, they are reported, and the script can do 2 things:
* Write out the differences (basically the stable_id and the different descriptions)
* Update the core database to replace the descriptions

The current implementation can replace descriptions for genes and transcripts.

This can be thought as a basis for a full fledge functional annotation loader (the things missing are basically the xrefs, the translations and the mobile elements).
