### PR TITLE
Add unit test for ensembl.io.genomio.genome_metadata.dump module

### DIFF
--- a/src/python/ensembl/io/genomio/data/schemas/genome.json
+++ b/src/python/ensembl/io/genomio/data/schemas/genome.json
@@ -25,7 +25,7 @@
       },
       "required": [
         "taxonomy_id"
-        ]
+      ]
     },
     "assembly_info": {
       "type": "object",
@@ -73,7 +73,7 @@
       },
       "required": [
         "version"
-        ]
+      ]
     },
     "provider_info": {
       "description" : "legacy. use (annotation|assembly).provider_(name|url) instead",
@@ -85,7 +85,7 @@
       },
       "required": [
         "name"
-        ]
+      ]
     },
     "BRC4_info": {
       "type": "object",
@@ -97,7 +97,7 @@
       "required": [
         "component",
         "organism_abbrev"
-        ]
+      ]
     },
     "added_sequence_info" : {
       "type": "object",
@@ -128,7 +128,7 @@
       "required" : [
         "species",
         "assembly"
-        ]
+      ]
     }
   },
 

--- a/src/python/ensembl/io/genomio/genome_metadata/dump.py
+++ b/src/python/ensembl/io/genomio/genome_metadata/dump.py
@@ -14,7 +14,12 @@
 # limitations under the License.
 """Generates a JSON file representing the genome metadata from a core database."""
 
-__all__ = ["get_genome_metadata", "filter_genome_meta", "check_assembly_version"]
+__all__ = [
+    "get_genome_metadata",
+    "filter_genome_meta",
+    "check_assembly_version",
+    "check_genebuild_version",
+]
 
 import json
 from typing import Any, Dict

--- a/src/python/ensembl/io/genomio/genome_metadata/dump.py
+++ b/src/python/ensembl/io/genomio/genome_metadata/dump.py
@@ -195,7 +195,3 @@ def main() -> None:
         genome_meta = filter_genome_meta(genome_meta)
 
     print(json.dumps(genome_meta, indent=2, sort_keys=True))
-
-
-if __name__ == "__main__":
-    main()

--- a/src/python/ensembl/io/genomio/genome_metadata/dump.py
+++ b/src/python/ensembl/io/genomio/genome_metadata/dump.py
@@ -172,6 +172,7 @@ def check_genebuild_version(genome_metadata: Dict[str, Any]) -> None:
         try:
             genebuild_id = genebuild["id"]
         except KeyError:
+            # pylint: disable=raise-missing-from
             raise ValueError("No genebuild version or ID found")
         genome_metadata["genebuild"]["version"] = str(genebuild_id)
     # Drop genebuild ID since there is a genebuild version

--- a/src/python/ensembl/io/genomio/genome_metadata/dump.py
+++ b/src/python/ensembl/io/genomio/genome_metadata/dump.py
@@ -22,7 +22,7 @@ __all__ = [
 ]
 
 import json
-from typing import Any, Dict
+from typing import Any, Dict, Type
 import logging
 
 from sqlalchemy import select
@@ -34,7 +34,7 @@ from ensembl.utils.argparse import ArgumentParser
 from ensembl.utils.logging import init_logging_with_args
 
 
-METADATA_FILTER = {
+METADATA_FILTER: Dict[str, Dict[str, Type]] = {
     "added_seq": {"region_name": str},
     "annotation": {"provider_name": str, "provider_url": str},
     "assembly": {

--- a/src/python/tests/genome_metadata/test_dump.py
+++ b/src/python/tests/genome_metadata/test_dump.py
@@ -20,7 +20,7 @@ Typical usage example::
 """
 
 from contextlib import nullcontext as does_not_raise
-from typing import Any, ContextManager, Dict
+from typing import Any, ContextManager, Dict, Optional
 from unittest.mock import Mock, patch
 
 from deepdiff import DeepDiff
@@ -34,45 +34,40 @@ from ensembl.io.genomio.genome_metadata import dump
 @pytest.mark.parametrize(
     "genome_metadata, output, expectation",
     [
-        param(
-            {"assembly": {"version": "1"}},
-            {"assembly": {"version": 1}},
-            does_not_raise(),
-            id="Version is '1'",
-        ),
+        param({"assembly": {"version": "1"}}, 1, does_not_raise(), id="Version is '1'"),
         param(
             {"assembly": {"accession": "GCA_00000001.1", "version": "a"}},
-            {"assembly": {"accession": "GCA_00000001.1", "version": 1}},
+            1,
             does_not_raise(),
-            id="Version is 'a', accession is '1'",
+            id="Version is 'a', accession's version is 1",
         ),
         param(
             {"assembly": {"accession": "GCA_00000001.1"}},
-            {"assembly": {"accession": "GCA_00000001.1", "version": 1}},
+            1,
             does_not_raise(),
-            id="No version, accession with version",
+            id="No version, accession's version is 1",
         ),
         param(
             {"assembly": {"accession": "GCA_00000001"}},
-            {},
+            0,
             pytest.raises(ValueError),
             id="No version, accession without version",
         ),
     ],
 )
 def test_check_assembly_version(
-    genome_metadata: Dict[str, Any], output: Dict[str, Any], expectation: ContextManager
+    genome_metadata: Dict[str, Any], output: int, expectation: ContextManager
 ) -> None:
     """Tests the `dump.check_assembly_version()` method.
 
     Args:
         genome_metadata: Nested genome metadata key values.
-        output: Expected change in the genome metadata dictionary.
+        output: Expected assembly version.
         expectation: Context manager for the expected exception (if any).
     """
     with expectation:
         dump.check_assembly_version(genome_metadata)
-        assert not DeepDiff(genome_metadata, output)
+        assert genome_metadata["assembly"]["version"] == output
 
 
 @pytest.mark.dependency(name="test_check_genebuild_version")

--- a/src/python/tests/genome_metadata/test_dump.py
+++ b/src/python/tests/genome_metadata/test_dump.py
@@ -26,7 +26,6 @@ from unittest.mock import Mock, patch
 
 from deepdiff import DeepDiff
 import pytest
-from pytest import param
 
 from ensembl.io.genomio.genome_metadata import dump
 
@@ -37,20 +36,20 @@ MetaRow = namedtuple("MetaRow", "meta_key meta_value")
 @pytest.mark.parametrize(
     "genome_metadata, output, expectation",
     [
-        param({"assembly": {"version": "1"}}, 1, does_not_raise(), id="Version is '1'"),
-        param(
+        pytest.param({"assembly": {"version": "1"}}, 1, does_not_raise(), id="Version is '1'"),
+        pytest.param(
             {"assembly": {"accession": "GCA_00000001.1", "version": "a"}},
             1,
             does_not_raise(),
             id="Version is 'a', accession's version is 1",
         ),
-        param(
+        pytest.param(
             {"assembly": {"accession": "GCA_00000001.1"}},
             1,
             does_not_raise(),
             id="No version, accession's version is 1",
         ),
-        param(
+        pytest.param(
             {"assembly": {"accession": "GCA_00000001"}},
             0,
             pytest.raises(ValueError),
@@ -76,26 +75,26 @@ def test_check_assembly_version(
 @pytest.mark.parametrize(
     "genome_metadata, output, expectation",
     [
-        param({}, {}, does_not_raise(), id="No 'genebuild' entry"),
-        param(
+        pytest.param({}, {}, does_not_raise(), id="No 'genebuild' entry"),
+        pytest.param(
             {"genebuild": {"version": "v1"}},
             {"genebuild": {"version": "v1"}},
             does_not_raise(),
             id="Version is 'v1', no ID",
         ),
-        param(
+        pytest.param(
             {"genebuild": {"version": "v1", "id": "v1"}},
             {"genebuild": {"version": "v1"}},
             does_not_raise(),
             id="Version is 'v1', ID dropped",
         ),
-        param(
+        pytest.param(
             {"genebuild": {"id": "v1"}},
             {"genebuild": {"version": "v1"}},
             does_not_raise(),
             id="No version, ID moved to version",
         ),
-        param({"genebuild": {}}, {}, pytest.raises(ValueError), id="No version or ID"),
+        pytest.param({"genebuild": {}}, {}, pytest.raises(ValueError), id="No version or ID"),
     ],
 )
 def test_check_genebuild_version(
@@ -142,29 +141,29 @@ def test_filter_genome_meta(genome_metadata: Dict[str, Any], output: Dict[str, A
 @pytest.mark.parametrize(
     "meta_data, output, expectation",
     [
-        param([], {}, does_not_raise(), id="Empty meta table"),
-        param(
+        pytest.param([], {}, does_not_raise(), id="Empty meta table"),
+        pytest.param(
             [
                 [MetaRow("sample", "gene1")],
                 [MetaRow("species.name", "dog")],
-                [MetaRow("species.synonym", "puppy")]
+                [MetaRow("species.synonym", "puppy")],
             ],
             {"sample": "gene1", "species": {"name": "dog", "synonym": "puppy"}},
             does_not_raise(),
             id="Meta table with simple values",
         ),
-        param(
+        pytest.param(
             [
                 [MetaRow("sample", "gene1")],
                 [MetaRow("sample", "gene2")],
                 [MetaRow("species.synonym", "dog")],
-                [MetaRow("species.synonym", "puppy")]
+                [MetaRow("species.synonym", "puppy")],
             ],
             {"sample": ["gene1", "gene2"], "species": {"synonym": ["dog", "puppy"]}},
             does_not_raise(),
             id="Meta table with lists",
         ),
-        param(
+        pytest.param(
             [[MetaRow("species", "dog")], [MetaRow("species.synonym", "puppy")]],
             {},
             pytest.raises(ValueError),

--- a/src/python/tests/genome_metadata/test_dump.py
+++ b/src/python/tests/genome_metadata/test_dump.py
@@ -137,8 +137,8 @@ def test_filter_genome_meta(genome_metadata: Dict[str, Any], output: Dict[str, A
     assert not DeepDiff(result, output)
 
 
-@patch("sqlalchemy.orm.Session")
 @patch("sqlalchemy.engine.Result")
+@patch("sqlalchemy.orm.Session")
 @pytest.mark.parametrize(
     "meta_data, output, expectation",
     [

--- a/src/python/tests/genome_metadata/test_dump.py
+++ b/src/python/tests/genome_metadata/test_dump.py
@@ -20,7 +20,7 @@ Typical usage example::
 """
 
 from contextlib import nullcontext as does_not_raise
-from typing import Any, ContextManager, Dict, Optional
+from typing import Any, ContextManager, Dict
 from unittest.mock import Mock, patch
 
 from deepdiff import DeepDiff

--- a/src/python/tests/genome_metadata/test_dump.py
+++ b/src/python/tests/genome_metadata/test_dump.py
@@ -113,8 +113,8 @@ def test_check_genebuild_version(
         assert not DeepDiff(genome_metadata, output)
 
 
-@patch("ensembl.io.genomio.genome_metadata.dump.check_assembly_version")
-@patch("ensembl.io.genomio.genome_metadata.dump.check_genebuild_version")
+@patch("ensembl.io.genomio.genome_metadata.dump.check_genebuild_version", Mock())
+@patch("ensembl.io.genomio.genome_metadata.dump.check_assembly_version", Mock())
 @pytest.mark.parametrize(
     "genome_metadata, output",
     [
@@ -126,22 +126,13 @@ def test_check_genebuild_version(
         ({"added_seq": {"region_name": [1, 2]}}, {"added_seq": {"region_name": ["1", "2"]}}),
     ],
 )
-def test_filter_genome_meta(
-    mock_check_assembly_version: Mock,
-    mock_check_genebuild_version: Mock,
-    genome_metadata: Dict[str, Any],
-    output: Dict[str, Any],
-) -> None:
+def test_filter_genome_meta(genome_metadata: Dict[str, Any], output: Dict[str, Any]) -> None:
     """Tests the `dump.check_genebuild_version()` method.
 
     Args:
-        mock_check_assembly_version: A mock of `dump.check_assembly_version()` method.
-        mock_check_genebuild_version: A mock of `dump.check_genebuild_version()` method.
         genome_metadata: Nested genome metadata key values.
         output: Expected change in the genome metadata dictionary.
     """
-    mock_check_assembly_version.return_value = None
-    mock_check_genebuild_version.return_value = None
     result = dump.filter_genome_meta(genome_metadata)
     assert not DeepDiff(result, output)
 

--- a/src/python/tests/genome_metadata/test_dump.py
+++ b/src/python/tests/genome_metadata/test_dump.py
@@ -1,0 +1,117 @@
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit testing of `ensembl.io.genomio.genome_metadata.dump` module.
+
+Typical usage example::
+    $ pytest test_dump.py
+
+"""
+
+from contextlib import nullcontext as does_not_raise
+from typing import Any, ContextManager, Dict
+
+from deepdiff import DeepDiff
+import pytest
+from pytest import param
+
+from ensembl.io.genomio.genome_metadata import dump
+
+
+@pytest.mark.dependency(name="test_check_assembly_version")
+@pytest.mark.parametrize(
+    "genome_metadata, output, expectation",
+    [
+        param(
+            {"assembly": {"version": "1"}},
+            {"assembly": {"version": 1}},
+            does_not_raise(),
+            id="Version is '1'"
+        ),
+        param(
+            {"assembly": {"accession": "GCA_00000001.1", "version": "a"}},
+            {"assembly": {"accession": "GCA_00000001.1", "version": 1}},
+            does_not_raise(),
+            id="Version is 'a', accession is '1'",
+        ),
+        param(
+            {"assembly": {"accession": "GCA_00000001.1"}},
+            {"assembly": {"accession": "GCA_00000001.1", "version": 1}},
+            does_not_raise(),
+            id="No version, accession with version",
+        ),
+        param(
+            {"assembly": {"accession": "GCA_00000001"}},
+            {},
+            pytest.raises(ValueError),
+            id="No version, accession without version",
+        ),
+    ],
+)
+def test_check_assembly_version(
+    genome_metadata: Dict[str, Any], output: Dict[str, Any], expectation: ContextManager
+) -> None:
+    """Tests the `dump.check_assembly_version()` method.
+
+    Args:
+        genome_metadata: Nested metadata key values from the core metadata table.
+        output: Expected change in the genome metadata dictionary.
+        expectation: Context manager for the expected exception, i.e. the test will only pass if that
+            exception is raised. Use `~contextlib.nullcontext` if no exception is expected.
+    """
+    with expectation:
+        dump.check_assembly_version(genome_metadata)
+        assert not DeepDiff(genome_metadata, output)
+
+
+@pytest.mark.dependency(name="test_check_genebuild_version")
+@pytest.mark.parametrize(
+    "genome_metadata, output, expectation",
+    [
+        param({}, {}, does_not_raise(), id="No 'genebuild' entry"),
+        param(
+            {"genebuild": {"version": "v1"}},
+            {"genebuild": {"version": "v1"}},
+            does_not_raise(),
+            id="Version is 'v1', no ID",
+        ),
+        param(
+            {"genebuild": {"version": "v1", "id": "v1"}},
+            {"genebuild": {"version": "v1"}},
+            does_not_raise(),
+            id="Version is 'v1', ID dropped",
+        ),
+        param(
+            {"genebuild": {"id": "v1"}},
+            {"genebuild": {"version": "v1"}},
+            does_not_raise(),
+            id="No version, ID moved to version",
+        ),
+        param({"genebuild": {}}, {}, pytest.raises(ValueError), id="No version or ID"),
+    ],
+)
+def test_check_genebuild_version(
+    genome_metadata: Dict[str, Any], output: Dict[str, Any], expectation: ContextManager
+) -> None:
+    """Tests the `dump.check_genebuild_version()` method.
+
+    Args:
+        genome_metadata: Nested metadata key values from the core metadata table.
+        output: Expected change in the genome metadata dictionary.
+        expectation: Context manager for the expected exception, i.e. the test will only pass if that
+            exception is raised. Use `~contextlib.nullcontext` if no exception is expected.
+    """
+    with expectation:
+        dump.check_genebuild_version(genome_metadata)
+        assert not DeepDiff(genome_metadata, output)

--- a/src/python/tests/genome_metadata/test_dump.py
+++ b/src/python/tests/genome_metadata/test_dump.py
@@ -37,7 +37,7 @@ from ensembl.io.genomio.genome_metadata import dump
             {"assembly": {"version": "1"}},
             {"assembly": {"version": 1}},
             does_not_raise(),
-            id="Version is '1'"
+            id="Version is '1'",
         ),
         param(
             {"assembly": {"accession": "GCA_00000001.1", "version": "a"}},

--- a/src/python/tests/genome_metadata/test_dump.py
+++ b/src/python/tests/genome_metadata/test_dump.py
@@ -67,8 +67,7 @@ def test_check_assembly_version(
     Args:
         genome_metadata: Nested metadata key values from the core metadata table.
         output: Expected change in the genome metadata dictionary.
-        expectation: Context manager for the expected exception, i.e. the test will only pass if that
-            exception is raised. Use `~contextlib.nullcontext` if no exception is expected.
+        expectation: Context manager for the expected exception (if any).
     """
     with expectation:
         dump.check_assembly_version(genome_metadata)
@@ -109,8 +108,7 @@ def test_check_genebuild_version(
     Args:
         genome_metadata: Nested metadata key values from the core metadata table.
         output: Expected change in the genome metadata dictionary.
-        expectation: Context manager for the expected exception, i.e. the test will only pass if that
-            exception is raised. Use `~contextlib.nullcontext` if no exception is expected.
+        expectation: Context manager for the expected exception (if any).
     """
     with expectation:
         dump.check_genebuild_version(genome_metadata)

--- a/src/python/tests/genome_metadata/test_dump.py
+++ b/src/python/tests/genome_metadata/test_dump.py
@@ -66,7 +66,7 @@ def test_check_assembly_version(
     """Tests the `dump.check_assembly_version()` method.
 
     Args:
-        genome_metadata: Nested metadata key values from the core metadata table.
+        genome_metadata: Nested genome metadata key values.
         output: Expected change in the genome metadata dictionary.
         expectation: Context manager for the expected exception (if any).
     """


### PR DESCRIPTION
Updated all methods (review docstrings, improve readability and reduce code complexity) and added unit tests for all of them.

In the case of `get_genome_metadata()` the rework whilst may not be as efficient as the previous code, I believe it is more readable and allows for further meta table checks in case the data found there does not match the expected format, e.g. is `species` meta key always has a subkey but there is an entry without, a `ValueError` is raised.

Added to `__all__` one of the functions that was missing.