### PR TITLE
RefSeq gene IDs update

### DIFF
--- a/src/python/ensembl/io/genomio/gff3/id_allocator.py
+++ b/src/python/ensembl/io/genomio/gff3/id_allocator.py
@@ -19,7 +19,7 @@ __all__ = ["StableIDAllocator", "InvalidStableID"]
 from dataclasses import dataclass, field
 import logging
 import re
-from typing import Dict, List, Set
+from typing import Dict, List, Optional, Set
 
 from Bio.SeqFeature import SeqFeature
 
@@ -161,7 +161,7 @@ class StableIDAllocator:
                         feat.id = f"{transcript.id}_cds"
                         feat.qualifiers["ID"] = feat.id
 
-    def normalize_gene_id(self, gene: SeqFeature) -> str:
+    def normalize_gene_id(self, gene: SeqFeature, refseq: Optional[bool] = False) -> str:
         """Returns a normalized gene stable ID.
 
         Removes any unnecessary prefixes, but will generate a new stable ID if the normalized one is
@@ -173,32 +173,40 @@ class StableIDAllocator:
         prefixes = ["gene-", "gene:"]
         new_gene_id = StableIDAllocator.remove_prefix(gene.id, prefixes)
 
+        is_valid = False
+        # Special case for RefSeq: only valid Gene IDs are LOC*
+        if refseq:
+            if new_gene_id.startswith("LOC"):
+                is_valid = True
+        else:
+            is_valid = self.is_valid(new_gene_id)
+
+        if is_valid:
+            return new_gene_id
+
         # In case the normalized gene ID is not valid, use the GeneID
-        if not self.is_valid(new_gene_id):
-            logging.debug(f"Gene ID is not valid: {new_gene_id}")
-            qual = gene.qualifiers
-            if "Dbxref" in qual:
-                for xref in qual["Dbxref"]:
-                    (db, value) = xref.split(":")
-                    if db != "GeneID":
-                        continue
-                    new_gene_id_base = f"{db}_{value}"
-                    new_gene_id = new_gene_id_base
-                    number = 1
-                    while new_gene_id in self._loaded_ids:
-                        number += 1
-                        new_gene_id = f"{new_gene_id_base}_{number}"
-                        if number > 10:
-                            raise InvalidStableID(f"Duplicate ID {new_gene_id_base} (up to {new_gene_id})")
-                    self._loaded_ids.add(new_gene_id)
-                    logging.debug(f"Using GeneID {new_gene_id} for stable_id instead of {gene.id}")
-                    return new_gene_id
-
-            # Make a new stable_id
-            if self.make_missing_stable_ids:
-                new_gene_id = self.generate_gene_id()
-                logging.debug(f"New ID: {new_gene_id} -> {new_gene_id}")
+        logging.debug(f"Gene ID is not valid: {new_gene_id}")
+        qual = gene.qualifiers
+        if "Dbxref" in qual:
+            for xref in qual["Dbxref"]:
+                (db, value) = xref.split(":")
+                if db != "GeneID":
+                    continue
+                new_gene_id_base = f"{db}_{value}"
+                new_gene_id = new_gene_id_base
+                number = 1
+                while new_gene_id in self._loaded_ids:
+                    number += 1
+                    new_gene_id = f"{new_gene_id_base}_{number}"
+                    if number > 10:
+                        raise InvalidStableID(f"Duplicate ID {new_gene_id_base} (up to {new_gene_id})")
+                self._loaded_ids.add(new_gene_id)
+                logging.debug(f"Using GeneID {new_gene_id} for stable_id instead of {gene.id}")
                 return new_gene_id
-            raise InvalidStableID(f"Can't use invalid gene id for {gene}")
 
-        return new_gene_id
+        # Make a new stable_id
+        if self.make_missing_stable_ids:
+            new_gene_id = self.generate_gene_id()
+            logging.debug(f"New ID: {new_gene_id} -> {new_gene_id}")
+            return new_gene_id
+        raise InvalidStableID(f"Can't use invalid gene id for {gene}")

--- a/src/python/ensembl/io/genomio/gff3/simplifier.py
+++ b/src/python/ensembl/io/genomio/gff3/simplifier.py
@@ -108,6 +108,10 @@ class GFFSimplifier:
             with Path(genome_path).open("r") as genome_fh:
                 self.genome = json.load(genome_fh)
 
+        self.refseq = False
+        if self.genome and self.genome["assembly"]["accession"].startswith("GCF"):
+            self.refseq = True
+
         # Other preparations
         self.stable_ids = StableIDAllocator()
         self.stable_ids.set_prefix(self.genome)
@@ -255,7 +259,7 @@ class GFFSimplifier:
             feat.type = "transposable_element"
             feat = self._normalize_mobile_genetic_element(feat)
             # Generate ID if needed
-            feat.id = self.stable_ids.normalize_gene_id(feat)
+            feat.id = self.stable_ids.normalize_gene_id(feat, self.refseq)
             feat.qualifiers["ID"] = feat.id
 
             self.annotations.add_feature(feat, "transposable_element")
@@ -319,7 +323,7 @@ class GFFSimplifier:
 
         """
 
-        gene.id = self.stable_ids.normalize_gene_id(gene)
+        gene.id = self.stable_ids.normalize_gene_id(gene, refseq=self.refseq)
         restructure_gene(gene)
         self.normalize_transcripts(gene)
         self.normalize_pseudogene(gene)


### PR DESCRIPTION
Change how we handle RefSeq gene IDs:
* The ID is valid if it starts with LOC*
* Otherwise we fallback to GeneID_*
* If there is no Dbxref GeneID, we generate a new ID

Rational: the current ID validity check is too broad for RefSeq so we sometimes we end up with some gene names as IDs. Restricting to LOC* and falling back directly to GeneIDs will avoid any such gene names to be used a IDs.