### PR TITLE
Add mocks for pipeline tests

### DIFF
--- a/pipelines/nextflow/modules/genome_metadata/prepare_genome_metadata.nf
+++ b/pipelines/nextflow/modules/genome_metadata/prepare_genome_metadata.nf
@@ -27,4 +27,10 @@ process PREPARE_GENOME_METADATA {
     '''
     genome_metadata_prepare --input_file !{input_json} --output_file !{output_json}
     '''
+    
+    stub:
+    output_json = "genome.json"
+    """
+    genome_metadata_prepare --input_file $input_json --output_file $output_json --mock_run
+    """
 }

--- a/pipelines/nextflow/modules/genome_metadata/prepare_genome_metadata.nf
+++ b/pipelines/nextflow/modules/genome_metadata/prepare_genome_metadata.nf
@@ -29,8 +29,8 @@ process PREPARE_GENOME_METADATA {
     '''
     
     stub:
-    output_json = "genome.json"
-    """
-    genome_metadata_prepare --input_file $input_json --output_file $output_json --mock_run
-    """
+        output_json = "genome.json"
+        """
+        genome_metadata_prepare --input_file $input_json --output_file $output_json --mock_run
+        """
 }

--- a/pipelines/nextflow/modules/seq_region/process_seq_region.nf
+++ b/pipelines/nextflow/modules/seq_region/process_seq_region.nf
@@ -40,4 +40,17 @@ process PROCESS_SEQ_REGION {
         
         schemas_json_validate --json_file !{output} --json_schema seq_region
         '''
+    
+    stub:
+        brc_mode = params.brc_mode ? '--brc_mode' : ''
+        output = "seq_region.json"
+        """
+        seq_region_prepare \
+            --genome_file $genome_json \
+            --report_file $assembly_report \
+            --gbff_file $genomic_gbff \
+            --dst_file $output \
+            --mock_run \
+            $brc_mode \
+        """
 }

--- a/pipelines/nextflow/tests/workflows/test_genome_prepare_brc_mode_off.yml
+++ b/pipelines/nextflow/tests/workflows/test_genome_prepare_brc_mode_off.yml
@@ -47,5 +47,5 @@
     # Manifest depends on the genome checksum, so also date dependent
     - path: ./test_genome_prepare_output/GCA_017607445.1/manifest.json
     - path: ./test_genome_prepare_output/GCA_017607445.1/seq_region.json
-      md5sum: ce512a675c09065fe3c7c2e9de1ffa30
+      md5sum: 28518b0c7cbc19a2890a6b347367a82f
     - path: ./test_genome_prepare_output/GCA_017607445.1/stats.txt

--- a/pipelines/nextflow/tests/workflows/test_genome_prepare_brc_mode_on.yml
+++ b/pipelines/nextflow/tests/workflows/test_genome_prepare_brc_mode_on.yml
@@ -46,5 +46,5 @@
     # Manifest depends on the genome checksum, so also date dependent
     - path: ./test_genome_prepare_output/OrganismDB/organAbrev123/manifest.json
     - path: ./test_genome_prepare_output/OrganismDB/organAbrev123/seq_region.json
-      md5sum: 585da9f97f094e83702860ce43da652f
+      md5sum: 96038c0cdbebd57d07b0da4c8977af38
     - path: ./test_genome_prepare_output/OrganismDB/organAbrev123/stats.txt

--- a/src/python/ensembl/io/genomio/genome_metadata/prepare.py
+++ b/src/python/ensembl/io/genomio/genome_metadata/prepare.py
@@ -184,6 +184,7 @@ def get_taxonomy_from_accession(accession: str, base_api_url: str = DEFAULT_API_
     # Use the GenBank accession without version
     gb_accession = accession.replace("GCF", "GCA").split(".")[0]
     response = requests.get(f"{base_api_url}/{gb_accession}", timeout=60)
+    response.raise_for_status()
     entry = ElementTree.fromstring(response.text)
 
     taxon_node = entry.find(".//TAXON")
@@ -232,6 +233,7 @@ def prepare_genome_metadata(
     output_file: PathLike,
     gff3_file: Optional[PathLike] = None,
     base_api_url: str = DEFAULT_API_URL,
+    mock_run: bool = True,
 ) -> None:
     """Updates the genome metadata JSON file with additional information.
 
@@ -243,6 +245,7 @@ def prepare_genome_metadata(
         output_file: Output directory where to generate the final `genome.json` file.
         gff3_file: Path to GFF3 file to use as annotation source for this genome.
         base_api_url: Base API URL to fetch the taxonomy data from.
+        mock_run: Do not call external taxonomy service.
 
     """
     genome_data = get_json(input_file)
@@ -250,7 +253,11 @@ def prepare_genome_metadata(
     add_provider(genome_data, gff3_file)
     add_assembly_version(genome_data)
     add_genebuild_metadata(genome_data)
-    add_species_metadata(genome_data, base_api_url)
+    if mock_run:
+        if not "taxonomy_id" in genome_data["species"]:
+            genome_data["species"]["taxonomy_id"] = 9999999
+    else:
+        add_species_metadata(genome_data, base_api_url)
     # Dump updated genome metadata
     print_json(output_file, genome_data)
 
@@ -271,6 +278,7 @@ def main() -> None:
     parser.add_argument(
         "--base_api_url", default=DEFAULT_API_URL, help="API URL to fetch the taxonomy data from"
     )
+    parser.add_argument("--mock_run", action="store_true", help="Do not call external APIs")
     parser.add_log_arguments()
     args = parser.parse_args()
     init_logging_with_args(args)
@@ -280,4 +288,5 @@ def main() -> None:
         output_file=args.output_file,
         gff3_file=args.gff3_file,
         base_api_url=args.base_api_url,
+        mock_run=args.mock_run,
     )

--- a/src/python/ensembl/io/genomio/genome_metadata/prepare.py
+++ b/src/python/ensembl/io/genomio/genome_metadata/prepare.py
@@ -233,7 +233,7 @@ def prepare_genome_metadata(
     output_file: PathLike,
     gff3_file: Optional[PathLike] = None,
     base_api_url: str = DEFAULT_API_URL,
-    mock_run: bool = True,
+    mock_run: bool = False,
 ) -> None:
     """Updates the genome metadata JSON file with additional information.
 
@@ -254,8 +254,7 @@ def prepare_genome_metadata(
     add_assembly_version(genome_data)
     add_genebuild_metadata(genome_data)
     if mock_run:
-        if not "taxonomy_id" in genome_data["species"]:
-            genome_data["species"]["taxonomy_id"] = 9999999
+        genome_data["species"].setdefault("taxonomy_id", 9999999)
     else:
         add_species_metadata(genome_data, base_api_url)
     # Dump updated genome metadata

--- a/src/python/ensembl/io/genomio/seq_region/prepare.py
+++ b/src/python/ensembl/io/genomio/seq_region/prepare.py
@@ -441,6 +441,7 @@ def prepare_seq_region_metadata(
     gbff_file: Optional[PathLike] = None,
     brc_mode: bool = False,
     to_exclude: Optional[List[str]] = None,
+    mock_run: bool = False,
 ) -> None:
     """Prepares the sequence region metadata found in the INSDC/RefSeq report and GBFF files.
 
@@ -455,6 +456,7 @@ def prepare_seq_region_metadata(
         dst_file: JSON file output for the processed sequence regions JSON.
         brc_mode: Include INSDC sequence region names.
         to_exclude: Sequence region names to exclude.
+        mock_run: Do not call external taxonomy service.
 
     """
     genome_data = get_json(genome_file)
@@ -479,7 +481,8 @@ def prepare_seq_region_metadata(
 
     # Add translation and mitochondrial codon tables
     add_translation_table(seq_regions)
-    add_mitochondrial_codon_table(seq_regions, genome_data["species"]["taxonomy_id"])
+    if not mock_run:
+        add_mitochondrial_codon_table(seq_regions, genome_data["species"]["taxonomy_id"])
 
     # Print out the file
     print_json(dst_file, seq_regions)
@@ -500,6 +503,7 @@ def main() -> None:
     parser.add_argument(
         "--to_exclude", nargs="*", metavar="SEQ_REGION_NAME", help="Sequence region names to exclude"
     )
+    parser.add_argument("--mock_run", action="store_true", help="Do not call external APIs")
     parser.add_log_arguments()
     args = parser.parse_args()
     init_logging_with_args(args)
@@ -511,4 +515,5 @@ def main() -> None:
         gbff_file=args.gbff_file,
         brc_mode=args.brc_mode,
         to_exclude=args.to_exclude,
+        mock_run=args.mock_run,
     )


### PR DESCRIPTION
When some external services are done, some parts of the pipeline may fail (`genome_metadata` and `seq_region` prepare in particular). We'd also prefer not to query those services when we run a mock pipeline.

This PR adds a `--mock_run` option to 2 prepare scripts that query ENA, and use it in `stub` commands for the corresponding nextflow modules. Because the output differs in the end, I've also updated the final md5sum for the seq region file.
