### PR TITLE
Prepare genome metadata with datasets

### DIFF
--- a/pipelines/nextflow/modules/genome_metadata/accession_metadata.nf
+++ b/pipelines/nextflow/modules/genome_metadata/accession_metadata.nf
@@ -13,19 +13,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-process PREPARE_GENOME_METADATA {
-    tag "$accession"
+process ACCESSION_METADATA {
+    tag "$input_json"
     label 'local'
 
     input:
-        tuple val(accession), path(input_json), path(ncbi_json)
+        path(input_json)
 
     output:
-        tuple val(accession), path("genome.json"), emit: genomic_dataset
+        tuple env(accession), path(input_json)
         
     shell:
-    output_json = "genome.json"
-    '''
-    genome_metadata_prepare --input_file !{input_json} --output_file !{output_json} --ncbi_meta !{ncbi_json}
-    '''
+        '''
+        accession=$(jq -r '.["assembly"]["accession"]' !{input_json})
+        '''
 }

--- a/pipelines/nextflow/modules/genome_metadata/datasets_metadata.nf
+++ b/pipelines/nextflow/modules/genome_metadata/datasets_metadata.nf
@@ -26,9 +26,12 @@ process DATASETS_METADATA {
         
     shell:
         '''
-        datasets summary genome accession !{accession} | jq '.' > ncbi_meta.json
-        if [ ! -s "ncbi_meta.json" ]; then
-            echo "No Metadata from datasets for !{accession}"
+        datasets summary genome accession !{accession} > ncbi_meta.json
+        if [ "$?" -ne 0 ]; then
+            echo "Invalid or unsupported assembly accession: !{accession}"
+            exit 1
+        elif [[ $(jq -r '.total_count' ncbi_meta.json) -eq 0 ]]; then
+            echo "No metadata returned for !{accession}"
             exit 1
         fi
         '''

--- a/pipelines/nextflow/modules/genome_metadata/datasets_metadata.nf
+++ b/pipelines/nextflow/modules/genome_metadata/datasets_metadata.nf
@@ -27,6 +27,10 @@ process DATASETS_METADATA {
         '''
         accession=$(jq -r '.["assembly"]["accession"]' !{input_json})
         datasets summary genome accession $accession | jq '.' > ncbi_meta.json
+        if [ ! -s "ncbi_meta.json" ]; then
+            echo "No Metadata from datasets for $accession"
+            exit 1
+        fi
         '''
     
     stub:

--- a/pipelines/nextflow/modules/genome_metadata/datasets_metadata.nf
+++ b/pipelines/nextflow/modules/genome_metadata/datasets_metadata.nf
@@ -15,6 +15,7 @@
 
 process DATASETS_METADATA {
     label 'local'
+    label 'cached'
 
     input:
         path(input_json, stageAs: "input_genome.json")

--- a/pipelines/nextflow/modules/genome_metadata/datasets_metadata.nf
+++ b/pipelines/nextflow/modules/genome_metadata/datasets_metadata.nf
@@ -13,18 +13,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-process PREPARE_GENOME_METADATA {
+process DATASETS_METADATA {
     label 'local'
 
     input:
-        tuple path(input_json), path(ncbi_json)
+        path(input_json, stageAs: "input_genome.json")
 
     output:
-        path ("genome.json"), emit: genomic_dataset
+        tuple path("input_genome.json", includeInputs: true), path("ncbi_meta.json")
         
     shell:
-    output_json = "genome.json"
-    '''
-    genome_metadata_prepare --input_file !{input_json} --output_file !{output_json} --ncbi_meta !{ncbi_json}
-    '''
+        '''
+        accession=$(jq -r '.["assembly"]["accession"]' !{input_json})
+        datasets summary genome accession $accession | jq '.' > ncbi_meta.json
+        '''
+    
+    stub:
+        """
+        echo '{"reports":[{"organism":{"tax_id":1000}}]}' > ncbi_meta.json
+        """
 }

--- a/pipelines/nextflow/modules/genome_metadata/datasets_metadata.nf
+++ b/pipelines/nextflow/modules/genome_metadata/datasets_metadata.nf
@@ -14,21 +14,21 @@
 // limitations under the License.
 
 process DATASETS_METADATA {
+    tag "$accession"
     label 'local'
     label 'cached'
 
     input:
-        path(input_json, stageAs: "input_genome.json")
+        val(accession)
 
     output:
-        tuple path("input_genome.json", includeInputs: true), path("ncbi_meta.json")
+        tuple val(accession), path("ncbi_meta.json")
         
     shell:
         '''
-        accession=$(jq -r '.["assembly"]["accession"]' !{input_json})
-        datasets summary genome accession $accession | jq '.' > ncbi_meta.json
+        datasets summary genome accession !{accession} | jq '.' > ncbi_meta.json
         if [ ! -s "ncbi_meta.json" ]; then
-            echo "No Metadata from datasets for $accession"
+            echo "No Metadata from datasets for !{accession}"
             exit 1
         fi
         '''

--- a/pipelines/nextflow/modules/genome_metadata/prepare_genome_metadata.nf
+++ b/pipelines/nextflow/modules/genome_metadata/prepare_genome_metadata.nf
@@ -25,7 +25,7 @@ process PREPARE_GENOME_METADATA {
     shell:
     output_json = "genome.json"
     '''
-    accession=$(jq '.["assembly"]["accession"]' genome.json | sed 's/"//g')
+    accession=$(jq '.["assembly"]["accession"]' !{input_json} | sed 's/"//g')
     datasets summary genome accession $accession | jq '.' > ncbi_meta.json
     genome_metadata_prepare --input_file !{input_json} --output_file !{output_json} --ncbi_meta ncbi_meta.json
     '''

--- a/pipelines/nextflow/modules/genome_metadata/prepare_genome_metadata.nf
+++ b/pipelines/nextflow/modules/genome_metadata/prepare_genome_metadata.nf
@@ -25,12 +25,15 @@ process PREPARE_GENOME_METADATA {
     shell:
     output_json = "genome.json"
     '''
-    genome_metadata_prepare --input_file !{input_json} --output_file !{output_json}
+    accession=$(jq '.["assembly"]["accession"]' genome.json | sed 's/"//g')
+    datasets summary genome accession $accession | jq '.' > ncbi_meta.json
+    genome_metadata_prepare --input_file !{input_json} --output_file !{output_json} --ncbi_meta ncbi_meta.json
     '''
     
     stub:
         output_json = "genome.json"
         """
-        genome_metadata_prepare --input_file $input_json --output_file $output_json --mock_run
+        echo '{"reports":[{"organism":{"tax_id":1000}}]}' > ncbi_meta.json
+        genome_metadata_prepare --input_file $input_json --output_file $output_json --ncbi_meta ncbi_meta.json
         """
 }

--- a/pipelines/nextflow/modules/genome_metadata/prepare_genome_metadata.nf
+++ b/pipelines/nextflow/modules/genome_metadata/prepare_genome_metadata.nf
@@ -25,7 +25,7 @@ process PREPARE_GENOME_METADATA {
     shell:
     output_json = "genome.json"
     '''
-    accession=$(jq '.["assembly"]["accession"]' !{input_json} | sed 's/"//g')
+    accession=$(jq -r '.["assembly"]["accession"]' !{input_json})
     datasets summary genome accession $accession | jq '.' > ncbi_meta.json
     genome_metadata_prepare --input_file !{input_json} --output_file !{output_json} --ncbi_meta ncbi_meta.json
     '''

--- a/pipelines/nextflow/subworkflows/genome_prepare/main.nf
+++ b/pipelines/nextflow/subworkflows/genome_prepare/main.nf
@@ -77,7 +77,7 @@ workflow GENOME_PREPARE {
         amended_genome = AMEND_GENOME_DATA(genome_data_files).amended_json
 
         // Group files
-        prepared_files = amended_genome.concat(
+        prepared_files = amended_genome.mix(
                 gene_models,
                 functional_annotation,
                 fasta_pep,

--- a/pipelines/nextflow/subworkflows/genome_prepare/main.nf
+++ b/pipelines/nextflow/subworkflows/genome_prepare/main.nf
@@ -86,7 +86,7 @@ workflow GENOME_PREPARE {
             )
             .map{ meta, file ->
                 key = meta
-                if (meta["annotations"]) {
+                if (meta["annotation"]) {
                     key = groupKey(meta, 6)
                 } else {
                     key = groupKey(meta, 3)

--- a/pipelines/nextflow/subworkflows/genome_prepare/main.nf
+++ b/pipelines/nextflow/subworkflows/genome_prepare/main.nf
@@ -78,12 +78,20 @@ workflow GENOME_PREPARE {
 
         // Group files
         prepared_files = amended_genome.mix(
+                seq_region,
+                fasta_dna,
                 gene_models,
                 functional_annotation,
                 fasta_pep,
-                seq_region,
-                fasta_dna
             )
+            .map{ meta, file ->
+                key = meta
+                if (meta["annotations"]) {
+                    key = groupKey(meta, 6)
+                } else {
+                    key = groupKey(meta, 3)
+                }
+                [key, file] }
             .groupTuple()
 
         // Checks and generate sequence stats for manifest

--- a/pipelines/nextflow/subworkflows/genome_prepare/main.nf
+++ b/pipelines/nextflow/subworkflows/genome_prepare/main.nf
@@ -86,7 +86,7 @@ workflow GENOME_PREPARE {
             )
             .map{ meta, file ->
                 key = meta
-                if (meta["annotation"]) {
+                if (meta["has_annotation"]) {
                     key = groupKey(meta, 6)
                 } else {
                     key = groupKey(meta, 3)

--- a/pipelines/nextflow/workflows/genome_prepare/main.nf
+++ b/pipelines/nextflow/workflows/genome_prepare/main.nf
@@ -50,12 +50,17 @@ def meta_from_genome_json(json_path) {
         prod_name = data.species.production_name
         publish_dir = prod_name
     }
+    has_annotation = false
+    if (data.annotation) {
+        has_annotation = true
+    }
 
     return [
         accession: data.assembly.accession,
         production_name: prod_name,
         publish_dir: publish_dir,
         prefix: "",
+        has_annotation: has_annotation,
     ]
 }
 

--- a/pipelines/nextflow/workflows/genome_prepare/main.nf
+++ b/pipelines/nextflow/workflows/genome_prepare/main.nf
@@ -32,6 +32,7 @@ if (params.brc_mode) {
 include { GENOME_PREPARE } from '../../subworkflows/genome_prepare/main.nf'
 // Import module
 include { PREPARE_GENOME_METADATA } from '../../modules/genome_metadata/prepare_genome_metadata.nf'
+include { DATASETS_METADATA } from '../../modules/genome_metadata/datasets_metadata.nf'
 // Utilities
 include { read_json } from '../../modules/utils/utils.nf'
 
@@ -61,7 +62,7 @@ def meta_from_genome_json(json_path) {
 // Run main workflow
 workflow {
     ch_genome_json = Channel.fromPath("${params.input_dir}/*.json", checkIfExists: true)
-    PREPARE_GENOME_METADATA(ch_genome_json)
+    PREPARE_GENOME_METADATA(DATASETS_METADATA(ch_genome_json))
 
     PREPARE_GENOME_METADATA.out.genomic_dataset
         .map{ json_file -> tuple(meta_from_genome_json(json_file), json_file) }

--- a/pipelines/nextflow/workflows/genome_prepare/main.nf
+++ b/pipelines/nextflow/workflows/genome_prepare/main.nf
@@ -57,7 +57,6 @@ def meta_from_genome_json(json_path) {
     }
 
     return [
-        // id: prod_name,
         accession: data.assembly.accession,
         production_name: prod_name,
         publish_dir: publish_dir,

--- a/src/python/ensembl/io/genomio/genome_metadata/prepare.py
+++ b/src/python/ensembl/io/genomio/genome_metadata/prepare.py
@@ -135,7 +135,7 @@ def add_genebuild_metadata(genome_data: Dict) -> None:
 
 
 def add_species_metadata(genome_metadata: Dict, ncbi_data: Dict) -> None:
-    """Adds tax_id and name from the NCBI dataset report.
+    """Adds taxonomy ID, scientific name and strain (if present) from the NCBI dataset report.
 
     Args:
         genome_metadata: Genome information of assembly, accession and annotation.

--- a/src/python/ensembl/io/genomio/genome_metadata/prepare.py
+++ b/src/python/ensembl/io/genomio/genome_metadata/prepare.py
@@ -21,21 +21,15 @@ __all__ = [
     "add_assembly_version",
     "add_genebuild_metadata",
     "add_species_metadata",
-    "get_taxonomy_from_accession",
     "prepare_genome_metadata",
     "PROVIDER_DATA",
-    "DEFAULT_API_URL",
     "MissingNodeError",
     "MetadataError",
 ]
 
 import datetime
 from os import PathLike
-from typing import Any, Dict, Optional
-from xml.etree import ElementTree
-from xml.etree.ElementTree import Element
-
-import requests
+from typing import Dict
 
 from ensembl.io.genomio.utils import get_json, print_json
 from ensembl.utils.argparse import ArgumentParser
@@ -64,7 +58,6 @@ PROVIDER_DATA = {
         },
     },
 }
-DEFAULT_API_URL = "https://www.ebi.ac.uk/ena/browser/api/xml"
 
 
 class MissingNodeError(Exception):
@@ -75,7 +68,7 @@ class MetadataError(Exception):
     """When a metadata value is not expected."""
 
 
-def add_provider(genome_metadata: Dict, gff3_file: Optional[PathLike] = None) -> None:
+def add_provider(genome_metadata: Dict, ncbi_data: Dict) -> None:
     """Updates the genome metadata adding provider information for assembly and gene models.
 
     Assembly provider metadata will only be added if it is missing, i.e. neither `"provider_name"` or
@@ -83,7 +76,7 @@ def add_provider(genome_metadata: Dict, gff3_file: Optional[PathLike] = None) ->
 
     Args:
         genome_data: Genome information of assembly, accession and annotation.
-        gff3_file: Path to GFF3 file to use as annotation source for this genome.
+        ncbi_data: Report data from datasets for this accession.
 
     Raises:
         MetadataError: If accession's format in genome metadata does not match with a known provider.
@@ -104,7 +97,7 @@ def add_provider(genome_metadata: Dict, gff3_file: Optional[PathLike] = None) ->
         assembly["provider_url"] = f'{provider["assembly"]["provider_url"]}/{accession}'
 
     # Add annotation provider if there are gene models
-    if gff3_file:
+    if "annotation_info" in ncbi_data:
         annotation = genome_metadata.setdefault("annotation", {})
         if ("provider_name" not in annotation) and ("provider_url" not in annotation):
             annotation["provider_name"] = provider["annotation"]["provider_name"]
@@ -141,95 +134,26 @@ def add_genebuild_metadata(genome_data: Dict) -> None:
         genebuild["start_date"] = current_date
 
 
-def add_species_metadata(genome_metadata: Dict, base_api_url: str = DEFAULT_API_URL) -> None:
-    """Adds missing species metadata from its taxonomy based on the genome's accession.
-
-    If `"taxonomy_id"` is already present in the species metadata, nothing is added. The `"taxonomy_id"`,
-    `"scientific_name"` and `"strain"` will be fetched from the taxonomy information linked to the given
-    accession.
+def add_species_metadata(genome_metadata: Dict, ncbi_data: Dict) -> None:
+    """Adds tax_id and name from the NCBI dataset report.
 
     Args:
         genome_metadata: Genome information of assembly, accession and annotation.
-        base_api_url: Base API URL to fetch the taxonomy data from.
+        ncbi_data: Report data from datasets for this accession.
 
     """
     species = genome_metadata.setdefault("species", {})
+    taxon_data = ncbi_data["assembly_info"]["biosample"]["description"]
     if not "taxonomy_id" in species:
-        accession = genome_metadata["assembly"]["accession"]
-        taxonomy = get_taxonomy_from_accession(accession, base_api_url)
-        species["taxonomy_id"] = taxonomy["taxon_id"]
-        if (not "strain" in species) and ("strain" in taxonomy):
-            species["strain"] = taxonomy["strain"]
-        if not "scientific_name" in species:
-            species["scientific_name"] = taxonomy["scientific_name"]
-
-
-def get_taxonomy_from_accession(accession: str, base_api_url: str = DEFAULT_API_URL) -> Dict[str, Any]:
-    """Returns the taxonomy metadata associated to the given accession.
-
-    Args:
-        accession: INSDC accession ID.
-        base_api_url: Base API URL to fetch the taxonomy data from.
-
-    Returns:
-        Dictionary with key-value pairs for `"taxon_id"` and `"scientific_name"`. `"strain"` will also be
-        included if it is present in the fetched taxonomy data.
-
-    Raises:
-        MissingNodeError: If `"TAXON"` node is missing in the taxonomy data fetched.
-
-    """
-    # Use the GenBank accession without version
-    gb_accession = accession.replace("GCF", "GCA").split(".")[0]
-    if not base_api_url.endswith("/"):
-        base_api_url += "/"
-    response = requests.get(f"{base_api_url}{gb_accession}", timeout=60)
-    response.raise_for_status()
-    entry = ElementTree.fromstring(response.text)
-    taxon_node = entry.find(".//TAXON")
-    if taxon_node is None:
-        raise MissingNodeError("Cannot find the TAXON node")
-    # Fetch taxon ID, scientific_name and strain
-    taxon_id = _get_node_text(taxon_node, "TAXON_ID")
-    scientific_name = _get_node_text(taxon_node, "SCIENTIFIC_NAME")
-    strain = _get_node_text(taxon_node, "STRAIN", optional=True)
-    taxonomy = {
-        # Ignore arg-type check in the following line since taxon_id cannot be None
-        "taxon_id": int(taxon_id),  # type: ignore[arg-type]
-        "scientific_name": scientific_name,
-    }
-    if strain:
-        taxonomy["strain"] = strain
-    return taxonomy
-
-
-def _get_node_text(node: Optional[Element], tag: str, optional: bool = False) -> Optional[str]:
-    """Returns the value of the field matching the provided tag inside `node`.
-
-    If the tag is not present and `optional` is True, returns `None` instead.
-
-    Args:
-        node: Node of an XML tree.
-        tag: Tag to fetch within the node.
-        optional: Do not raise an exception if the tag does not exist.
-
-    Raises:
-        MissingNodeError: If no node is provided or if the tag is missing (if `optional == False`).
-    """
-    if node is None:
-        raise MissingNodeError(f"No node provided to look for '{tag}'")
-    tag_text = node.findtext(tag)
-    if not optional and (tag_text is None):
-        raise MissingNodeError(f"No node found for tag '{tag}'")
-    return tag_text
+        species["taxonomy_id"] = taxon_data["organism"]["tax_id"]
+    if not "scientific_name" in species:
+        species["scientific_name"] = taxon_data["title"]
 
 
 def prepare_genome_metadata(
     input_file: PathLike,
     output_file: PathLike,
-    gff3_file: Optional[PathLike] = None,
-    base_api_url: str = DEFAULT_API_URL,
-    mock_run: bool = False,
+    ncbi_meta: PathLike,
 ) -> None:
     """Updates the genome metadata JSON file with additional information.
 
@@ -239,20 +163,19 @@ def prepare_genome_metadata(
     Args:
         input_file: Path to JSON file with genome metadata.
         output_file: Output directory where to generate the final `genome.json` file.
-        gff3_file: Path to GFF3 file to use as annotation source for this genome.
-        base_api_url: Base API URL to fetch the taxonomy data from.
-        mock_run: Do not call external taxonomy service.
+        ncbi_meta: JSON file from NCBI datasets for the accession.
 
     """
     genome_data = get_json(input_file)
+    ncbi_data = {}
+    if ncbi_meta:
+        ncbi_data = get_json(ncbi_meta)["reports"][0]
+
     # Amend any missing metadata
-    add_provider(genome_data, gff3_file)
+    add_provider(genome_data, ncbi_data)
     add_assembly_version(genome_data)
     add_genebuild_metadata(genome_data)
-    if mock_run:
-        genome_data["species"].setdefault("taxonomy_id", 9999999)
-    else:
-        add_species_metadata(genome_data, base_api_url)
+    add_species_metadata(genome_data, ncbi_data)
     # Dump updated genome metadata
     print_json(output_file, genome_data)
 
@@ -264,11 +187,7 @@ def main() -> None:
     parser.add_argument_dst_path(
         "--output_file", required=True, help="Output path for the new genome metadata file"
     )
-    parser.add_argument_src_path("--gff3_file", help="GFF3 file to use as annotation source")
-    parser.add_argument(
-        "--base_api_url", default=DEFAULT_API_URL, help="API URL to fetch the taxonomy data from"
-    )
-    parser.add_argument("--mock_run", action="store_true", help="Do not call external APIs")
+    parser.add_argument_src_path("--ncbi_meta", required=True, help="JSON file from NCBI datasets for this accession.")
     parser.add_log_arguments()
     args = parser.parse_args()
     init_logging_with_args(args)
@@ -276,7 +195,5 @@ def main() -> None:
     prepare_genome_metadata(
         input_file=args.input_file,
         output_file=args.output_file,
-        gff3_file=args.gff3_file,
-        base_api_url=args.base_api_url,
-        mock_run=args.mock_run,
+        ncbi_meta=args.ncbi_meta
     )

--- a/src/python/ensembl/io/genomio/genome_metadata/prepare.py
+++ b/src/python/ensembl/io/genomio/genome_metadata/prepare.py
@@ -196,13 +196,13 @@ def main() -> None:
     parser.add_argument_dst_path(
         "--output_file", required=True, help="Output path for the new genome metadata file"
     )
-    parser.add_argument_src_path("--ncbi_meta", required=True, help="JSON file from NCBI datasets for this accession.")
+    parser.add_argument_src_path(
+        "--ncbi_meta", required=True, help="JSON file from NCBI datasets for this accession."
+    )
     parser.add_log_arguments()
     args = parser.parse_args()
     init_logging_with_args(args)
 
     prepare_genome_metadata(
-        input_file=args.input_file,
-        output_file=args.output_file,
-        ncbi_meta=args.ncbi_meta
+        input_file=args.input_file, output_file=args.output_file, ncbi_meta=args.ncbi_meta
     )

--- a/src/python/ensembl/io/genomio/genome_metadata/prepare.py
+++ b/src/python/ensembl/io/genomio/genome_metadata/prepare.py
@@ -76,7 +76,7 @@ def add_provider(genome_metadata: Dict, ncbi_data: Dict) -> None:
 
     Args:
         genome_data: Genome information of assembly, accession and annotation.
-        ncbi_data: Report data from datasets for this accession.
+        ncbi_data: Report data from NCBI datasets.
 
     Raises:
         MetadataError: If accession's format in genome metadata does not match with a known provider.
@@ -139,7 +139,7 @@ def add_species_metadata(genome_metadata: Dict, ncbi_data: Dict) -> None:
 
     Args:
         genome_metadata: Genome information of assembly, accession and annotation.
-        ncbi_data: Report data from datasets for this accession.
+        ncbi_data: Report data from NCBI datasets.
 
     """
     species = genome_metadata.setdefault("species", {})
@@ -172,7 +172,7 @@ def prepare_genome_metadata(
     Args:
         input_file: Path to JSON file with genome metadata.
         output_file: Output directory where to generate the final `genome.json` file.
-        ncbi_meta: JSON file from NCBI datasets for the accession.
+        ncbi_meta: JSON file from NCBI datasets.
 
     """
     genome_data = get_json(input_file)
@@ -197,7 +197,7 @@ def main() -> None:
         "--output_file", required=True, help="Output path for the new genome metadata file"
     )
     parser.add_argument_src_path(
-        "--ncbi_meta", required=True, help="JSON file from NCBI datasets for this accession."
+        "--ncbi_meta", required=True, help="JSON file from NCBI datasets for this genome."
     )
     parser.add_log_arguments()
     args = parser.parse_args()

--- a/src/python/ensembl/io/genomio/genome_metadata/prepare.py
+++ b/src/python/ensembl/io/genomio/genome_metadata/prepare.py
@@ -143,11 +143,20 @@ def add_species_metadata(genome_metadata: Dict, ncbi_data: Dict) -> None:
 
     """
     species = genome_metadata.setdefault("species", {})
-    taxon_data = ncbi_data["assembly_info"]["biosample"]["description"]
-    if not "taxonomy_id" in species:
-        species["taxonomy_id"] = taxon_data["organism"]["tax_id"]
-    if not "scientific_name" in species:
-        species["scientific_name"] = taxon_data["title"]
+    try:
+        organism = ncbi_data["organism"]
+    except KeyError:
+        return
+
+    if "tax_id" in organism:
+        species.setdefault("taxonomy_id", organism["tax_id"])
+    if "organism_name" in organism:
+        species.setdefault("scientific_name", organism["organism_name"])
+
+    try:
+        species.setdefault("strain", organism["infraspecific_names"]["strain"])
+    except KeyError:
+        pass
 
 
 def prepare_genome_metadata(

--- a/src/python/tests/genome_metadata/test_prepare.py
+++ b/src/python/tests/genome_metadata/test_prepare.py
@@ -83,7 +83,7 @@ def test_add_provider(
     Args:
         json_data: JSON test file parsing fixture.
         genome_file: Genome metadata JSON file.
-        ncbi_data: Report from datasets.
+        ncbi_data: Report from NCBI datasets.
         output: Expected elements present in the updated genome metadata.
         expectation: Context manager for the expected exception (if any).
     """
@@ -220,9 +220,9 @@ def test_prepare_genome_metadata(
     """Tests the `prepare.prepare_genome_metadata()` method.
 
     Args:
-        input_filename: Genome json input.
-        ncbi_filename: NCBI dataset json input.
-        expected_filename: Genome json input expected output.
+        input_filename: Input genome JSON file.
+        ncbi_filename: NCBI dataset report JSON file.
+        expected_filename: Expected output genome JSON file.
     """
     mock_date.today.return_value = mock_date
     mock_date.isoformat.return_value = "2024-03-19"

--- a/src/python/tests/genome_metadata/test_prepare.py
+++ b/src/python/tests/genome_metadata/test_prepare.py
@@ -190,6 +190,7 @@ def test_add_species_metadata(
     assert not DeepDiff(genome_metadata["species"], output)
 
 
+@patch("datetime.date")
 @pytest.mark.parametrize(
     "input_filename, ncbi_filename, expected_filename",
     [
@@ -208,6 +209,7 @@ def test_add_species_metadata(
     ],
 )
 def test_prepare_genome_metadata(
+    mock_date: Mock,
     tmp_path: Path,
     data_dir: Path,
     assert_files: Callable[[Path, Path], None],
@@ -222,6 +224,9 @@ def test_prepare_genome_metadata(
         ncbi_filename: NCBI dataset json input.
         expected_filename: Genome json input expected output.
     """
+    mock_date.today.return_value = mock_date
+    mock_date.isoformat.return_value = "2024-03-19"
+
     input_file = data_dir / input_filename
     ncbi_meta = data_dir / ncbi_filename
     output_file = tmp_path / expected_filename

--- a/src/python/tests/genome_metadata/test_prepare.py
+++ b/src/python/tests/genome_metadata/test_prepare.py
@@ -154,7 +154,11 @@ def test_add_genebuild_metadata(
         ),
         pytest.param(
             "refseq_genome.json",
-            {"tax_id": 34611, "organism_name": "Rhipicephalus annulatus", "infraspecific_names": {"strain": "Klein Grass"}},
+            {
+                "tax_id": 34611,
+                "organism_name": "Rhipicephalus annulatus",
+                "infraspecific_names": {"strain": "Klein Grass"},
+            },
             {"taxonomy_id": 34611, "scientific_name": "Rhipicephalus annulatus", "strain": "Klein Grass"},
             id="Add strain taxonomy information",
         ),

--- a/src/python/tests/genome_metadata/test_prepare.py
+++ b/src/python/tests/genome_metadata/test_prepare.py
@@ -12,18 +12,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Unit testing of `ensembl.io.genomio.genome_metadata.prepare` module.
-
-Typical usage example::
-    $ pytest test_prepare.py
-
-"""
+"""Unit testing of `ensembl.io.genomio.genome_metadata.prepare` module."""
 
 from contextlib import nullcontext as does_not_raise
 from pathlib import Path
 from typing import Any, Callable, ContextManager, Dict, Optional
 from unittest.mock import Mock, patch
-from xml.etree import ElementTree
 
 from deepdiff import DeepDiff
 import pytest
@@ -31,13 +25,12 @@ import pytest
 from ensembl.io.genomio.genome_metadata import prepare
 
 
-# @pytest.mark.dependency(name="test_get_gbff_regions")
 @pytest.mark.parametrize(
-    "genome_file, gff3_file, output, expectation",
+    "genome_file, ncbi_data, output, expectation",
     [
         pytest.param(
             "genbank_genome.json",
-            None,
+            {},
             {
                 "assembly": {
                     "provider_name": "GenBank",
@@ -49,7 +42,7 @@ from ensembl.io.genomio.genome_metadata import prepare
         ),
         pytest.param(
             "refseq_genome.json",
-            Path("fake.gff3"),
+            {"annotation_info": {}},
             {
                 "assembly": {
                     "provider_name": "RefSeq",
@@ -65,7 +58,7 @@ from ensembl.io.genomio.genome_metadata import prepare
         ),
         pytest.param(
             "updated_genome.json",
-            Path("fake.gff3"),
+            {"annotation_info": {}},
             {
                 "assembly": {"provider_name": "GenBank", "provider_url": None},
                 "annotation": {"provider_name": "GenBank", "provider_url": None},
@@ -74,14 +67,14 @@ from ensembl.io.genomio.genome_metadata import prepare
             id="Provider information already present",
         ),
         pytest.param(
-            "cncb_genome.json", None, {}, pytest.raises(prepare.MetadataError), id="Unexpected provider"
+            "cncb_genome.json", {}, {}, pytest.raises(prepare.MetadataError), id="Unexpected provider"
         ),
     ],
 )
 def test_add_provider(
     json_data: Callable[[str], Any],
     genome_file: str,
-    gff3_file: Optional[Path],
+    ncbi_data: Dict,
     output: Dict[str, Dict[str, Optional[str]]],
     expectation: ContextManager,
 ) -> None:
@@ -90,13 +83,13 @@ def test_add_provider(
     Args:
         json_data: JSON test file parsing fixture.
         genome_file: Genome metadata JSON file.
-        gff3_file: GFF3 file.
+        ncbi_data: Report from datasets.
         output: Expected elements present in the updated genome metadata.
         expectation: Context manager for the expected exception (if any).
     """
     genome_metadata = json_data(genome_file)
     with expectation:
-        prepare.add_provider(genome_metadata, gff3_file)
+        prepare.add_provider(genome_metadata, ncbi_data)
         for section, metadata in output.items():
             for key, value in metadata.items():
                 assert genome_metadata[section].get(key, None) == value
@@ -150,195 +143,84 @@ def test_add_genebuild_metadata(
     assert genome_metadata["genebuild"]["version"] == output
 
 
-@pytest.mark.dependency(name="test_get_node_text")
 @pytest.mark.parametrize(
-    "xml_file, tag, optional, output, expectation",
-    [
-        pytest.param(
-            "",
-            "tag",
-            False,
-            "",
-            pytest.raises(prepare.MissingNodeError, match="No node provided to look for 'tag'"),
-            id="No node provided",
-        ),
-        pytest.param("default_taxonomy.xml", "TAXON_ID", False, "34611", does_not_raise(), id="Tag present"),
-        pytest.param("default_taxonomy.xml", "tag", True, None, does_not_raise(), id="Missing optional tag"),
-        pytest.param(
-            "default_taxonomy.xml",
-            "tag",
-            False,
-            "",
-            pytest.raises(prepare.MissingNodeError, match="No node found for tag 'tag'"),
-            id="Missing mandatory tag",
-        ),
-    ],
-)
-def test_get_node_text(
-    data_dir: Path,
-    xml_file: str,
-    tag: str,
-    optional: bool,
-    output: Optional[str],
-    expectation: ContextManager,
-) -> None:
-    """Tests the `prepare._get_node_text()` method.
-
-    Args:
-        data_dir: Module's test data directory fixture.
-        xml_file: XML file with assembly's taxonomy data.
-        tag: Tag to fetch within the node.
-        optional: Do not raise an exception if the tag does not exist.
-        output: Expected field value returned.
-        expectation: Context manager for the expected exception (if any).
-    """
-    if xml_file:
-        tree = ElementTree.parse(data_dir / xml_file)
-        node = tree.find(".//TAXON")
-    else:
-        node = None
-    with expectation:
-        result = prepare._get_node_text(node, tag, optional)  # pylint: disable=protected-access
-        assert result == output
-
-
-@pytest.mark.dependency(depends=["test_get_node_text"])
-@patch("requests.Response")
-@patch("requests.get")
-@pytest.mark.parametrize(
-    "accession, base_api_url, xml_file, output, expectation",
-    [
-        pytest.param(
-            "GCF_013436015.2",
-            prepare.DEFAULT_API_URL,
-            "default_taxonomy.xml",
-            {"taxon_id": 34611, "scientific_name": "Rhipicephalus annulatus"},
-            does_not_raise(),
-            id="Basic taxonomy data",
-        ),
-        pytest.param(
-            "GCA_013436015.2",
-            "/",
-            "strain_taxonomy.xml",
-            {"taxon_id": 34611, "scientific_name": "Rhipicephalus annulatus", "strain": "Klein Grass"},
-            does_not_raise(),
-            id="Taxonomy with strain data",
-        ),
-        pytest.param(
-            "GCA_013436015.2",
-            "",
-            "no_taxonomy.xml",
-            {},
-            pytest.raises(prepare.MissingNodeError, match="Cannot find the TAXON node"),
-            id="Missing TAXON node",
-        ),
-    ],
-)
-def test_get_taxonomy_from_accession(
-    mock_requests_get: Mock,
-    mock_response: Mock,
-    data_dir: Path,
-    accession: str,
-    base_api_url: str,
-    xml_file: str,
-    output: Dict[str, Any],
-    expectation: ContextManager,
-):
-    """Tests the `prepare.get_taxonomy_from_accession()` method.
-
-    Args:
-        mock_requests_get: A mock of `requests.get()` function.
-        mock_response: A mock of `requests.Response` class.
-        data_dir: Module's test data directory fixture.
-        accession: INSDC accession ID.
-        base_api_url: Base API URL to fetch the taxonomy data from.
-        xml_file: XML file with assembly's taxonomy data.
-        output: Expected taxonomy data returned.
-        expectation: Context manager for the expected exception (if any).
-    """
-    xml_path = data_dir / xml_file
-    with xml_path.open() as xml:
-        text = "".join(xml.readlines())
-    mock_response.text = text
-    mock_requests_get.return_value = mock_response
-    with expectation:
-        result = prepare.get_taxonomy_from_accession(accession, base_api_url)
-        assert not DeepDiff(result, output)
-
-
-@patch("ensembl.io.genomio.genome_metadata.prepare.get_taxonomy_from_accession")
-@pytest.mark.parametrize(
-    "genome_file, taxonomy, output",
+    "genome_file, ncbi_data_organism, output",
     [
         pytest.param(
             "genbank_genome.json",
-            {"taxon_id": 34611, "scientific_name": "Rhipicephalus annulatus"},
+            {"tax_id": 34611, "organism_name": "Rhipicephalus annulatus"},
             {"taxonomy_id": 34611, "scientific_name": "Rhipicephalus annulatus"},
             id="Add taxonomy information",
         ),
         pytest.param(
             "refseq_genome.json",
-            {"taxon_id": 34611, "scientific_name": "Rhipicephalus annulatus", "strain": "Klein Grass"},
+            {"tax_id": 34611, "organism_name": "Rhipicephalus annulatus", "infraspecific_names": {"strain": "Klein Grass"}},
             {"taxonomy_id": 34611, "scientific_name": "Rhipicephalus annulatus", "strain": "Klein Grass"},
             id="Add strain taxonomy information",
         ),
         pytest.param(
             "updated_genome.json",
-            {"taxon_id": 34611},
+            {"tax_id": 34611},
             {"taxonomy_id": 10092, "scientific_name": "Mus musculus", "strain": "domesticus"},
             id="Nothing to add",
         ),
     ],
 )
 def test_add_species_metadata(
-    mock_get_taxonomy_data: Mock,
     json_data: Callable[[str], Any],
     genome_file: str,
-    taxonomy: Dict[str, Any],
+    ncbi_data_organism: Dict,
     output: Dict[str, Any],
 ):
     """Tests the `prepare.add_species_metadata()` method.
 
     Args:
-        mock_get_taxonomy_data: A mock of
-            `ensembl.io.genomio.genome_metadata.prepare.get_taxonomy_from_accession()` function.
         json_data: JSON test file parsing fixture.
         genome_file: Genome metadata JSON file.
-        taxonomy: Taxonomy metadata to add.
+        ncbi_data_organism: NCBI dataset organism report.
         output: Expected `"species"` genome metadata content.
     """
-    mock_get_taxonomy_data.return_value = taxonomy
+    ncbi_data = {"organism": ncbi_data_organism}
     genome_metadata = json_data(genome_file)
-    prepare.add_species_metadata(genome_metadata)
+    prepare.add_species_metadata(genome_metadata, ncbi_data)
     assert not DeepDiff(genome_metadata["species"], output)
 
 
-@patch("ensembl.io.genomio.genome_metadata.prepare.add_species_metadata")
-@patch("ensembl.io.genomio.genome_metadata.prepare.add_genebuild_metadata")
-@patch("ensembl.io.genomio.genome_metadata.prepare.add_assembly_version")
-@patch("ensembl.io.genomio.genome_metadata.prepare.add_provider")
+@pytest.mark.parametrize(
+    "input_filename, ncbi_filename, expected_filename",
+    [
+        pytest.param(
+            "genome_accession.json",
+            "genome_accession_ncbi.json",
+            "genome_accession_updated.json",
+            id="Add information from an accession",
+        ),
+        pytest.param(
+            "updated_genome.json",
+            "updated_genome_ncbi.json",
+            "updated_genome.json",
+            id="Nothing to add",
+        ),
+    ],
+)
 def test_prepare_genome_metadata(
-    mock_add_provider: Mock,
-    mock_add_assembly_version: Mock,
-    mock_add_genebuild_metadata: Mock,
-    mock_add_species_metadata: Mock,
     tmp_path: Path,
     data_dir: Path,
     assert_files: Callable[[Path, Path], None],
+    input_filename: str,
+    ncbi_filename: str,
+    expected_filename: str,
 ):
     """Tests the `prepare.prepare_genome_metadata()` method.
 
     Args:
-        mock_*: A mock of `ensembl.io.genomio.genome_metadata.prepare.*` functions.
-        tmp_path: Test's unique temporary directory fixture.
-        data_dir: Module's test data directory fixture.
-        assert_files: File diff assertion fixture.
+        input_filename: Genome json input.
+        ncbi_filename: NCBI dataset json input.
+        expected_filename: Genome json input expected output.
     """
-    input_file = data_dir / "updated_genome.json"
-    output_file = tmp_path / "output.json"
-    prepare.prepare_genome_metadata(input_file, output_file)
-    mock_add_provider.assert_called_once()
-    mock_add_assembly_version.assert_called_once()
-    mock_add_genebuild_metadata.assert_called_once()
-    mock_add_species_metadata.assert_called_once()
-    assert_files(input_file, output_file)
+    input_file = data_dir / input_filename
+    ncbi_meta = data_dir / ncbi_filename
+    output_file = tmp_path / expected_filename
+    expected_file = data_dir / expected_filename
+    prepare.prepare_genome_metadata(input_file=input_file, output_file=output_file, ncbi_meta=ncbi_meta)
+    assert_files(output_file, expected_file)

--- a/src/python/tests/genome_metadata/test_prepare/default_taxonomy.xml
+++ b/src/python/tests/genome_metadata/test_prepare/default_taxonomy.xml
@@ -1,8 +1,0 @@
-<ASSEMBLY_SET>
-  <ASSEMBLY accession="GCA_013436015.2" alias="TxGen Rann" center_name="USDA-Agricultural Research Service, USA">
-    <TAXON>
-      <TAXON_ID>34611</TAXON_ID>
-      <SCIENTIFIC_NAME>Rhipicephalus annulatus</SCIENTIFIC_NAME>
-    </TAXON>
-  </ASSEMBLY>
-</ASSEMBLY_SET>

--- a/src/python/tests/genome_metadata/test_prepare/genome_accession.json
+++ b/src/python/tests/genome_metadata/test_prepare/genome_accession.json
@@ -1,0 +1,5 @@
+{
+    "assembly": {
+        "accession": "GCA_013436015.2"
+    }
+}

--- a/src/python/tests/genome_metadata/test_prepare/genome_accession_ncbi.json
+++ b/src/python/tests/genome_metadata/test_prepare/genome_accession_ncbi.json
@@ -1,0 +1,19 @@
+{
+    "reports": [
+        {
+            "accession": "GCA_013436015.1",
+            "assembly_info": {
+                "release_date": "2020-07-21",
+                "submitter": "USDA-Agricultural Research Service, USA"
+            },
+            "organism": {
+                "infraspecific_names": {
+                    "strain": "Klein Grass"
+                },
+                "organism_name": "Rhipicephalus annulatus",
+                "tax_id": 34611
+            }
+        }
+    ],
+    "total_count": 1
+}

--- a/src/python/tests/genome_metadata/test_prepare/genome_accession_updated.json
+++ b/src/python/tests/genome_metadata/test_prepare/genome_accession_updated.json
@@ -1,0 +1,17 @@
+{
+    "assembly": {
+        "accession": "GCA_013436015.2",
+        "provider_name": "GenBank",
+        "provider_url": "https://www.ncbi.nlm.nih.gov/datasets/genome/GCA_013436015.2",
+        "version": 2
+    },
+    "genebuild": {
+        "start_date": "2024-03-19",
+        "version": "2024-03-19"
+    },
+    "species": {
+        "scientific_name": "Rhipicephalus annulatus",
+        "strain": "Klein Grass",
+        "taxonomy_id": 34611
+    }
+}

--- a/src/python/tests/genome_metadata/test_prepare/ncbi_meta.json
+++ b/src/python/tests/genome_metadata/test_prepare/ncbi_meta.json
@@ -1,0 +1,28 @@
+{
+  "reports": [
+    {
+      "accession": "GCA_020800215.1",
+      "annotation_info": {
+        "name": "Annotation submitted by USDA ARS",
+        "provider": "USDA ARS",
+        "release_date": "2022-11-23"
+      },
+      "assembly_info": {
+        "biosample": {
+          "accession": "SAMN19730089",
+          "description": {
+            "organism": {
+              "organism_name": "Phytophthora ramorum",
+              "tax_id": 164328
+            },
+            "title": "Phytophthora ramorum isolate PR-102"
+          },
+          "last_updated": "2021-11-10T12:39:52.023"
+        },
+        "refseq_category": "representative genome",
+        "release_date": "2021-11-08",
+        "submitter": "USDA ARS"
+      }
+    }
+  ]
+}

--- a/src/python/tests/genome_metadata/test_prepare/no_taxonomy.xml
+++ b/src/python/tests/genome_metadata/test_prepare/no_taxonomy.xml
@@ -1,4 +1,0 @@
-<ASSEMBLY_SET>
-  <ASSEMBLY accession="GCA_013436015.2" alias="TxGen Rann" center_name="USDA-Agricultural Research Service, USA">
-  </ASSEMBLY>
-</ASSEMBLY_SET>

--- a/src/python/tests/genome_metadata/test_prepare/strain_taxonomy.xml
+++ b/src/python/tests/genome_metadata/test_prepare/strain_taxonomy.xml
@@ -1,9 +1,0 @@
-<ASSEMBLY_SET>
-  <ASSEMBLY accession="GCA_013436015.2" alias="TxGen Rann" center_name="USDA-Agricultural Research Service, USA">
-    <TAXON>
-      <TAXON_ID>34611</TAXON_ID>
-      <SCIENTIFIC_NAME>Rhipicephalus annulatus</SCIENTIFIC_NAME>
-      <STRAIN>Klein Grass</STRAIN>
-    </TAXON>
-  </ASSEMBLY>
-</ASSEMBLY_SET>

--- a/src/python/tests/genome_metadata/test_prepare/updated_genome_ncbi.json
+++ b/src/python/tests/genome_metadata/test_prepare/updated_genome_ncbi.json
@@ -1,0 +1,19 @@
+{
+    "reports": [
+        {
+            "accession": "GCA_013436015.1",
+            "assembly_info": {
+                "release_date": "2020-07-21",
+                "submitter": "USDA-Agricultural Research Service, USA"
+            },
+            "organism": {
+                "infraspecific_names": {
+                    "strain": "Klein Grass"
+                },
+                "organism_name": "Rhipicephalus annulatus",
+                "tax_id": 34611
+            }
+        }
+    ],
+    "total_count": 1
+}


### PR DESCRIPTION
Instead of using a request to the ENA API, get the metadata from the JSON report from NCBI's datasets.
This simplifies the code (and the tests) since we don't need to check/mock that part.

Now we need to download the dataset file before running the script, so I've updated the Nextflow module to do so.


I've also modified the prepare part in to incorporate the "annotation" part of the genome json if there are annotations, and we can use this information to determine how many files we expect at the end of the Nextflow pipeline (3 or 6).
Also note that I've replaced `concat` by `mix`, since `concat` actually waits for the whole list of each channel before passing the next one, and mix push they as they arrive.

This change makes the `groupTuple()` work correctly: now instead of waiting for all the channels to finish, it starts as soon as it has all the files for a genome.
