### PR TITLE
Mbarba/hack/store gene

### DIFF
--- a/src/python/ensembl/io/genomio/gff3/extract_annotation.py
+++ b/src/python/ensembl/io/genomio/gff3/extract_annotation.py
@@ -252,3 +252,18 @@ class FunctionalAnnotations:
         self.transfer_descriptions()
         feats_list = self._to_list()
         print_json(Path(out_path), feats_list)
+
+    def store_gene(self, gene: SeqFeature) -> None:
+        """Record the functional_annotations of a gene and its children features."""
+        self.add_feature(gene, "gene")
+
+        cds_found = False
+        for transcript in gene.sub_features:
+            self.add_feature(transcript, "transcript", gene.id)
+            for feat in transcript.sub_features:
+                if feat.type != "CDS":
+                    continue
+                # Store CDS functional annotation only once
+                if not cds_found:
+                    cds_found = True
+                    self.add_feature(feat, "translation", transcript.id)

--- a/src/python/ensembl/io/genomio/gff3/simplifier.py
+++ b/src/python/ensembl/io/genomio/gff3/simplifier.py
@@ -162,23 +162,8 @@ class GFFSimplifier:
 
         # Normalize, store annotation, and return the cleaned up gene
         gene = self.normalize_gene(gene)
-        self.store_gene_annotations(gene)
+        self.annotations.store_gene(gene)
         return self.clean_gene(gene)
-
-    def store_gene_annotations(self, gene: SeqFeature) -> None:
-        """Record the functional_annotations of the gene and its children features."""
-        self.annotations.add_feature(gene, "gene")
-
-        cds_found = False
-        for transcript in gene.sub_features:
-            self.annotations.add_feature(transcript, "transcript", gene.id)
-            for feat in transcript.sub_features:
-                if feat.type != "CDS":
-                    continue
-                # Store CDS functional annotation only once
-                if not cds_found:
-                    cds_found = True
-                    self.annotations.add_feature(feat, "translation", transcript.id)
 
     def clean_gene(self, gene: SeqFeature) -> SeqFeature:
         """Return the same gene without qualifiers unrelated to the gene structure."""

--- a/src/python/tests/gff3/test_extract_annotation.py
+++ b/src/python/tests/gff3/test_extract_annotation.py
@@ -292,13 +292,14 @@ def test_transfer_descriptions(
 
 @pytest.mark.dependency(depends=["add_feature"])
 @pytest.mark.parametrize(
-    "with_cds, num_genes, num_tr, num_cds",
+    "cds_parts, num_genes, num_tr, num_cds",
     [
-        pytest.param(False, 1, 1, 0, id="Store gene without CDS"),
-        pytest.param(True, 1, 1, 1, id="Store gene with CDS"),
+        pytest.param(0, 1, 1, 0, id="Store gene without CDS"),
+        pytest.param(1, 1, 1, 1, id="Store gene with CDS in one part"),
+        pytest.param(2, 1, 1, 1, id="Store gene with CDS in 2 parts"),
     ],
 )
-def test_store_gene(with_cds: bool, num_genes: int, num_tr: int, num_cds: int) -> None:
+def test_store_gene(cds_parts: int, num_genes: int, num_tr: int, num_cds: int) -> None:
     """Test store_gene given a gene Feature with transcripts and optional translations.
     ."""
     annot = FunctionalAnnotations()
@@ -308,9 +309,17 @@ def test_store_gene(with_cds: bool, num_genes: int, num_tr: int, num_cds: int) -
     one_gene.sub_features = []
     one_transcript = SeqFeature(type="mRNA", id=transcript_name)
     one_transcript.sub_features = []
-    if with_cds:
-        one_translation = SeqFeature(type="CDS", id="cds_A")
-        one_transcript.sub_features.append(one_translation)
+
+    # Add one exon
+    one_exon = SeqFeature(type="exon", id="exon_A")
+    one_transcript.sub_features.append(one_exon)
+
+    # Add a translation (possibly in parts)
+    if cds_parts > 0:
+        for _ in range(1, cds_parts + 1):
+            one_translation = SeqFeature(type="CDS", id="cds_A")
+            one_transcript.sub_features.append(one_translation)
+
     one_gene.sub_features.append(one_transcript)
 
     annot.store_gene(one_gene)

--- a/src/python/tests/gff3/test_extract_annotation.py
+++ b/src/python/tests/gff3/test_extract_annotation.py
@@ -300,8 +300,14 @@ def test_transfer_descriptions(
     ],
 )
 def test_store_gene(cds_parts: int, num_genes: int, num_tr: int, num_cds: int) -> None:
-    """Test store_gene given a gene Feature with transcripts and optional translations.
-    ."""
+    """Test store_gene given a gene Feature with a transcript and optional translation.
+
+    Args:
+        cds_parts: Number of parts of the one CDS (0 means no CDS)
+        num_genes: Number of genes stored as expected
+        num_tr: Number of transcripts stored as expected
+        num_cds: Number of CDSs stored as expected
+    """
     annot = FunctionalAnnotations()
     gene_name = "gene_A"
     transcript_name = "tran_A"

--- a/src/python/tests/gff3/test_extract_annotation.py
+++ b/src/python/tests/gff3/test_extract_annotation.py
@@ -288,3 +288,32 @@ def test_transfer_descriptions(
     transcs = annot.get_features("transcript")
     assert genes[gene_name].get("description") == out_gene_desc
     assert transcs[transcript_name].get("description") == out_transc_desc
+
+
+@pytest.mark.dependency(depends=["add_feature"])
+@pytest.mark.parametrize(
+    "with_cds, num_genes, num_tr, num_cds",
+    [
+        pytest.param(False, 1, 1, 0, id="Store gene without CDS"),
+        pytest.param(True, 1, 1, 1, id="Store gene with CDS"),
+    ],
+)
+def test_store_gene(with_cds: bool, num_genes: int, num_tr: int, num_cds: int) -> None:
+    """Test store_gene given a gene Feature with transcripts and optional translations.
+    ."""
+    annot = FunctionalAnnotations()
+    gene_name = "gene_A"
+    transcript_name = "tran_A"
+    one_gene = SeqFeature(type="gene", id=gene_name)
+    one_gene.sub_features = []
+    one_transcript = SeqFeature(type="mRNA", id=transcript_name)
+    one_transcript.sub_features = []
+    if with_cds:
+        one_translation = SeqFeature(type="CDS", id="cds_A")
+        one_transcript.sub_features.append(one_translation)
+    one_gene.sub_features.append(one_transcript)
+
+    annot.store_gene(one_gene)
+    assert len(annot.features["gene"]) == num_genes
+    assert len(annot.features["transcript"]) == num_tr
+    assert len(annot.features["translation"]) == num_cds


### PR DESCRIPTION
Move the `store_gene_annotations` to the annotation module and add tests.

NB: one thing to note is that we have to add the `sub_features` list attrib to the SeqFeatures as those are no longer created by Biopython 1.81+. This attrib is instead added by `bcbio-gff` (cf [this part of its code](https://github.com/chapmanb/bcbb/blob/9c6d83ee3f0491f647a9ecd5947b13c99b478f26/gff/BCBio/GFF/GFFParser.py#L591-L593))
