### PR TITLE
Pytest is too verbose

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,7 +179,6 @@ warn_unused_configs = true
 addopts = [
     "--import-mode=importlib",
     "--tb=native",
-    "--verbose",
     "--server=sqlite:///",
 ]
 testpaths = ["src/python/tests"]


### PR DESCRIPTION
Now that we have more than a hundred tests, the `--verbose` option floods our terminal every time we run pytest.

This PR is to just remove this param by default: now we'll see 1 line per test file, instead of 1 line per individual test.
