### PR TITLE
CICD when scripts are modified

### DIFF
--- a/cicd/gitlab/parts/python.gitlab-ci.yml
+++ b/cicd/gitlab/parts/python.gitlab-ci.yml
@@ -27,6 +27,7 @@
       - pyproject.toml
       - "*.py"
       - src/python/**/*.py
+      - scripts/**/*.py
 
 ## Prepare and load the Python virtual environment
 


### PR DESCRIPTION
Black is run on all folders, but CICD is not run when scripts/ Python scripts are modified. This lead to issues later on.
