### PR TITLE
Fix seq compare in integrity

### DIFF
--- a/src/python/ensembl/io/genomio/manifest/check_integrity.py
+++ b/src/python/ensembl/io/genomio/manifest/check_integrity.py
@@ -154,7 +154,7 @@ class Manifest:
             if readable_hash != md5sum:
                 raise InvalidIntegrityError(f"Invalid md5 checksum for {file_path}")
 
-    def prepare_integrity_data(self) -> None:
+    def prepare_integrity_data(self) -> None:  # pylint: disable=too-many-branches
         """Read all the files and keep a record (IDs and their lengths)
         for each cases to be compared later.
         """

--- a/src/python/ensembl/io/genomio/manifest/check_integrity.py
+++ b/src/python/ensembl/io/genomio/manifest/check_integrity.py
@@ -735,6 +735,7 @@ class IntegrityTool:
                 seq_id not in comp["common"]
                 and seq_id not in comp["diff"]
                 and seq_id not in comp["diff_circular"]
+                and seq_id not in seqrs
             ):
                 comp["only_feat"].append(seq_id)
 

--- a/src/python/ensembl/io/genomio/manifest/check_integrity.py
+++ b/src/python/ensembl/io/genomio/manifest/check_integrity.py
@@ -187,6 +187,10 @@ class Manifest:
                     seq_circular[seq["name"]] = seq.get("circular", False)
                     if seq["coord_system_level"] == "contig":
                         seqr_seqlevel[seq["name"]] = int(seq["length"])
+                    # Also record synonyms (in case GFF file uses synonyms)
+                    if "synonyms" in seq:
+                        for synonym in seq["synonyms"]:
+                            seq_lengths[synonym["name"]] = int(seq["length"])
                 self.lengths["seq_regions"] = seq_lengths
                 self.circular["seq_regions"] = seq_circular
                 self.seq_regions = seq_regions


### PR DESCRIPTION
2 fixes:
- Use the synonyms from the seq_region json in case the GFF uses synonyms
- The number of only_feat seq regions was incorrect
