### PR TITLE
Add manual Nextflow test stage to CI/CD

### DIFF
--- a/cicd/gitlab/dot.gitlab-ci.yml
+++ b/cicd/gitlab/dot.gitlab-ci.yml
@@ -26,6 +26,7 @@ workflow:
 
 variables:
   PYTHON_IMAGE: python:3.8
+  NEXTFLOW_IMAGE: nextflow:23.10.1
   RUN_DIR: ./cicd/runtime
 
 # Using default stages (https://docs.gitlab.com/ee/ci/yaml/#stages): .pre > build > test > deploy > .post

--- a/cicd/gitlab/dot.gitlab-ci.yml
+++ b/cicd/gitlab/dot.gitlab-ci.yml
@@ -26,7 +26,7 @@ workflow:
 
 variables:
   PYTHON_IMAGE: python:3.8
-  NEXTFLOW_IMAGE: nextflow/nextflow:23.10.1
+  NEXTFLOW_IMAGE: quay.io/biocontainers/nextflow:23.10.1--hdfd78af_0
   RUN_DIR: ./cicd/runtime
 
 # Using default stages (https://docs.gitlab.com/ee/ci/yaml/#stages): .pre > build > test > deploy > .post

--- a/cicd/gitlab/dot.gitlab-ci.yml
+++ b/cicd/gitlab/dot.gitlab-ci.yml
@@ -26,7 +26,7 @@ workflow:
 
 variables:
   PYTHON_IMAGE: python:3.8
-  NEXTFLOW_IMAGE: nextflow:23.10.1
+  NEXTFLOW_IMAGE: nextflow/nextflow:23.10.1
   RUN_DIR: ./cicd/runtime
 
 # Using default stages (https://docs.gitlab.com/ee/ci/yaml/#stages): .pre > build > test > deploy > .post

--- a/cicd/gitlab/parts/python.gitlab-ci.yml
+++ b/cicd/gitlab/parts/python.gitlab-ci.yml
@@ -136,7 +136,8 @@ python:nextflow:
       artifacts: true
   when: manual
   script:
-    - pytest --git-aware pipelines/nextflow/tests/workflows/
+    - nextflow -version
+    - pytest --git-aware --kwd --basetemp=$RUN_DIR/tmp pipelines/nextflow/tests/workflows/
 
 
 # Deploy stage instances

--- a/cicd/gitlab/parts/python.gitlab-ci.yml
+++ b/cicd/gitlab/parts/python.gitlab-ci.yml
@@ -123,6 +123,21 @@ python:coverage:
     paths:
       - $RUN_DIR/coverage
 
+## Nextflow tests
+
+python:nextflow:
+  extends: .python:test
+  services:
+    - $NEXTFLOW_IMAGE
+  needs:
+    # "extends" cannot merge arrays (https://docs.gitlab.com/ee/ci/yaml/yaml_optimization.html#merge-details)
+    - !reference [.python:test, needs]
+    - job: python:pytest
+      artifacts: true
+  when: manual
+  script:
+    - pytest --git-aware pipelines/nextflow/tests/workflows/
+
 
 # Deploy stage instances
 


### PR DESCRIPTION
I have added in the Python pipeline since there is a strong dependency between these 2 (and our current testing system relies on `pytest`).