### PR TITLE
Mbarba/lcampbell hack

### DIFF
--- a/src/python/ensembl/io/genomio/assembly/download.py
+++ b/src/python/ensembl/io/genomio/assembly/download.py
@@ -186,7 +186,7 @@ def download_files(ftp_connection: FTP, accession: str, dl_dir: Path, max_redo: 
                         _download_file(ftp_connection, ftp_file, md5_sums, dl_dir, max_redo)
         else:
             logging.warning(
-                f"Could not detect accession '{accession}' from ftp download dir path {ftp_dir} in open FTP connection"
+                f"Could not find accession '{accession}' from ftp {ftp_dir} in open FTP connection"
             )
 
 

--- a/src/python/ensembl/io/genomio/assembly/download.py
+++ b/src/python/ensembl/io/genomio/assembly/download.py
@@ -29,7 +29,6 @@ __all__ = [
 
 from ftplib import FTP
 import hashlib
-from importlib import reload
 import logging
 from os import PathLike
 from pathlib import Path
@@ -315,13 +314,6 @@ def retrieve_assembly_data(
         None
     """
     download_dir = Path(download_dir)
-
-    # Configure logging
-    log_file = f"{accession}_download.log"
-    reload(logging)
-    logging.basicConfig(
-        filename=log_file, format="%(levelname)s:%(message)s", filemode="w", level=logging.DEBUG
-    )
 
     # Set and create dedicated dir for download
     if not download_dir.is_dir():

--- a/src/python/ensembl/io/genomio/assembly/download.py
+++ b/src/python/ensembl/io/genomio/assembly/download.py
@@ -82,12 +82,9 @@ def establish_ftp(ftp_conn: FTP, ftp_url: str, accession: str) -> FTP:
     sub_dir = Path("genomes", "all", gca, part1, part2, part3)
 
     # Try now to establish connection to remote FTP server
-    try:
-        ftp_conn.connect(ftp_url)
-        ftp_conn.login()
-        ftp_conn.cwd(str(sub_dir))
-    except:
-        raise FTPConnectionError(f"Could not create FTP connection on {ftp_url} remote path {sub_dir}")
+    ftp_conn.connect(ftp_url)
+    ftp_conn.login()
+    ftp_conn.cwd(str(sub_dir))
 
     return ftp_conn
 

--- a/src/python/ensembl/io/genomio/assembly/download.py
+++ b/src/python/ensembl/io/genomio/assembly/download.py
@@ -35,7 +35,7 @@ from os import PathLike
 from pathlib import Path
 import re
 import time
-from typing import Dict
+from typing import Dict, Optional
 
 from ensembl.utils.argparse import ArgumentParser
 from ensembl.utils.logging import init_logging_with_args
@@ -93,26 +93,24 @@ def establish_ftp(ftp_conn: FTP, ftp_url: str, accession: str) -> FTP:
     return ftp_conn
 
 
-def md5_files(dl_dir: Path, md5: Path) -> bool:
+def md5_files(dl_dir: Path, md5_path: Optional[Path] = None, md5_filename: str = "md5checksums.txt") -> bool:
     """
     Check all files checksums with the sums listed in a checksum file, if available.
     Return False if there is no checksum file, or a file is missing, or has a wrong checksum.
 
     Args:
         dl_dir: Path location to containing downloaded FTP files.
-        md5: Path location of checksum file
+        md5_path: Full path to an md5 checksum file.
+        md5_filename: name of a checksum file in the dl_dir (used if no md5_path is given).
 
     Returns:
         Bool: True if dl files match checksum, False otherwise.
     """
     # Get or set md5 file to user or default setting
-    if md5 is None:
-        md5_file = "md5checksums.txt"
-    else:
-        md5_file = md5
+    if md5_path is None:
+        md5_path = dl_dir / md5_filename
 
     # Get checksums and compare
-    md5_path = dl_dir / md5_file
     sums = get_checksums(md5_path)
     if not sums:
         return False

--- a/src/python/tests/assembly/test_download.py
+++ b/src/python/tests/assembly/test_download.py
@@ -76,7 +76,7 @@ def test_ftp_connection(
 
     def side_eff_conn(url: str):
         if not url:
-            raise Exception()
+            raise FTPConnectionError()
 
     mock_ftp.connect.side_effect = side_eff_conn
 

--- a/src/python/tests/assembly/test_download.py
+++ b/src/python/tests/assembly/test_download.py
@@ -122,22 +122,22 @@ def test_checksums(data_dir: Path, checksum_file: Path, checksum: str, expectati
 #################
 @pytest.mark.dependency(name="test_md5_files")
 @pytest.mark.parametrize(
-    "md5file, checksum_bool",
+    "md5_file, md5_path, checksum_bool",
     [
-        pytest.param("md5checksums.txt", True, id="Normal case"),
-        pytest.param("wrong_md5_checksums.txt", False, id="Incorrect md5 checksum"),
-        pytest.param(None, True, id="No md5file specified, resort to default"),
-        pytest.param(Path("*"), False, id="Incompatible os path '*'"),
-        pytest.param("missingfile_md5.txt", False, id="md5 checksum with ref of missing file"),
+        pytest.param("md5checksums.txt", None, True, id="Normal case"),
+        pytest.param("wrong_md5_checksums.txt", None, False, id="Incorrect md5 checksum"),
+        pytest.param(None, None, True, id="No md5file specified, resort to default"),
+        pytest.param(None, Path("*"), False, id="Incompatible os path '*'"),
+        pytest.param("missingfile_md5.txt", None, False, id="md5 checksum with ref of missing file"),
     ],
 )
 @pytest.mark.dependency(depends=["test_checksums"])
-def test_md5_files(data_dir: Path, md5file: Path, checksum_bool: bool) -> None:
+def test_md5_files(data_dir: Path, md5_file: str, md5_path: Path, checksum_bool: bool) -> None:
     """Tests the md5_files() function"""
-    if md5file is None:
-        return_bool_on_md5files = md5_files(data_dir)
+    if md5_file is None:
+        return_bool_on_md5files = md5_files(data_dir, md5_path=md5_path)
     else:
-        return_bool_on_md5files = md5_files(data_dir, md5_filename=md5file)
+        return_bool_on_md5files = md5_files(data_dir, md5_path=md5_path, md5_filename=md5_file)
     assert return_bool_on_md5files == checksum_bool
 
 

--- a/src/python/tests/assembly/test_download.py
+++ b/src/python/tests/assembly/test_download.py
@@ -27,7 +27,7 @@ import logging
 from pathlib import Path
 from unittest.mock import Mock, patch, MagicMock
 from contextlib import nullcontext as does_not_raise
-from typing import ContextManager
+from typing import Callable, ContextManager
 
 from ftplib import error_reply as ftp_error_reply
 import pytest
@@ -201,7 +201,7 @@ def test_download_single_file(
     data_file = data_dir / ftp_file
     retr_file = tmp_dir / ftp_file
 
-    def mock_retr_binary(command: str, callback: object):
+    def mock_retr_binary(command: str, callback: Callable):
         logging.info(f"Faking the download of {command}")
         try:
             with data_file.open("rb") as data_fh:
@@ -278,7 +278,7 @@ def test_download_all_files(
 
     mock_ftp.mlsd.side_effect = side_eff_ftp_mlsd
 
-    def mock_retr_binary(command: str, callback: object):
+    def mock_retr_binary(command: str, callback: Callable):
         logging.info(f"Faking the download of {command}")
         try:
             with data_file.open("rb") as data_fh:

--- a/src/python/tests/assembly/test_download.py
+++ b/src/python/tests/assembly/test_download.py
@@ -421,14 +421,14 @@ def test_retrieve_assembly_data(
         expectation: Context manager expected raise exception
     """
 
-    if is_dir == False:
+    if is_dir is False:
         download_dir = Path(data_dir / str("test_ftp_file.txt"))
     else:
         download_dir = data_dir
 
     def side_eff_conn(url: str):
         if not url:
-            raise Exception()
+            raise FileDownloadError()
 
     mock_ftp.connect.side_effect = side_eff_conn
 

--- a/src/python/tests/assembly/test_download.py
+++ b/src/python/tests/assembly/test_download.py
@@ -271,7 +271,7 @@ def test_download_all_files(
         mlsd_ret = []
         files = data_dir.glob("*GCA_017607445.1*.gz")
         for file_path in files:
-            ftp_file = str(file_path).split("/")[-1]
+            ftp_file = Path(file_path).name
             mlsd_ret.append((str(ftp_file), ["fact_1", "fact_2"]))
 
         return mlsd_ret
@@ -308,7 +308,7 @@ def test_download_all_files(
 #################
 @pytest.mark.dependency(name="test_get_files_selection")
 @pytest.mark.parametrize(
-    "download_dir, files_expected, expectation",
+    "has_download_dir, files_expected, expectation",
     [
         pytest.param(
             True,
@@ -331,7 +331,7 @@ def test_download_all_files(
     ],
 )
 def test_get_files_selection(
-    data_dir: Path, download_dir: bool, files_expected: dict, expectation: ContextManager
+    data_dir: Path, has_download_dir: bool, files_expected: dict, expectation: ContextManager
 ) -> None:
     """Test the get a subset of download.get_files_selection() files function `
 
@@ -341,16 +341,16 @@ def test_get_files_selection(
         expectation: Context manager expected raise exception
     """
 
-    if download_dir:
+    if has_download_dir:
         download_dir = data_dir
     else:
-        download_dir = Path("")
+        download_dir = Path()
 
     with expectation:
         subset_files = get_files_selection(download_dir)
-        for file_end_name in subset_files.keys():
+        for file_end_name, file_path in subset_files.items():
             expected_file = files_expected[file_end_name]
-            test_data_file_name = subset_files[file_end_name].split("/")[-1]
+            test_data_file_name = Path(file_path).name
             assert test_data_file_name == expected_file
 
 

--- a/src/python/tests/assembly/test_download.py
+++ b/src/python/tests/assembly/test_download.py
@@ -82,9 +82,9 @@ def test_ftp_connection(
 
     with expectation:
         connected_ftp = establish_ftp(mock_ftp, ftp_url, accession)
-        connected_ftp.connect.assert_called_once_with(ftp_url)
-        connected_ftp.login.assert_called_once()
-        connected_ftp.cwd.assert_called_once_with("genomes/all/GCA/017/607/445")
+        connected_ftp.connect.assert_called_once_with(ftp_url)  # type: ignore[attr-defined]
+        connected_ftp.login.assert_called_once()  # type: ignore[attr-defined]
+        connected_ftp.cwd.assert_called_once_with("genomes/all/GCA/017/607/445")  # type: ignore[attr-defined]
 
 
 #################

--- a/src/python/tests/assembly/test_download.py
+++ b/src/python/tests/assembly/test_download.py
@@ -134,7 +134,10 @@ def test_checksums(data_dir: Path, checksum_file: Path, checksum: str, expectati
 @pytest.mark.dependency(depends=["test_checksums"])
 def test_md5_files(data_dir: Path, md5file: Path, checksum_bool: bool) -> None:
     """Tests the md5_files() function"""
-    return_bool_on_md5files = md5_files(data_dir, md5file)
+    if md5file is None:
+        return_bool_on_md5files = md5_files(data_dir)
+    else:
+        return_bool_on_md5files = md5_files(data_dir, md5_filename=md5file)
     assert return_bool_on_md5files == checksum_bool
 
 

--- a/src/python/tests/assembly/test_download.py
+++ b/src/python/tests/assembly/test_download.py
@@ -448,5 +448,5 @@ def test_retrieve_assembly_data(
         assert mock_os.mkdir.called_with(download_dir)
         assert mock_os.md5_files.called_once_with("md5checksums.txt")
         assert mock_download_files.download_files.called_once()
-        assert mock_download_singlefile._download_file.called_once()
+        assert mock_download_singlefile._download_file.called_once()  # pylint: disable=protected-access
         assert mock_file_select.get_files_selection.called_with(files_downloaded)


### PR DESCRIPTION
Misc fixes to make mypy and pylint happy.

I made one significant change to md5_files() to differentiate giving a file name (that should reside in the `dl_dir`), and an actual file path.


The only thing left is the calls in the calls `.assert_called_once*` for which mypy still complains.