### PR TITLE
Temporal pytest version restriction

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ cicd = [
     "genbadge[coverage]",
     "mypy >= 1.2.0",
     "pylint >= 3.0.2",
-    "pytest >= 7.4.3",
+    "pytest >= 7.4.3, < 8.1",
     "pytest-dependency",
     "pytest-mock",
     "pytest-workflow",


### PR DESCRIPTION
`pytest` 8.1+ has introduced a change that makes it incompatible with the latest `pytest-workflow`. This deprecation was not announced by `pytest` so the other library (active) could not update in time (update in progress now).