### PR TITLE
Support for miRNA genes

### DIFF
--- a/src/python/ensembl/io/genomio/data/gff3/biotypes.json
+++ b/src/python/ensembl/io/genomio/data/gff3/biotypes.json
@@ -49,6 +49,7 @@
             "mRNA",
             "ncRNA",
             "piRNA",
+            "primary_transcript",
             "pseudogenic_rRNA",
             "pseudogenic_transcript",
             "pseudogenic_tRNA",

--- a/src/python/ensembl/io/genomio/gff3/id_allocator.py
+++ b/src/python/ensembl/io/genomio/gff3/id_allocator.py
@@ -175,7 +175,7 @@ class StableIDAllocator:
 
         # In case the normalized gene ID is not valid, use the GeneID
         if not self.is_valid(new_gene_id):
-            logging.warning(f"Gene ID is not valid: {new_gene_id}")
+            logging.debug(f"Gene ID is not valid: {new_gene_id}")
             qual = gene.qualifiers
             if "Dbxref" in qual:
                 for xref in qual["Dbxref"]:

--- a/src/python/ensembl/io/genomio/gff3/simplifier.py
+++ b/src/python/ensembl/io/genomio/gff3/simplifier.py
@@ -69,7 +69,7 @@ class GFFSimplifier:
         self,
         genome_path: Optional[PathLike] = None,
         skip_unrecognized: bool = False,
-        allow_pseudogene_with_cds: Optional[bool] = False,
+        allow_pseudogene_with_cds: bool = False,
     ):
         """Create an object that simplifies `SeqFeature` objects.
 

--- a/src/python/ensembl/io/genomio/gff3/simplifier.py
+++ b/src/python/ensembl/io/genomio/gff3/simplifier.py
@@ -68,7 +68,7 @@ class GFFSimplifier:
     def __init__(
         self,
         genome_path: Optional[PathLike] = None,
-        skip_unrecognized: Optional[bool] = False,
+        skip_unrecognized: bool = False,
         allow_pseudogene_with_cds: Optional[bool] = False,
     ):
         """Create an object that simplifies `SeqFeature` objects.

--- a/src/python/ensembl/io/genomio/gff3/simplifier.py
+++ b/src/python/ensembl/io/genomio/gff3/simplifier.py
@@ -125,8 +125,8 @@ class GFFSimplifier:
                 self.records.append(clean_record)
 
             if self.fail_types:
-                fail_errors = "\n   ".join(self.fail_types.keys())
-                logging.warning(f"Unrecognized types found:\n   {fail_errors}")
+                fail_errors = ", ".join(self.fail_types.keys())
+                logging.warning(f"Unrecognized types found: {fail_errors}")
                 if not self.skip_unrecognized:
                     raise GFFParserError("Unrecognized types found, abort")
 

--- a/src/python/ensembl/io/genomio/gff3/simplifier.py
+++ b/src/python/ensembl/io/genomio/gff3/simplifier.py
@@ -446,7 +446,6 @@ class GFFSimplifier:
             gene_subfeats.append(transcript)
         gene.sub_features = gene_subfeats
 
-
     def normalize_mirna(self, gene: SeqFeature) -> List[SeqFeature]:
         """Returns gene representations from a miRNA gene that can be loaded in an Ensembl database.
 
@@ -463,9 +462,9 @@ class GFFSimplifier:
             return []
         if len(transcript) > 1:
             raise GFFParserError(f"Gene has too many sub_features for miRNA {gene.id}")
-        
+
         logging.debug(f"Formatting miRNA gene {gene.id}")
-        
+
         primary = transcript[0]
         new_genes = []
         new_primary_subfeatures = []

--- a/src/python/ensembl/io/genomio/gff3/simplifier.py
+++ b/src/python/ensembl/io/genomio/gff3/simplifier.py
@@ -68,7 +68,7 @@ class GFFSimplifier:
     def __init__(
         self,
         genome_path: Optional[PathLike] = None,
-        skip_unrecognized: Optional[bool] = True,
+        skip_unrecognized: Optional[bool] = False,
         allow_pseudogene_with_cds: Optional[bool] = False,
     ):
         """Create an object that simplifies `SeqFeature` objects.

--- a/src/python/ensembl/io/genomio/gff3/simplifier.py
+++ b/src/python/ensembl/io/genomio/gff3/simplifier.py
@@ -115,9 +115,13 @@ class GFFSimplifier:
                 # Clean all root features and make clean record
                 clean_record = SeqRecord(record.seq, id=record.id)
                 for feature in record.features:
-                    clean_feature = self.simpler_gff3_feature(feature)
-                    if clean_feature is not None:
-                        clean_record.features.append(clean_feature)
+                    split_genes = self.normalize_mirna(feature)
+                    if split_genes:
+                        clean_record.features += split_genes
+                    else:
+                        clean_feature = self.simpler_gff3_feature(feature)
+                        if clean_feature is not None:
+                            clean_record.features.append(clean_feature)
                 self.records.append(clean_record)
 
             if self.fail_types:
@@ -441,3 +445,50 @@ class GFFSimplifier:
             transcript.sub_features = new_subfeats
             gene_subfeats.append(transcript)
         gene.sub_features = gene_subfeats
+
+
+    def normalize_mirna(self, gene: SeqFeature) -> List[SeqFeature]:
+        """Returns gene representations from a miRNA gene that can be loaded in an Ensembl database.
+
+        Change the representation from the form `gene[ primary_transcript[ exon, miRNA[ exon ] ] ]`
+        to `gene[ primary_transcript[ exon ] ]` and `gene[ miRNA[ exon ] ]`
+        """
+
+        transcript = gene.sub_features
+        if len(transcript) == 0 or transcript[0].type != "primary_transcript":
+            return []
+        if len(transcript) > 1:
+            raise GFFParserError(f"Gene has too many sub_features for miRNA {gene.id}")
+        
+        logging.debug(f"Formatting miRNA gene {gene.id}")
+        
+        primary = transcript[0]
+        new_genes = []
+        new_primary_subfeatures = []
+        num = 1
+        for sub in primary.sub_features:
+            if sub.type == "exon":
+                new_primary_subfeatures.append(sub)
+            elif sub.type == "miRNA":
+                new_gene_id = f"{gene.id}_{num}"
+                num += 1
+                new_gene = SeqFeature(sub.location, "gene", id=new_gene_id)
+                new_gene.qualifiers = {"source": sub.qualifiers["source"], "ID": new_gene_id}
+                new_gene.sub_features = [sub]
+                new_genes.append(new_gene)
+            else:
+                raise GFFParserError(f"Unknown subtypes for miRNA features: {sub.id}")
+        primary.sub_features = new_primary_subfeatures
+
+        if not new_genes:
+            raise GFFParserError(f"Could not parse a primary_transcript for {gene.id}")
+
+        all_genes = [gene] + new_genes
+
+        # Normalize like normal genes
+        all_genes_cleaned = []
+        for new_gene in all_genes:
+            new_gene = self.normalize_gene(new_gene)
+            self.annotations.store_gene(new_gene)
+            all_genes_cleaned.append(self.clean_gene(new_gene))
+        return all_genes_cleaned

--- a/src/python/ensembl/io/genomio/gff3/simplifier.py
+++ b/src/python/ensembl/io/genomio/gff3/simplifier.py
@@ -452,10 +452,14 @@ class GFFSimplifier:
 
         Change the representation from the form `gene[ primary_transcript[ exon, miRNA[ exon ] ] ]`
         to `gene[ primary_transcript[ exon ] ]` and `gene[ miRNA[ exon ] ]`
+
+        Raises:
+            GFFParserError: If gene has more than 1 transcript, the transcript was not formatted
+                correctly or there are unknown sub-features.
         """
 
         transcript = gene.sub_features
-        if len(transcript) == 0 or transcript[0].type != "primary_transcript":
+        if (len(transcript) == 0) or (transcript[0].type != "primary_transcript"):
             return []
         if len(transcript) > 1:
             raise GFFParserError(f"Gene has too many sub_features for miRNA {gene.id}")
@@ -485,7 +489,7 @@ class GFFSimplifier:
 
         all_genes = [gene] + new_genes
 
-        # Normalize like normal genes
+        # Normalize like other genes
         all_genes_cleaned = []
         for new_gene in all_genes:
             new_gene = self.normalize_gene(new_gene)


### PR DESCRIPTION
Move the miRNA from under the primary_transcript, to its own gene, so that it can be imported in Ensembl core database.

Also change the default to fail if an unsupported type is found.
