### PR TITLE
Better integrity check

### DIFF
--- a/src/python/ensembl/io/genomio/manifest/check_integrity.py
+++ b/src/python/ensembl/io/genomio/manifest/check_integrity.py
@@ -498,18 +498,18 @@ class IntegrityTool:
             # including pseudogenes are compared to the gff
             if ann_genes:
                 self.add_errors(self.check_ids(ann_genes, gff_genes, "Gene ids metadata vs gff"))
-                found_tr_errors = self.check_ids(
+                tr_id_errors = self.check_ids(
                     ann_translations, gff_translations, "Translation ids metadata vs gff"
                 )
-                if found_tr_errors:
-                    found_tr_errors_all = self.check_ids(
+                if tr_id_errors:
+                    tr_id_errors_all = self.check_ids(
                         ann_translations,
                         gff_all_translations,
                         "Translation ids metadata vs gff (include pseudo CDS)",
                     )
-                    if found_tr_errors_all:
-                        self.add_errors(found_tr_errors)
-                        self.add_errors(found_tr_errors_all)
+                    if tr_id_errors_all:
+                        self.add_errors(tr_id_errors)
+                        self.add_errors(tr_id_errors_all)
                 self.add_errors(
                     self.check_ids(
                         ann_transposable_elements,

--- a/src/python/ensembl/io/genomio/manifest/check_integrity.py
+++ b/src/python/ensembl/io/genomio/manifest/check_integrity.py
@@ -424,7 +424,7 @@ class IntegrityTool:
         self.errors: List[str] = []
 
     def add_errors(self, errors: Union[List[str], str]) -> None:
-        """Store the given errors in the list."""
+        """Store the given errors (list or single string) in the list of all errors."""
         if isinstance(errors, str):
             self.errors.append(errors)
         else:

--- a/src/python/ensembl/io/genomio/manifest/check_integrity.py
+++ b/src/python/ensembl/io/genomio/manifest/check_integrity.py
@@ -350,7 +350,7 @@ class Manifest:
             "TR_C_gene",
             "TR_V_gene",
         }
-        cds_transcripts = protein_transcripts | ig_transcripts
+        cds_transcripts = protein_transcripts.union(ig_transcripts)
         for feat2 in feat.sub_features:
             if feat2.type in cds_transcripts:
                 length = {}

--- a/src/python/ensembl/io/genomio/manifest/check_integrity.py
+++ b/src/python/ensembl/io/genomio/manifest/check_integrity.py
@@ -25,7 +25,7 @@ from math import floor
 from os import PathLike
 from pathlib import Path
 import re
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from BCBio import GFF
 from Bio import SeqIO, SeqFeature
@@ -423,13 +423,12 @@ class IntegrityTool:
         self.set_ignore_final_stops(ignore_final_stops)
         self.errors: List[str] = []
 
-    def add_error(self, error: str) -> None:
-        """Store the given error in the list."""
-        self.errors.append(error)
-
-    def add_errors(self, errors: List[str]) -> None:
+    def add_errors(self, errors: Union[List[str], str]) -> None:
         """Store the given errors in the list."""
-        self.errors += errors
+        if isinstance(errors, str):
+            self.errors.append(errors)
+        else:
+            self.errors += errors
 
     def check_integrity(self):
         """Load files listed in the manifest.json and check the integrity.
@@ -556,7 +555,7 @@ class IntegrityTool:
                 if "accession" in genome_ass:
                     genome_acc = genome_ass["accession"]
                     if not re.match(r"GC[AF]_\d{9}(\.\d+)?", genome_acc):
-                        self.add_error(f"Genome assembly accession is wrong: '{genome_acc}'")
+                        self.add_errors(f"Genome assembly accession is wrong: '{genome_acc}'")
 
     def check_ids(self, list1, list2, name) -> List[str]:
         """Compare the ids in list1 and list2.
@@ -703,12 +702,12 @@ class IntegrityTool:
             example = diff_circular[0]
             logging.info(f"{len(diff_circular)} differences for circular elements in {name} (e.g. {example})")
         if diff:
-            self.add_error(f"{len(diff)} common elements with higher length in {name} (e.g. {diff[0]})")
+            self.add_errors(f"{len(diff)} common elements with higher length in {name} (e.g. {diff[0]})")
         if only_seqr:
             # Not an error!
             logging.info(f"{len(only_seqr)} only in seq_region list in {name} (first: {only_seqr[0]})")
         if only_feat:
-            self.add_error(f"{len(only_feat)} only in second list in {name} (first: {only_feat[0]})")
+            self.add_errors(f"{len(only_feat)} only in second list in {name} (first: {only_feat[0]})")
 
     def _compare_seqs(
         self, seqrs: Dict[str, Any], feats: Dict[str, Any], circular: Optional[Dict[str, Any]] = None

--- a/src/python/ensembl/io/genomio/manifest/check_integrity.py
+++ b/src/python/ensembl/io/genomio/manifest/check_integrity.py
@@ -340,8 +340,19 @@ class Manifest:
             gene_id = gene_id.replace("gene:", "")
         genes[gene_id] = abs(feat.location.end - feat.location.start)
         # Get CDS id and length
+        protein_transcripts = {
+            "mRNA",
+            "pseudogenic_transcript",
+        }
+        ig_transcripts = {
+            "IG_V_gene",
+            "IG_C_gene",
+            "TR_C_gene",
+            "TR_V_gene",
+        }
+        cds_transcripts = protein_transcripts | ig_transcripts
         for feat2 in feat.sub_features:
-            if feat2.type in ("mRNA", "pseudogenic_transcript"):
+            if feat2.type in cds_transcripts:
                 length = {}
                 for feat3 in feat2.sub_features:
                     if feat3.type == "CDS":
@@ -354,7 +365,7 @@ class Manifest:
                 for pep_id, pep_length in length.items():
                     # Store length for translations, add pseudo translations separately
                     pep_length = floor(pep_length / 3) - 1
-                    if feat.type != "pseudogene":
+                    if feat.type != "pseudogene" and feat2.type in protein_transcripts:
                         peps[pep_id] = pep_length
                     all_peps[pep_id] = pep_length
 


### PR DESCRIPTION
* ~~Separate `add_error` and `add_errors` to avoid confusion (and better type hint)~~ Unified `add_errors()`
* Return list of errors instead of numbers (homogeneity)
* Better reports errors when 2 checks are done (e.g. Translation Fasta vs GFF with or without pseudogenes/IG genes)
* Support for IG genes that have a CDS but have no sequence in the peptide FASTA file
