### PR TITLE
Set publish dir for addition pipeline too

### DIFF
--- a/pipelines/nextflow/workflows/additional_seq_prepare/main.nf
+++ b/pipelines/nextflow/workflows/additional_seq_prepare/main.nf
@@ -30,7 +30,8 @@ if (params.brc_mode) {
 meta = [
     "accession": params.accession,
     "production_name": params.production_name,
-    "prefix": params.prefix
+    "prefix": params.prefix,
+    "publish_dir": params.accession,
 ]
 
 // Import modules/subworkflows


### PR DESCRIPTION
The `publish_dir` was changed to use an explicit value in the prepare_genome pipeline in a previous PR, but the addition_prepare pipeline that used the same module did not have that changed

(NB: this broke the Nextflow test `test_addition_prepare.yml`, now fixed)
