### PR TITLE
Fix db_list when not defined

### DIFF
--- a/pipelines/nextflow/modules/database/db_factory.nf
+++ b/pipelines/nextflow/modules/database/db_factory.nf
@@ -30,9 +30,13 @@ process DB_FACTORY {
         dbname_re = filter_map.dbname_re ? "--db_regex $filter_map.dbname_re" : ''
 
         // Prepare db_list to write in a file
-        db_list_str = filter_map.db_list.join("\n")
+        db_list = ""
+        db_list_str = ""
         db_list_file = "db_list.tsv"
-        db_list = filter_map.db_list ? "--db_list $db_list_file" : ''
+        if (filter_map.db_list) {
+            db_list_str = filter_map.db_list.join("\n")
+            db_list = "--db_list $db_list_file"
+        }
         """
         echo "$db_list_str" > $db_list_file
 


### PR DESCRIPTION
Bugfix: the join part fails if no db_list is provided

(part of the dumper pipeline; to reproduce the bug, run the pipeline with no `--db_list` parameter)