### PR TITLE
Plugin with version to not check/update when testing

### DIFF
--- a/pipelines/nextflow/tests/workflows/nextflow_test.config
+++ b/pipelines/nextflow/tests/workflows/nextflow_test.config
@@ -19,6 +19,10 @@ nextflowVersion = '!>=23.01'
 // Set default for NXF_WORK
 NXF_WORK = System.getenv("NXF_WORK") ?: "$PWD/work"
 
+plugins {
+    id 'nf-validation@1.1.3'
+}
+
 params {
     cache_dir = "$NXF_WORK/cache"
     storeDir_latency = 5


### PR DESCRIPTION
For the sake of ensuring we can run the pipelines tests offline, we need to fix the nextflow plugin versions in the test config (cf [nextflow doc](https://www.nextflow.io/docs/latest/plugins.html#using-plugins)). That way nextflow doesn't try to connect outside and get the latest version.

With this the current tests (pipelines and pytest) can run completely offline, assuming all dependencies/plugins are installed.
