### PR TITLE
Addition of a new sub-module 'status' to assembly module. 

### DIFF
--- a/containers/ncbi_datasets_v16.10.0.def
+++ b/containers/ncbi_datasets_v16.10.0.def
@@ -1,3 +1,18 @@
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 Bootstrap: docker
 From: ubuntu:24.04
 
@@ -16,19 +31,14 @@ From: ubuntu:24.04
 %post
     apt-get update && apt-get -y upgrade
     apt-get -y install \
-
     wget \
-    
     unzip \
-    
     procps \
-    
     ca-certificates \
-    
+
     rm -rf /var/lib/apt/lists/*
-    
     apt-get clean
-    
+
     #Installing ncbi datasets & dataformat
     cd /usr/local/bin/ && \
     wget https://github.com/ncbi/datasets/releases/download/v16.10.0/linux-amd64.cli.package.zip && \

--- a/containers/ncbi_datasets_v16.10.0.def
+++ b/containers/ncbi_datasets_v16.10.0.def
@@ -22,7 +22,7 @@ From: ubuntu:24.04
     export LC_ALL=C
 
 %labels
-    Author lcampbell@ebi.ac.uk
+    Author ensembl-metazoa@ebi.ac.uk
     Software "NCBI's datasets and dataformat"
     Software.version v16.10.0
     Software.website "https://github.com/ncbi/datasets/releases/tag/v16.10.0"

--- a/containers/ncbi_datasets_v16.10.0.def
+++ b/containers/ncbi_datasets_v16.10.0.def
@@ -16,12 +16,17 @@ From: ubuntu:24.04
 %post
     apt-get update && apt-get -y upgrade
     apt-get -y install \
+
     wget \
+    
     unzip \
+    
     procps \
+    
     ca-certificates \
     
     rm -rf /var/lib/apt/lists/*
+    
     apt-get clean
     
     #Installing ncbi datasets & dataformat

--- a/containers/ncbi_datasets_v16.10.0.def
+++ b/containers/ncbi_datasets_v16.10.0.def
@@ -1,0 +1,50 @@
+Bootstrap: docker
+From: ubuntu:24.04
+
+%environment
+    export SINGULARITY_SHELL=/bin/bash
+    export DEBIAN_FRONTEND=noninteractive
+    export LC_ALL=C
+
+%labels
+    Author lcampbell@ebi.ac.uk
+    Software "NCBI's datasets and dataformat"
+    Software.version v16.10.0
+    Software.website "https://github.com/ncbi/datasets/releases/tag/v16.10.0"
+    Description "NCBI Datasets is a new resource that lets you easily gather data from across NCBI databases."
+
+%post
+    apt-get update && apt-get -y upgrade
+    apt-get -y install \
+    wget \
+    unzip \
+    procps \
+    ca-certificates \
+    
+    rm -rf /var/lib/apt/lists/*
+    apt-get clean
+    
+    #Installing ncbi datasets & dataformat
+    cd /usr/local/bin/ && \
+    wget https://github.com/ncbi/datasets/releases/download/v16.10.0/linux-amd64.cli.package.zip && \
+    unzip linux-amd64.cli.package.zip && \
+    rm linux-amd64.cli.package.zip && \
+    chmod +x datasets dataformat
+
+%test
+    #!/usr/bin/bash
+    echo "Testing OS is Ubuntu...."
+    source /etc/os-release
+    grep -q -e "PRETTY_NAME=\"Ubuntu" /etc/os-release
+    if [ $? -eq 0 ]; then
+        if [ $VERSION_ID == "24.04" ]; then
+	   echo "Container base is Ubuntu version ${VERSION_ID} as expected."
+        fi
+    else
+        echo "Container base is not Ubuntu."
+        exit 1
+    fi
+
+    echo -e -n "\n** Checking we have datasets installed **\n"
+    datasets --version
+    datasets --help

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ dependencies = [
     "mysql-connector-python >= 8.0.29",
     "python-redmine >= 2.3.0",
     "requests >= 2.28.0",
+    "spython >= 0.3.13",
 ]
 
 [project.optional-dependencies]
@@ -91,6 +92,7 @@ documentation = "https://ensembl.github.io/ensembl-genomio"
 [project.scripts]
 # Assembly
 assembly_download = "ensembl.io.genomio.assembly.download:main"
+assembly_tracker = "ensembl.io.genomio.assembly.status:main"
 # Database
 database_factory = "ensembl.io.genomio.database.factory:main"
 # Events

--- a/src/python/ensembl/io/genomio/assembly/__init__.py
+++ b/src/python/ensembl/io/genomio/assembly/__init__.py
@@ -15,3 +15,4 @@
 """Assembly preparation module."""
 
 from .download import *
+from .status import *

--- a/src/python/ensembl/io/genomio/assembly/status.py
+++ b/src/python/ensembl/io/genomio/assembly/status.py
@@ -462,7 +462,7 @@ def main() -> None:
     # Pull or load pre-existing 'datasets' singularity container image.
     datasets_image = Client.pull(container_url, stream=False, pull_folder=image_dl_path, quiet=True)
 
-    # Datasets query implementation for one or more bacthed accessions
+    # Datasets query implementation for one or more batched accessions
     assembly_reports = datasets_asm_reports(
         datasets_image, query_accessions, args.download_dir, args.datasets_batch_size
     )

--- a/src/python/ensembl/io/genomio/assembly/status.py
+++ b/src/python/ensembl/io/genomio/assembly/status.py
@@ -199,7 +199,7 @@ def fetch_accessions_from_cores(database_names: list, connection_url: URL) -> Di
 
         if query_result is None:
             logging.warning(f"We have no accession on core: {core}")
-        elif len(qry_result) == 1:
+        elif len(query_result) == 1:
             count_accn_found += 1
             asm_accession = qry_result.pop()[0]
             logging.info(f"{core} -> assembly.accession[{asm_accession}]")

--- a/src/python/ensembl/io/genomio/assembly/status.py
+++ b/src/python/ensembl/io/genomio/assembly/status.py
@@ -197,7 +197,7 @@ def fetch_accessions_from_cores(database_names: list, connection_url: URL) -> Di
             'SELECT meta_value FROM meta WHERE meta_key = "assembly.accession";'
         ).fetchall()
 
-        if qry_result is None:
+        if query_result is None:
             logging.warning(f"We have no accession on core: {core}")
         elif len(qry_result) == 1:
             count_accn_found += 1

--- a/src/python/ensembl/io/genomio/assembly/status.py
+++ b/src/python/ensembl/io/genomio/assembly/status.py
@@ -73,7 +73,7 @@ class ReportStructure(dict):
 
 def resolve_query_type(
     query_list: list, host_server: str, host_port: str, input_cores: str, input_accessions: str
-) -> Union[Tuple[Dict,str]]:
+) -> Union[Tuple[Dict, str]]:
     """Function to indentify the kind of querys being passed by user,
     then extract the queries (core names or accesisons) and store each with appropriate identifier.
 
@@ -313,6 +313,7 @@ def generate_report_tsv(
 
 # def classify_assembly_status(core_accessions: dict) -> None:
 #     """Main function to pare set of core list and call ncbi datasets"""
+
 
 def main() -> None:
     """Module's entry-point."""

--- a/src/python/ensembl/io/genomio/assembly/status.py
+++ b/src/python/ensembl/io/genomio/assembly/status.py
@@ -250,8 +250,7 @@ def datasets_asm_reports(
         if not isinstance(result, str):
             raise ValueError("Result obtained from datasets is not the expected format 'string'")
         if re.search("^FATAL", result):
-            logging.critical(f"Singularity image execution failed! -> '{result.strip()}'")
-            sys.exit(1)
+            raise RuntimeError(f"Singularity image execution failed! -> '{result.strip()}'")
         # Returned a list, i.e. datasets returned a result to client.execute
 
         tmp_asm_dict = json.loads(result)

--- a/src/python/ensembl/io/genomio/assembly/status.py
+++ b/src/python/ensembl/io/genomio/assembly/status.py
@@ -108,7 +108,7 @@ def examine_parameterization(
             )
             sys.exit()
     # Accession centered run
-    elif input_cores is None and input_accessions:
+    else:
         user_query_file = input_accessions
         logging.info(f"Performing assembly status report using INSDC accession list file: {user_query_file}")
 

--- a/src/python/ensembl/io/genomio/assembly/status.py
+++ b/src/python/ensembl/io/genomio/assembly/status.py
@@ -260,8 +260,8 @@ def datasets_asm_reports(
             batch_reports_json = tmp_asm_dict["reports"]
             for assembly_report in batch_reports_json:
                 accession = assembly_report["accession"]
-                asm_json_outfile = f"{download_directory}/{accession}.asm_report.json"
-                print_json(Path(asm_json_outfile), assembly_report)
+                asm_json_outfile = Path(download_directory, f"/{accession}.asm_report.json")
+                print_json(asm_json_outfile, assembly_report)
                 # Save assembly report into master core<>report dict
                 for core, accession_core in assembly_accessions.items():
                     if accession == accession_core:

--- a/src/python/ensembl/io/genomio/assembly/status.py
+++ b/src/python/ensembl/io/genomio/assembly/status.py
@@ -181,6 +181,7 @@ def fetch_accessions_from_cores(database_names: list, connection_url: URL) -> Di
     Args:
         database_names: Set of names for one or more core databases
         connection_url: Partial MYSQL host name : port
+
     Returns:
         Dict of core name(s) (key) and its INSDC assembly.accession (value)
     """

--- a/src/python/ensembl/io/genomio/assembly/status.py
+++ b/src/python/ensembl/io/genomio/assembly/status.py
@@ -31,8 +31,7 @@ import os
 from os import PathLike
 from pathlib import Path
 import re
-import sys
-from typing import Dict, Tuple, Union, List
+from typing import Dict, List, Tuple, Union
 
 from spython.main import Client
 from sqlalchemy.engine import URL

--- a/src/python/ensembl/io/genomio/assembly/status.py
+++ b/src/python/ensembl/io/genomio/assembly/status.py
@@ -27,12 +27,12 @@ __all__ = [
 import csv
 import json
 import os
-from os import PathLike, getcwd
-from pathlib import Path
 import re
 import logging
 import sys
 from typing import Dict, Tuple, Union
+from pathlib import Path
+from os import PathLike
 
 from spython.main import Client
 from sqlalchemy.engine import URL
@@ -41,6 +41,7 @@ from ensembl.io.genomio.utils.json_utils import print_json
 from ensembl.io.genomio.database.dbconnection_lite import DBConnectionLite as dbc
 from ensembl.utils.argparse import ArgumentParser
 from ensembl.utils.logging import init_logging_with_args
+
 
 DATASETS_SINGULARITY = {
     "datasets_version_url": "library://lcampbell/ensembl-genomio/ncbi-datasets-v16.10.0:latest",
@@ -81,7 +82,7 @@ def singularity_image_setter(sif_cache_dir: Path, datasets_version: str) -> Clie
         datasets_version: URL of singularity container (custom 'datasets' version if desired)
 
     Returns:
-        spython.main.client instance of singularity container image housing 'datasets'
+        `spython.main.client` instance of singularity container image housing 'datasets'.
     """
 
     # Set singularity cache dir from user defined path or use environment
@@ -347,7 +348,7 @@ def generate_report_tsv(
     parsed_asm_reports: dict,
     outfile_prefix: str,
     query_type: str,
-    output_directory: PathLike = Path(getcwd()),
+    output_directory: PathLike = Path(),
 ) -> None:
     """Generate and write the assembly report to a TSV file
 
@@ -369,10 +370,6 @@ def generate_report_tsv(
             final_asm_report = [core] + list(report_meta.values())
             writer.writerow(final_asm_report)
         tsv_out.close()
-
-
-# def classify_assembly_status(core_accessions: dict) -> None:
-#     """Main function to pare set of core list and call ncbi datasets"""
 
 
 def main() -> None:
@@ -444,8 +441,7 @@ def main() -> None:
     init_logging_with_args(args)
 
     # Set and create dir for download files
-    if not args.download_dir.is_dir():
-        args.download_dir.mkdir(parents=True)
+    args.download_dir.mkdir(parents=True, exist_ok=True)
 
     # Set input file and determine if proper parameterization options are defined.
     user_query_file = check_parameterization(args.input_cores, args.input_accessions, args.host, args.port)

--- a/src/python/ensembl/io/genomio/assembly/status.py
+++ b/src/python/ensembl/io/genomio/assembly/status.py
@@ -32,7 +32,7 @@ from os import PathLike
 from pathlib import Path
 import re
 import sys
-from typing import Dict, Tuple, Union
+from typing import Dict, Tuple, Union, List
 
 from spython.main import Client
 from sqlalchemy.engine import URL
@@ -174,7 +174,7 @@ def resolve_query_type(
     return query_accessions, query_type
 
 
-def fetch_accessions_from_cores(database_names: list, connection_url: URL) -> Dict:
+def fetch_accessions_from_cores(database_names: List, connection_url: URL) -> Dict:
     """Obtain the associated INSDC accession [meta.assembly.accession] given a set of core(s) names
     and a MYSQL server host.
 
@@ -215,8 +215,7 @@ def fetch_accessions_from_cores(database_names: list, connection_url: URL) -> Di
 def datasets_asm_reports(
     sif_image: str, assembly_accessions: dict, download_directory: PathLike, batch_size: int
 ) -> Dict:
-    """Obtain multiple assembly report JSONs in one or more querys to datasets,
-    i.e. make individual since accn query to datasets tool.
+    """Obtain assembly report(s) JSONs for one or more queries made to datasets CLI.
 
     Args:
         sif_image: Instance of Client.loaded singularity image.

--- a/src/python/ensembl/io/genomio/assembly/status.py
+++ b/src/python/ensembl/io/genomio/assembly/status.py
@@ -341,7 +341,7 @@ def generate_report_tsv(
     query_type: str,
     output_directory: PathLike = Path(),
 ) -> None:
-    """Generate and write the assembly report to a TSV file
+    """Generate and write the assembly report to a TSV file.
 
     Args:
         parsed_asm_reports: Parsed assembly report meta

--- a/src/python/ensembl/io/genomio/assembly/status.py
+++ b/src/python/ensembl/io/genomio/assembly/status.py
@@ -198,7 +198,7 @@ def fetch_accessions_from_cores(database_names: list, connection_url: URL) -> Di
         ).fetchall()
 
         if query_result is None:
-            logging.warning(f"We have no accession on core: {core}")
+            logging.warning(f"No accessions found in core: {core}")
         elif len(query_result) == 1:
             count_accn_found += 1
             asm_accession = qry_result.pop()[0]

--- a/src/python/ensembl/io/genomio/assembly/status.py
+++ b/src/python/ensembl/io/genomio/assembly/status.py
@@ -165,7 +165,7 @@ def datasets_asm_reports(
     combined_asm_reports = {}
 
     # Setting the number of combined accessions to query in a single call to datasets
-    list_split = list(range(0, len(master_accn_list), batch_size)) ## Note best to use >=10
+    list_split = list(range(0, len(master_accn_list), batch_size))  ## Note best to use >=10
     accn_subsample = [master_accn_list[ind : ind + batch_size] for ind in list_split]
 
     for accessions in accn_subsample:
@@ -300,7 +300,6 @@ def generate_report_tsv(
     header_list = [query_type] + header_list
 
     with open(tsv_outfile, "w+") as tsv_out:
-
         writer = csv.writer(tsv_out, delimiter="\t", lineterminator="\n")
         writer.writerow(header_list)
 
@@ -387,9 +386,7 @@ def main() -> None:
         )
         exit()
     elif args.input_cores and args.input_accns:
-        logging.critical(
-            "Detected '--input_cores' AND '--input_accns'. Please provide just one such option."
-        )
+        logging.critical("Detected '--input_cores' AND '--input_accns'. Please provide just one such option.")
         exit()
     # Input core names centered run
     elif args.input_cores and args.input_accns is None:

--- a/src/python/ensembl/io/genomio/assembly/status.py
+++ b/src/python/ensembl/io/genomio/assembly/status.py
@@ -100,10 +100,9 @@ def resolve_query_type(
             match = re.match(r"(GC[AF])_([0-9]{3})([0-9]{3})([0-9]{3})\.?([0-9]+)", accession)
             if not match:
                 raise UnsupportedFormatError(f"Could not recognize GCA accession format: {accession}")
-            else:
-                query_name = f"Query_#{query_count}"
-                query_count += 1
-                query_accessions[query_name] = accession
+            query_name = f"Query_#{query_count}"
+            query_count += 1
+            query_accessions[query_name] = accession
 
     return query_accessions, query_type
 
@@ -166,7 +165,7 @@ def datasets_asm_reports(
     combined_asm_reports = {}
 
     # Setting the number of combined accessions to query in a single call to datasets
-    list_split = [i for i in range(0, len(master_accn_list), batch_size)]  ## Note best to use >=10
+    list_split = list(range(0, len(master_accn_list), batch_size)) ## Note best to use >=10
     accn_subsample = [master_accn_list[ind : ind + batch_size] for ind in list_split]
 
     for accessions in accn_subsample:

--- a/src/python/ensembl/io/genomio/assembly/status.py
+++ b/src/python/ensembl/io/genomio/assembly/status.py
@@ -353,7 +353,7 @@ def main() -> None:
         type=str,
         required=False,
         metavar="URL",
-        help="Custom datasets version. E.g. library://lcampbell/ensembl-genomio/ncbi-datasets-v16.10.0:latest",
+        help="datasets version: E.g. library://lcampbell/ensembl-genomio/ncbi-datasets-v16.10.0:latest",
     )
     parser.add_argument(
         "--cache_dir",
@@ -384,12 +384,12 @@ def main() -> None:
     # Check for required input in the form of cores/accessions
     if args.input_cores is None and args.input_accns is None:
         logging.critical(
-            f"Did not detect user required input. Please specify option: '--input_cores' (core db names); OR '--input_accns' (INSDC accessions)."
+            "Missing required input: '--input_cores' (core db names) OR '--input_accns' (INSDC accessions)."
         )
         exit()
     elif args.input_cores and args.input_accns:
         logging.critical(
-            f"Detected both '--input_cores' AND '--input_accns' user inputs. Please provide just one such option."
+            "Detected '--input_cores' AND '--input_accns'. Please provide just one such option."
         )
         exit()
     # Input core names centered run
@@ -397,8 +397,8 @@ def main() -> None:
         user_query_file = args.input_cores
         logging.info(f"Performing assembly status report using core db list file: {user_query_file}")
         if args.host is None or args.port is None:
-            print(
-                f"User must specify both arguments '--host' and '--port' when providing core database names. Exiting !"
+            logging.critical(
+                "User must specify both arguments '--host' and '--port' when providing core database names."
             )
             exit()
     # Accession centered run

--- a/src/python/ensembl/io/genomio/assembly/status.py
+++ b/src/python/ensembl/io/genomio/assembly/status.py
@@ -245,7 +245,7 @@ def datasets_asm_reports(
 
         result = client_return["message"]
 
-        ## Test what result we have returned following execution of sif image and accession value
+        ## Test what result we have obtained following execution of sif image and accession value
         # Returned a str, i.e. no datasets result obtained exited with fatal error
         if not isinstance(result, str):
             raise ValueError("Result obtained from datasets is not the expected format 'string'")

--- a/src/python/ensembl/io/genomio/assembly/status.py
+++ b/src/python/ensembl/io/genomio/assembly/status.py
@@ -77,7 +77,7 @@ def singularity_image_setter(sif_cache_dir: Path, datasets_version: str) -> Clie
     container and define version and location of container.
 
     Args:
-        sif_cache_dir: Path to attempt locating/download SIF container image.
+        sif_cache_dir: Path to locate existing, or download new SIF container image.
         datasets_version: URL of singularity container (custom 'datasets' version if desired)
 
     Returns:
@@ -121,10 +121,10 @@ def check_parameterization(input_cores: Path, input_accessions: Path, db_host: s
     incorrect parameterization.
 
     Args:
-        input_cores: input core(s) list file name.
-        input_accessions: input accession (s) list file name.
-        db_host: host server name
-        db_port: host server port
+        input_cores: Input core(s) list file name.
+        input_accessions: Input accession (s) list file name.
+        db_host: Host server name
+        db_port: Host server port
 
     Returns:
         User input file used in assembly status querying
@@ -149,8 +149,8 @@ def resolve_query_type(
     Args:
         query_list: List of user defined queries either core names, or accessions
         partial_url: A partial MYSQL connection URL (host:port)
-        input_cores: arg parse param '--input_cores'
-        input_accessions: arg parse param '--input_accns'
+        input_cores: Arg parse param '--input_cores'
+        input_accessions: Arg parse param '--input_accessions'
 
     Returns:
         User queries stored as identifier[(core db name | UniqueID#)] : accession
@@ -258,7 +258,7 @@ def datasets_asm_reports(
             batch_reports_json = tmp_asm_dict["reports"]
             for assembly_report in batch_reports_json:
                 accession = assembly_report["accession"]
-                asm_json_outfile = Path(download_directory, f"/{accession}.asm_report.json")
+                asm_json_outfile = Path(download_directory, f"{accession}.asm_report.json")
                 print_json(asm_json_outfile, assembly_report)
                 # Save assembly report into master core<>report dict
                 for core, accession_core in assembly_accessions.items():

--- a/src/python/ensembl/io/genomio/assembly/status.py
+++ b/src/python/ensembl/io/genomio/assembly/status.py
@@ -256,7 +256,7 @@ def datasets_asm_reports(
 
         tmp_asm_dict = json.loads(result)
         if tmp_asm_dict["total_count"] >= 1:
-            logging.info(f"Asm report obtained for accession(s) [{accessions}]")
+            logging.info(f"Assembly report obtained for accession(s) {accessions}")
 
             batch_reports_json = tmp_asm_dict["reports"]
             for assembly_report in batch_reports_json:

--- a/src/python/ensembl/io/genomio/assembly/status.py
+++ b/src/python/ensembl/io/genomio/assembly/status.py
@@ -359,8 +359,6 @@ def generate_report_tsv(
     tsv_outfile = f"{output_directory}/{outfile_prefix}.tsv"
 
     header_list = list(ReportStructure().keys())
-    # header_list.remove("Strain")
-    # header_list.remove("Isolate")
     header_list = [query_type] + header_list
 
     with open(tsv_outfile, "w+") as tsv_out:
@@ -480,3 +478,5 @@ def main() -> None:
 
     # Produce the finalized assembly status report TSV from set of parsed 'datasets summary report'
     generate_report_tsv(key_assembly_report_meta, args.assembly_report_prefix, query_type, args.download_dir)
+
+    sys.exit(0)

--- a/src/python/ensembl/io/genomio/assembly/status.py
+++ b/src/python/ensembl/io/genomio/assembly/status.py
@@ -193,7 +193,7 @@ def fetch_accessions_from_cores(database_names: list, connection_url: URL) -> Di
     for core in database_names:
         db_connection_url = connection_url.set(database=core)
         db_connection = dbc(f"{db_connection_url}")
-        qry_result = db_connection.execute(
+        query_result = db_connection.execute(
             'SELECT meta_value FROM meta WHERE meta_key = "assembly.accession";'
         ).fetchall()
 

--- a/src/python/ensembl/io/genomio/assembly/status.py
+++ b/src/python/ensembl/io/genomio/assembly/status.py
@@ -281,7 +281,7 @@ def datasets_asm_reports(
 
 
 def extract_assembly_metadata(assembly_reports: Dict[str, dict]) -> Dict[str, ReportStructure]:
-    """ "Function to parse assembly reports and extract specific key information on
+    """Function to parse assembly reports and extract specific key information on
     status and related fields.
 
     Args:

--- a/src/python/ensembl/io/genomio/assembly/status.py
+++ b/src/python/ensembl/io/genomio/assembly/status.py
@@ -336,7 +336,7 @@ def extract_assembly_metadata(assembly_reports: Dict[str, dict]) -> Dict[str, Re
 
 
 def generate_report_tsv(
-    parsed_asm_reports: dict,
+    parsed_asm_reports: Dict,
     outfile_prefix: str,
     query_type: str,
     output_directory: PathLike = Path(),

--- a/src/python/ensembl/io/genomio/assembly/status.py
+++ b/src/python/ensembl/io/genomio/assembly/status.py
@@ -71,10 +71,11 @@ class ReportStructure(dict):
             }
         )
 
-def examine_parameterization(input_cores: PathLike,
-    input_accessions: PathLike, db_host: str, db_port: int
-    ) -> Path:
-    """Detect the kind of user input (cores/accessions) and determine any missing or 
+
+def examine_parameterization(
+    input_cores: PathLike, input_accessions: PathLike, db_host: str, db_port: int
+) -> Path:
+    """Detect the kind of user input (cores/accessions) and determine any missing or
     incorrect parameterization.
 
     Args:
@@ -112,6 +113,7 @@ def examine_parameterization(input_cores: PathLike,
         logging.info(f"Performing assembly status report using INSDC accession list file: {user_query_file}")
 
     return user_query_file
+
 
 def resolve_query_type(
     query_list: list, host_server: str, host_port: str, input_cores: str, input_accessions: str

--- a/src/python/ensembl/io/genomio/assembly/status.py
+++ b/src/python/ensembl/io/genomio/assembly/status.py
@@ -201,7 +201,7 @@ def fetch_accessions_from_cores(database_names: list, connection_url: URL) -> Di
             logging.warning(f"No accessions found in core: {core}")
         elif len(query_result) == 1:
             count_accn_found += 1
-            asm_accession = qry_result.pop()[0]
+            asm_accession = query_result.pop()[0]
             logging.info(f"{core} -> assembly.accession[{asm_accession}]")
             core_accn_meta[core] = asm_accession
         else:

--- a/src/python/ensembl/io/genomio/assembly/status.py
+++ b/src/python/ensembl/io/genomio/assembly/status.py
@@ -99,7 +99,7 @@ def examine_parameterization(
         logging.critical("Detected '--input_cores' AND '--input_accns'. Please provide just one such option.")
         sys.exit()
     # Input core names centered run
-    elif input_cores and input_accessions is None:
+    elif input_cores:
         user_query_file = input_cores
         logging.info(f"Performing assembly status report using core db list file: {user_query_file}")
         if db_host is None or db_port is None:

--- a/src/python/ensembl/io/genomio/assembly/status.py
+++ b/src/python/ensembl/io/genomio/assembly/status.py
@@ -205,7 +205,7 @@ def fetch_accessions_from_cores(database_names: list, connection_url: URL) -> Di
             logging.info(f"{core} -> assembly.accession[{asm_accession}]")
             core_accn_meta[core] = asm_accession
         else:
-            logging.warning(f"Core {core} Has {len(qry_result)} assembly.accessions")
+            logging.warning(f"Core {core} has {len(query_result)} assembly.accessions")
 
     logging.info(f"From initial input cores ({core_list_count}), obtained ({count_accn_found}) accessions")
 

--- a/src/python/ensembl/io/genomio/assembly/status.py
+++ b/src/python/ensembl/io/genomio/assembly/status.py
@@ -130,23 +130,15 @@ def check_parameterization(input_cores: Path, input_accessions: Path, db_host: s
     Returns:
         User input file used in assembly status querying
     """
-    user_query_file: Path
-
     # Input core names centered run
     if input_cores:
-        user_query_file = input_cores
-        logging.info(f"Performing assembly status report using core db list file: {user_query_file}")
+        logging.info(f"Performing assembly status report using core db list file: {input_cores}")
         if db_host is None or db_port is None:
-            logging.critical(
-                "User must specify both arguments '--host' and '--port' when providing core database names."
-            )
-            sys.exit(1)
+            raise RuntimeError("Core database names require both arguments '--host' and '--port'")
+        return input_cores
     # Accession centered run
-    else:
-        user_query_file = input_accessions
-        logging.info(f"Performing assembly status report using INSDC accession list file: {user_query_file}")
-
-    return user_query_file
+    logging.info(f"Performing assembly status report using INSDC accession list file: {input_accessions}")
+    return input_accessions
 
 
 def resolve_query_type(

--- a/src/python/ensembl/io/genomio/assembly/status.py
+++ b/src/python/ensembl/io/genomio/assembly/status.py
@@ -232,7 +232,7 @@ def datasets_asm_reports(
     combined_asm_reports = {}
 
     # Setting the number of combined accessions to query in a single call to datasets
-    list_split = list(range(0, len(master_accn_list), batch_size))  ## Note best to use >=10
+    list_split = list(range(0, len(master_accn_list), batch_size))
     accn_subsample = [master_accn_list[ind : ind + batch_size] for ind in list_split]
 
     for accessions in accn_subsample:

--- a/src/python/ensembl/io/genomio/assembly/status.py
+++ b/src/python/ensembl/io/genomio/assembly/status.py
@@ -118,8 +118,8 @@ def examine_parameterization(
 def resolve_query_type(
     query_list: list, host_server: str, host_port: str, input_cores: str, input_accessions: str
 ) -> Union[Tuple[Dict, str]]:
-    """Function to indentify the kind of querys being passed by user,
-    then extract the queries (core names or accesisons) and store each with appropriate identifier.
+    """Function to identify the kind of queries being passed by user,
+    then extract the queries (core names or accessions) and store each with appropriate identifier.
 
     Args:
         query_list: List of user defined queries either core names, or accessions
@@ -127,7 +127,7 @@ def resolve_query_type(
         input_accessions: arg parse param '--input_accns'
 
     Returns:
-        User queries stored as indentifier[(core db name | UniqueID#)] : accession
+        User queries stored as identifier[(core db name | UniqueID#)] : accession
     """
 
     query_accessions: Dict = {}

--- a/src/python/ensembl/io/genomio/assembly/status.py
+++ b/src/python/ensembl/io/genomio/assembly/status.py
@@ -379,9 +379,7 @@ def generate_report_tsv(
 
 def main() -> None:
     """Module's entry-point."""
-    parser = ArgumentParser(
-        description=__doc__
-    )
+    parser = ArgumentParser(description=__doc__)
     input_group = parser.add_mutually_exclusive_group(required=True)
     input_group.add_argument(
         "--input_cores",
@@ -479,4 +477,3 @@ def main() -> None:
 
     # Produce the finalized assembly status report TSV from set of parsed 'datasets summary report'
     generate_report_tsv(key_assembly_report_meta, args.assembly_report_prefix, query_type, args.download_dir)
-

--- a/src/python/ensembl/io/genomio/assembly/status.py
+++ b/src/python/ensembl/io/genomio/assembly/status.py
@@ -1,0 +1,458 @@
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Record the assembly status for a set of INSDC accessions using ncbi 'datasets' tool"""
+
+__all__ = [
+    "resolve_query_type",
+    "fetch_asm_accn",
+    "datasets_asm_reports",
+    "extract_assembly_metadata",
+    "generate_report_tsv",
+]
+
+import csv
+import json
+import os
+from os import PathLike, getcwd
+from pathlib import Path
+import re
+import logging
+from sys import exit
+from typing import Dict, Tuple, Union
+
+from spython.main import Client
+
+from ensembl.io.genomio.utils.json_utils import print_json
+from ensembl.database import DBConnection as dbc
+from ensembl.utils.argparse import ArgumentParser
+from ensembl.utils.logging import init_logging_with_args
+
+DATASETS_SINGULARITY = {
+    "datasets_version_url": "library://lcampbell/ensembl-genomio/ncbi-datasets-v16.10.0:latest",
+}
+
+
+class UnsupportedFormatError(Exception):
+    """When a string does not have the expected format."""
+
+
+class ReportStructure(dict):
+    """Dict setter class of key report meta information"""
+
+    def __init__(self):
+        dict.__init__(self)
+        self.update(
+            {
+                "Species Name": "",
+                "Taxon ID": "",
+                "Strain": "",
+                "Isolate": "",
+                "Isolate/Strain": "",
+                "Asm name": "",
+                "Assembly type": "",
+                "Asm accession": "",
+                "Paired assembly": "",
+                "Asm last updated": "",
+                "Asm status": "",
+                "Asm notes": "",
+            }
+        )
+
+
+def resolve_query_type(
+    query_list: list, host_server: str, host_port: str, input_cores: str, input_accessions: str
+) -> Union[Tuple[Dict,str]]:
+    """Function to indentify the kind of querys being passed by user,
+    then extract the queries (core names or accesisons) and store each with appropriate identifier.
+
+    Args:
+        query_list: List of user defined queries either core names, or accessions
+        input_cores: arg parse param '--input_cores'
+        input_accessions: arg parse param '--input_accns'
+
+    Returns:
+        User queries stored as indentifier[(core db name | UniqueID#)] : accession
+    """
+
+    query_accessions: Dict = {}
+    query_type: str = ""
+
+    if input_cores and input_accessions is None:
+        server_details = f"mysql://ensro@{host_server}:{host_port}/"  ## Requires some more dev !!
+        query_accessions = fetch_asm_accn(query_list, server_details)
+        query_type = "CoreDB"
+    elif input_cores is None and input_accessions:
+        query_count = 1
+        query_type = "Accession"
+        for accession in query_list:
+            match = re.match(r"(GC[AF])_([0-9]{3})([0-9]{3})([0-9]{3})\.?([0-9]+)", accession)
+            if not match:
+                raise UnsupportedFormatError(f"Could not recognize GCA accession format: {accession}")
+            else:
+                query_name = f"Query_#{query_count}"
+                query_count += 1
+                query_accessions[query_name] = accession
+
+    return query_accessions, query_type
+
+
+def fetch_asm_accn(database_names: list, server_details: str) -> Dict:
+    """Obtain the associated INSDC accession [meta.assembly.accession] given a set of core(s) names
+    and a MYSQL server host.
+
+    Args:
+        cores: Set of names for one or more core databases
+        server_details: MYSQL host server name and port [mysql-ens-(NAME:Port)]
+
+    Returns:
+        Dict of core name(s) (key) and its INSDC assembly.accession (value)
+    """
+
+    core_accn_meta = {}
+    core_list_count = len(database_names)
+    count_accn_found = 0
+
+    for core in database_names:
+        db_connection_url = f"{server_details}{core}"
+        db_connection = dbc(f"{db_connection_url}")
+        qry_result = db_connection.execute(
+            'SELECT meta_value FROM meta WHERE meta_key = "assembly.accession";'
+        ).fetchall()
+
+        if qry_result is None:
+            logging.warning(f"We have no accession on core: {core}")
+        elif len(qry_result) == 1:
+            count_accn_found += 1
+            asm_accession = qry_result.pop()[0]
+            logging.info(f"{core} -> assembly.accession[{asm_accession}]")
+            core_accn_meta[core] = asm_accession
+        else:
+            logging.warning(f"Core {core} Has {len(qry_result)} assembly.accessions")
+
+    logging.info(f"From initial input cores ({core_list_count}), obtained ({count_accn_found}) accessions")
+
+    return core_accn_meta
+
+
+def datasets_asm_reports(
+    sif_image: str, assembly_accessions: dict, download_directory: PathLike, batch_size: int
+) -> Dict:
+    """Obtain multiple assembly report JSONs in one or more querys to datasets,
+    i.e. make individual since accn query to datasets tool.
+
+    Args:
+        sif_image: Instance of Client.loaded singularity image.
+        assembly_accessions: Dict of core accessions.
+        download_directory: Dir path to store assembly report JSON files.
+        batch_size: Number of assembly accessions to batch submit to 'datasets'.
+
+    Returns:
+        Dictionary of core name and its assoicated assembly report
+    """
+
+    master_accn_list = list(assembly_accessions.values())
+    combined_asm_reports = {}
+
+    # Setting the number of combined accessions to query in a single call to datasets
+    list_split = [i for i in range(0, len(master_accn_list), batch_size)]  ## Note best to use >=10
+    accn_subsample = [master_accn_list[ind : ind + batch_size] for ind in list_split]
+
+    for accessions in accn_subsample:
+        datasets_command = ["datasets", "summary", "genome", "accession"] + accessions
+
+        # Make call to singularity datasets providing a multi accn query:
+        client_return = Client.execute(
+            image=sif_image, command=datasets_command, return_result=True, quiet=True
+        )
+
+        result = client_return["message"]
+
+        ## Test what result we have returned following execution of sif image and accession value
+        # Returned a str, i.e. no datasets result obtained exited with fatal error
+        if isinstance(result, str) and re.search("^FATAL", result):
+            logging.critical(f"Singularity image execution failed! -> '{result.strip()}'")
+        # Returned a list, i.e. datasets returned a result to client.execute
+        elif isinstance(result, str):
+            tmp_asm_dict = json.loads(result)
+
+            if tmp_asm_dict["total_count"] == 0:
+                logging.warning(f"No assembly report found for accession(s) {accessions}")
+            elif tmp_asm_dict["reports"]:
+                logging.info(f"Asm report obtained for accession(s) [{accessions}]")
+                batch_reports_json = tmp_asm_dict["reports"]
+                for assembly_report in batch_reports_json:
+                    accession = assembly_report["accession"]
+                    asm_json_outfile = f"{download_directory}/{accession}.asm_report.json"
+                    print_json(Path(asm_json_outfile), assembly_report)
+
+                    # Save assembly report into master core<>report dict
+                    for core, accession_core in assembly_accessions.items():
+                        if accession == accession_core:
+                            combined_asm_reports[core] = assembly_report
+            else:
+                logging.critical("Something is not right parsing 'datasets' results !")
+        else:
+            logging.critical(
+                f"Something not right while running datasets with singularity client.execute {result}"
+            )
+    return combined_asm_reports
+
+
+def extract_assembly_metadata(assembly_reports: Dict[str, dict]) -> Dict[str, ReportStructure]:
+    """ "Function to parse assembly reports and extract specific key information on
+    status and related fields.
+
+    Args:
+        assembly_reports: Key value pair of core_name : assembly report.
+
+    Returns:
+        Parsed assembly report meta (core, meta).
+    """
+    parsed_meta = {}
+
+    for core, asm_report in assembly_reports.items():
+        asm_meta_info = ReportStructure()
+
+        # Mandatory meta key parsing:
+        asm_meta_info["Asm accession"] = asm_report["accession"]
+        asm_meta_info["Asm name"] = asm_report["assembly_info"]["assembly_name"]
+        asm_meta_info["Assembly type"] = asm_report["assembly_info"]["assembly_type"]
+        asm_meta_info["Asm status"] = asm_report["assembly_info"]["assembly_status"]
+        asm_meta_info["Species Name"] = asm_report["organism"]["organism_name"]
+        asm_meta_info["Taxon ID"] = asm_report["organism"]["tax_id"]
+
+        ## Non-mandatory meta key parsing:
+        # asm_meta_info["Asm last updated"] = asm_report["assembly_info"]["biosample"]["last_updated"]
+        assembly_meta_keys = asm_report["assembly_info"].keys()
+        organism_keys = asm_report["organism"].keys()
+
+        # check for genome_notes:
+        if "genome_notes" in assembly_meta_keys:
+            complete_notes = ", ".join(asm_report["assembly_info"]["genome_notes"])
+            asm_meta_info["Asm notes"] = complete_notes
+        else:
+            asm_meta_info["Asm notes"] = "NA"
+
+        # check for biosample:
+        if "biosample" in assembly_meta_keys:
+            asm_meta_info["Asm last updated"] = asm_report["assembly_info"]["biosample"]["last_updated"]
+        else:
+            asm_meta_info["Asm last updated"] = "NA"
+
+        # check for paired assembly:
+        if "paired_assembly" in assembly_meta_keys:
+            asm_meta_info["Paired assembly"] = asm_report["assembly_info"]["paired_assembly"]["accession"]
+        else:
+            asm_meta_info["Paired assembly"] = "NA"
+
+        # check for isolate/strain type:
+        if "infraspecific_names" in organism_keys:
+            organism_type_keys = asm_report["organism"]["infraspecific_names"].keys()
+            if "isolate" in organism_type_keys:
+                asm_meta_info["Isolate"] = asm_report["organism"]["infraspecific_names"]["isolate"]
+                asm_meta_info.pop("Strain")
+                asm_meta_info.pop("Isolate/Strain")
+            elif "strain" in organism_type_keys:
+                asm_meta_info["Strain"] = asm_report["organism"]["infraspecific_names"]["strain"]
+                asm_meta_info.pop("Isolate")
+                asm_meta_info.pop("Isolate/Strain")
+            else:
+                asm_meta_info["Isolate/Strain"] = "NA"
+                asm_meta_info.pop("Strain")
+                asm_meta_info.pop("Isolate")
+        else:
+            # elif ("strain" not in organism_type_keys) and ("isolate" not in organism_type_keys):
+            asm_meta_info["Isolate/Strain"] = "NA"
+            asm_meta_info.pop("Strain")
+            asm_meta_info.pop("Isolate")
+
+        parsed_meta[core] = asm_meta_info
+
+    return parsed_meta
+
+
+def generate_report_tsv(
+    parsed_asm_reports: dict, outfile_prefix: str, query_type: str, output_directoy: PathLike = Path(getcwd())
+) -> None:
+    """Generate and write the assembly report to a TSV file
+
+    Args:
+        parsed_asm_reports: Parsed assembly report meta
+        output_directoy: Path to directory where output TSV is stored.
+    """
+
+    tsv_outfile = f"{output_directoy}/{outfile_prefix}.tsv"
+
+    header_list = list(ReportStructure().keys())
+    header_list.remove("Strain")
+    header_list.remove("Isolate")
+    header_list = [query_type] + header_list
+
+    with open(tsv_outfile, "w+") as tsv_out:
+
+        writer = csv.writer(tsv_out, delimiter="\t", lineterminator="\n")
+        writer.writerow(header_list)
+
+        for core, report_meta in parsed_asm_reports.items():
+            final_asm_report = [core] + list(report_meta.values())
+            writer.writerow(final_asm_report)
+        tsv_out.close()
+
+
+# def classify_assembly_status(core_accessions: dict) -> None:
+#     """Main function to pare set of core list and call ncbi datasets"""
+
+def main() -> None:
+    """Module's entry-point."""
+    parser = ArgumentParser(
+        description="Track the assembly status of a set of input core(s) using NCBI 'datasets'"
+    )
+    parser.add_argument_src_path(
+        "--input_cores",
+        required=False,
+        default=None,
+        help="List of ensembl core db names to retrieve accessions",
+    )
+    parser.add_argument_src_path(
+        "--input_accns", required=False, default=None, help="List of query assembly accessions"
+    )
+    parser.add_argument_dst_path(
+        "--download_dir",
+        default="Assembly_report_jsons",
+        help="Folder where the assembly report JSON file(s) are stored",
+    )
+    parser.add_argument_dst_path(
+        "--assembly_report_prefix",
+        default="AssemblyStatusReport",
+        help="Prefix used in assembly report TSV output file.",
+    )
+    parser.add_argument(
+        "--host",
+        type=str,
+        required=False,
+        help="Server hostname (fmt: mysql-ens-XXXXX-YY); required with '--input_cores'",
+    )
+    parser.add_argument(
+        "--port", type=str, required=False, help="Server port (fmt: 1234); required with '--input_cores'"
+    )
+    parser.add_argument(
+        "--datasets_version_url",
+        type=str,
+        required=False,
+        metavar="URL",
+        help="Custom datasets version. E.g. library://lcampbell/ensembl-genomio/ncbi-datasets-v16.10.0:latest",
+    )
+    parser.add_argument(
+        "--cache_dir",
+        type=Path,
+        required=False,
+        default="$NXF_SINGULARITY_CACHEDIR",
+        metavar="SINGULARITY_CACHE",
+        help="Custom path to user generated singularity container housing ncbi tool 'datasets'",
+    )
+    parser.add_argument(
+        "--datasets_batch_size",
+        type=int,
+        required=False,
+        default=100,
+        metavar="BATCH_SIZE",
+        help="Number of accessions requested in one query to datasets",
+    )
+
+    parser.add_log_arguments(add_log_file=True)
+    args = parser.parse_args()
+
+    init_logging_with_args(args)
+
+    # Set and create dir for download files
+    if not args.download_dir.is_dir():
+        args.download_dir.mkdir(parents=True)
+
+    # Check for required input in the form of cores/accessions
+    if args.input_cores is None and args.input_accns is None:
+        logging.critical(
+            f"Did not detect user required input. Please specify option: '--input_cores' (core db names); OR '--input_accns' (INSDC accessions)."
+        )
+        exit()
+    elif args.input_cores and args.input_accns:
+        logging.critical(
+            f"Detected both '--input_cores' AND '--input_accns' user inputs. Please provide just one such option."
+        )
+        exit()
+    # Input core names centered run
+    elif args.input_cores and args.input_accns is None:
+        user_query_file = args.input_cores
+        logging.info(f"Performing assembly status report using core db list file: {user_query_file}")
+        if args.host is None or args.port is None:
+            print(
+                f"User must specify both arguments '--host' and '--port' when providing core database names. Exiting !"
+            )
+            exit()
+    # Accession centered run
+    elif args.input_cores is None and args.input_accns:
+        user_query_file = args.input_accns
+        logging.info(f"Performing assembly status report using INSDC accession list file: {user_query_file}")
+
+    ## Parse and store cores/accessions from user input query file
+    try:
+        with user_query_file.open(mode="r") as f:
+            query_list = f.read().splitlines()
+    except IOError as err:
+        logging.error(f"Unable to read user queries from inputfile '{user_query_file}' due to {err}.")
+        exit()
+
+    # Set singularity cache dir from user defined path or use environment
+    if args.cache_dir and args.cache_dir.is_dir():
+        image_dl_path = Path(args.cache_dir)
+        logging.info(f"Using user-defined cache_dir: '{image_dl_path}'")
+    elif os.environ.get("NXF_SINGULARITY_CACHEDIR"):
+        image_dl_path = Path(os.environ["NXF_SINGULARITY_CACHEDIR"])
+        logging.info(
+            f"Using preferred nextflow singularity cache dir 'NXF_SINGULARITY_CACHEDIR': {image_dl_path}"
+        )
+    elif os.environ.get("SINGULARITY_CACHEDIR"):
+        image_dl_path = Path(os.environ["SINGULARITY_CACHEDIR"])
+        logging.info(
+            f"Using the default singularity installation cache dir 'SINGULARITY_CACHEDIR': {image_dl_path}"
+        )
+    else:
+        image_dl_path = Path()
+        logging.warning(f"Unable to set singularity cache dir properly, using CWD {image_dl_path}")
+
+    # Set the datasets version URL
+    if args.datasets_version_url is None:
+        container_url = DATASETS_SINGULARITY["datasets_version_url"]
+        logging.info(f"Using default 'ncbi datasets' version '{container_url}'")
+    else:
+        container_url = args.datasets_version_url
+        logging.info(f"Using user defined 'ncbi datasets' version '{container_url}'")
+
+    ## Get accessions on cores list or use user accession list directly
+    query_accessions, query_type = resolve_query_type(
+        query_list, args.host, args.port, args.input_cores, args.input_accns
+    )
+
+    # Pull or load pre-existing 'datasets' singularity container image.
+    datasets_image = Client.pull(container_url, stream=False, pull_folder=image_dl_path, quiet=True)
+
+    # Datasets query implementation for one or more bacthed accessions
+    assembly_reports = datasets_asm_reports(
+        datasets_image, query_accessions, args.download_dir, args.datasets_batch_size
+    )
+
+    # Extract the key assembly report meta information for reporting status
+    key_asmreport_meta = extract_assembly_metadata(assembly_reports)
+
+    generate_report_tsv(key_asmreport_meta, args.assembly_report_prefix, query_type, args.download_dir)

--- a/src/python/ensembl/io/genomio/assembly/status.py
+++ b/src/python/ensembl/io/genomio/assembly/status.py
@@ -238,7 +238,7 @@ def datasets_asm_reports(
     for accessions in accn_subsample:
         datasets_command = ["datasets", "summary", "genome", "accession"] + accessions
 
-        # Make call to singularity datasets providing a multi accn query:
+        # Make call to singularity datasets providing a multi-accession query:
         client_return = Client.execute(
             image=sif_image, command=datasets_command, return_result=True, quiet=True
         )

--- a/src/python/ensembl/io/genomio/assembly/status.py
+++ b/src/python/ensembl/io/genomio/assembly/status.py
@@ -60,8 +60,6 @@ class ReportStructure(dict):
             {
                 "Species Name": "",
                 "Taxon ID": "",
-                "Strain": "",
-                "Isolate": "",
                 "Isolate/Strain": "",
                 "Asm name": "",
                 "Assembly type": "",
@@ -118,9 +116,7 @@ def singularity_image_setter(sif_cache_dir: Path, datasets_version: str) -> Clie
     return datasets_image
 
 
-def check_parameterization(
-    input_cores: Path, input_accessions: Path, db_host: str, db_port: int
-) -> Path:
+def check_parameterization(input_cores: Path, input_accessions: Path, db_host: str, db_port: int) -> Path:
     """Detect the kind of user input (cores/accessions) and determine any missing or
     incorrect parameterization.
 
@@ -175,14 +171,11 @@ def resolve_query_type(
         query_accessions = fetch_accessions_from_cores(query_list, partial_url)
         query_type = "CoreDB"
     elif input_cores is None and input_accessions:
-        # query_count = 1
         query_type = "Accession"
         for accession in query_list:
             match = re.match(r"(GC[AF])_([0-9]{3})([0-9]{3})([0-9]{3})\.?([0-9]+)", accession)
             if not match:
                 raise UnsupportedFormatError(f"Could not recognize GCA accession format: {accession}")
-            # query_name = f"Query_#{query_count}"
-            # query_count += 1
             query_accessions[accession] = accession
 
     return query_accessions, query_type
@@ -337,22 +330,13 @@ def extract_assembly_metadata(assembly_reports: Dict[str, dict]) -> Dict[str, Re
         if "infraspecific_names" in organism_keys:
             organism_type_keys = asm_report["organism"]["infraspecific_names"].keys()
             if "isolate" in organism_type_keys:
-                asm_meta_info["Isolate"] = asm_report["organism"]["infraspecific_names"]["isolate"]
-                asm_meta_info.pop("Strain")
-                asm_meta_info.pop("Isolate/Strain")
+                asm_meta_info["Isolate/Strain"] = asm_report["organism"]["infraspecific_names"]["isolate"]
             elif "strain" in organism_type_keys:
-                asm_meta_info["Strain"] = asm_report["organism"]["infraspecific_names"]["strain"]
-                asm_meta_info.pop("Isolate")
-                asm_meta_info.pop("Isolate/Strain")
+                asm_meta_info["Isolate/Strain"] = asm_report["organism"]["infraspecific_names"]["strain"]
             else:
                 asm_meta_info["Isolate/Strain"] = "NA"
-                asm_meta_info.pop("Strain")
-                asm_meta_info.pop("Isolate")
         else:
-            # elif ("strain" not in organism_type_keys) and ("isolate" not in organism_type_keys):
             asm_meta_info["Isolate/Strain"] = "NA"
-            asm_meta_info.pop("Strain")
-            asm_meta_info.pop("Isolate")
 
         parsed_meta[core] = asm_meta_info
 
@@ -375,8 +359,8 @@ def generate_report_tsv(
     tsv_outfile = f"{output_directory}/{outfile_prefix}.tsv"
 
     header_list = list(ReportStructure().keys())
-    header_list.remove("Strain")
-    header_list.remove("Isolate")
+    # header_list.remove("Strain")
+    # header_list.remove("Isolate")
     header_list = [query_type] + header_list
 
     with open(tsv_outfile, "w+") as tsv_out:

--- a/src/python/ensembl/io/genomio/assembly/status.py
+++ b/src/python/ensembl/io/genomio/assembly/status.py
@@ -268,7 +268,6 @@ def datasets_asm_reports(
                         combined_asm_reports[core] = assembly_report
         else:
             logging.warning(f"No assembly report found for accession(s) {accessions}. Exiting !")
-            sys.exit(0)
 
     return combined_asm_reports
 


### PR DESCRIPTION
This submodule allows for users to:
- track the assembly 'status' of INSDC accessions. 
- Status results obtained from assembly summary reports (JSON)
- Users can request status checks by providing either A) list of core(s) dbs; or B) list of GCA/GCF accessions
- Status tracking is achieved via use of containerised ncbi 'datasets' and integration of singularity to python (via [spthon](https://github.com/singularityhub/singularity-cli))
- ncbi datasets is set up to perform batched searches, can be customised. Currently set to batches of n=100. 
- The results of said status check is stored for user inspection as TSV file. 
- Status of given INSDC accessions also retrieves (where it exists) the associated 'paired' assembly

This PR comprises the first iteration of assembly status tracking (i.e. version 1.0). With expanded functionality planned in later versions.

For other details on functionality see Jira ticket [ENSMETAZOA-167](https://www.ebi.ac.uk/panda/jira/browse/ENSMETAZOA-167)