### PR TITLE
Fix assembly provider for annotation

### DIFF
--- a/src/python/ensembl/io/genomio/gff3/extract_annotation.py
+++ b/src/python/ensembl/io/genomio/gff3/extract_annotation.py
@@ -58,9 +58,9 @@ class FunctionalAnnotations:
 
     ignored_xrefs = {"go", "interpro", "uniprot"}
 
-    def __init__(self, genome: Optional[Dict[str, Dict[str, Any]]] = None) -> None:
+    def __init__(self, provider_name: str = "") -> None:
         self.annotations: List[Annotation] = []
-        self.genome = genome
+        self.provider_name = provider_name
         # Annotated features
         # Under each feature, each dict's key is a feature ID
         self.features: Dict[str, Dict[str, Annotation]] = {
@@ -81,20 +81,10 @@ class FunctionalAnnotations:
         if not "Dbxref" in feature.qualifiers:
             return all_xref
 
-        # Using provider name to modify the xref
-        provider_name = "GenBank"
-        if self.genome:
-            try:
-                provider_name = self.genome["assembly"]["provider_name"]
-            except KeyError:
-                if self.genome["assembly"]["accession"].startswith("GCF"):
-                    provider_name = "RefSeq"
-                logging.warning(f"Provider name inferred from accession: {provider_name}")
-
         # Extract the Dbxrefs
         for xref in feature.qualifiers["Dbxref"]:
             dbname, name = xref.split(":", maxsplit=1)
-            if dbname == "GenBank" and provider_name == "RefSeq":
+            if dbname == "GenBank" and self.provider_name == "RefSeq":
                 dbname = "RefSeq"
 
             if dbname.lower() in self.ignored_xrefs:

--- a/src/python/ensembl/io/genomio/gff3/extract_annotation.py
+++ b/src/python/ensembl/io/genomio/gff3/extract_annotation.py
@@ -82,12 +82,14 @@ class FunctionalAnnotations:
             return all_xref
 
         # Using provider name to modify the xref
-        provider_name = None
+        provider_name = "GenBank"
         if self.genome:
             try:
                 provider_name = self.genome["assembly"]["provider_name"]
             except KeyError:
-                logging.warning("No provider name is provided in the genome file")
+                if self.genome["assembly"]["accession"].startswith("GCF"):
+                    provider_name = "RefSeq"
+                logging.warning(f"Provider name inferred from accession: {provider_name}")
 
         # Extract the Dbxrefs
         for xref in feature.qualifiers["Dbxref"]:

--- a/src/python/ensembl/io/genomio/gff3/extract_annotation.py
+++ b/src/python/ensembl/io/genomio/gff3/extract_annotation.py
@@ -22,7 +22,6 @@ __all__ = [
     "FunctionalAnnotations",
 ]
 
-import logging
 from os import PathLike
 from pathlib import Path
 import re

--- a/src/python/ensembl/io/genomio/gff3/simplifier.py
+++ b/src/python/ensembl/io/genomio/gff3/simplifier.py
@@ -117,7 +117,7 @@ class GFFSimplifier:
         # Init the actual data we will store
         self.records = Records()
         self.annotations = FunctionalAnnotations(self.get_provider_name())
-    
+
     def get_provider_name(self) -> str:
         provider_name = "GenBank"
         if self.genome:

--- a/src/python/ensembl/io/genomio/gff3/simplifier.py
+++ b/src/python/ensembl/io/genomio/gff3/simplifier.py
@@ -116,7 +116,19 @@ class GFFSimplifier:
 
         # Init the actual data we will store
         self.records = Records()
-        self.annotations = FunctionalAnnotations()
+        self.annotations = FunctionalAnnotations(self.get_provider_name())
+    
+    def get_provider_name(self) -> str:
+        provider_name = "GenBank"
+        if self.genome:
+            try:
+                provider_name = self.genome["assembly"]["provider_name"]
+            except KeyError:
+                if self.genome["assembly"]["accession"].startswith("GCF"):
+                    provider_name = "RefSeq"
+        else:
+            logging.warning(f"No Provider name, using default {provider_name}")
+        return provider_name
 
     def simpler_gff3(self, in_gff_path: PathLike) -> None:
         """Loads a GFF3 from INSDC and rewrites it in a simpler version, whilst also writing a

--- a/src/python/ensembl/io/genomio/gff3/simplifier.py
+++ b/src/python/ensembl/io/genomio/gff3/simplifier.py
@@ -119,11 +119,11 @@ class GFFSimplifier:
         self.annotations = FunctionalAnnotations(self.get_provider_name())
 
     def get_provider_name(self) -> str:
-    """Returns the provider name for this genome.
+        """Returns the provider name for this genome.
 
-    If this information is not available, will try to infer it from the assembly accession. Will
-    return "GenBank" otherwise.
-    """
+        If this information is not available, will try to infer it from the assembly accession. Will
+        return "GenBank" otherwise.
+        """
         provider_name = "GenBank"
         if self.genome:
             try:

--- a/src/python/ensembl/io/genomio/gff3/simplifier.py
+++ b/src/python/ensembl/io/genomio/gff3/simplifier.py
@@ -119,6 +119,11 @@ class GFFSimplifier:
         self.annotations = FunctionalAnnotations(self.get_provider_name())
 
     def get_provider_name(self) -> str:
+    """Returns the provider name for this genome.
+
+    If this information is not available, will try to infer it from the assembly accession. Will
+    return "GenBank" otherwise.
+    """
         provider_name = "GenBank"
         if self.genome:
             try:
@@ -127,7 +132,7 @@ class GFFSimplifier:
                 if self.genome["assembly"]["accession"].startswith("GCF"):
                     provider_name = "RefSeq"
         else:
-            logging.warning(f"No Provider name, using default {provider_name}")
+            logging.warning(f"No genome file, using the default provider_name: {provider_name}")
         return provider_name
 
     def simpler_gff3(self, in_gff_path: PathLike) -> None:

--- a/src/python/tests/gff3/test_extract_annotation.py
+++ b/src/python/tests/gff3/test_extract_annotation.py
@@ -196,50 +196,36 @@ def test_add_feature_fail(
 
 
 @pytest.mark.parametrize(
-    "in_xrefs, genome, expected_xrefs",
+    "in_xrefs, provider_name, expected_xrefs",
     [
-        param(None, None, [], id="No xref"),
-        param([], None, [], id="Empty xref"),
-        param(["DBname:Value"], None, [{"dbname": "DBname", "id": "Value"}], id="One xref"),
+        param(None, "", [], id="No xref"),
+        param([], "", [], id="Empty xref"),
+        param(["DBname:Value"], "", [{"dbname": "DBname", "id": "Value"}], id="One xref"),
         param(
             ["DBname:Value:parts"],
-            None,
+            "",
             [{"dbname": "DBname", "id": "Value:parts"}],
             id="One xref with colon",
         ),
-        param(["GO:XXX"], None, [], id="Ignore GO"),
-        param(["GenBank:XXX"], None, [{"dbname": "GenBank", "id": "XXX"}], id="Genbank"),
+        param(["GO:XXX"], "", [], id="Ignore GO"),
+        param(["GenBank:XXX"], "", [{"dbname": "GenBank", "id": "XXX"}], id="Genbank"),
         param(
             ["GenBank:XXX"],
-            {"assembly": {"provider_name": "RefSeq", "accession": "GCF0000000"}},
+            "RefSeq",
             [{"dbname": "RefSeq", "id": "XXX"}],
             id="RefSeq explicit provider",
         ),
-        param(
-            ["GenBank:XXX"],
-            {"assembly": {"accession": "GCF000000"}},
-            [{"dbname": "RefSeq", "id": "XXX"}],
-            id="RefSeq from accession",
-        ),
-        param(
-            ["GenBank:XXX"],
-            {"assembly": {"accession": "GCA000000"}},
-            [{"dbname": "GenBank", "id": "XXX"}],
-            id="GenBank from accession",
-        ),
-        param(["GenBank:XXX"], {}, [{"dbname": "GenBank", "id": "XXX"}], id="Empty genome"),
+        param(["GenBank:XXX"], "", [{"dbname": "GenBank", "id": "XXX"}], id="No provider_name"),
     ],
 )
 def test_get_xrefs(
-    in_xrefs: Optional[List[str]], genome: Optional[Dict], expected_xrefs: List[Dict[str, str]]
+    in_xrefs: Optional[List[str]], provider_name: str, expected_xrefs: List[Dict[str, str]]
 ) -> None:
     """Tests the `FunctionaAnnotation.get_xrefs()` method."""
-    annot = FunctionalAnnotations()
+    annot = FunctionalAnnotations(provider_name=provider_name)
     one_gene = SeqFeature(type="gene")
     if in_xrefs is not None:
         one_gene.qualifiers["Dbxref"] = in_xrefs
-    if genome is not None:
-        annot.genome = genome
 
     out_xrefs = annot.get_xrefs(one_gene)
     assert out_xrefs == expected_xrefs

--- a/src/python/tests/gff3/test_extract_annotation.py
+++ b/src/python/tests/gff3/test_extract_annotation.py
@@ -211,17 +211,23 @@ def test_add_feature_fail(
         param(["GenBank:XXX"], None, [{"dbname": "GenBank", "id": "XXX"}], id="Genbank"),
         param(
             ["GenBank:XXX"],
-            {"assembly": {"provider_name": "RefSeq"}},
+            {"assembly": {"provider_name": "RefSeq", "accession": "GCF0000000"}},
             [{"dbname": "RefSeq", "id": "XXX"}],
-            id="RefSeq",
+            id="RefSeq explicit provider",
         ),
-        param(["GenBank:XXX"], {}, [{"dbname": "GenBank", "id": "XXX"}], id="Empty genome"),
         param(
             ["GenBank:XXX"],
-            {"assembly": {}},
-            [{"dbname": "GenBank", "id": "XXX"}],
-            id="No provider in genome",
+            {"assembly": {"accession": "GCF000000"}},
+            [{"dbname": "RefSeq", "id": "XXX"}],
+            id="RefSeq from accession",
         ),
+        param(
+            ["GenBank:XXX"],
+            {"assembly": {"accession": "GCA000000"}},
+            [{"dbname": "GenBank", "id": "XXX"}],
+            id="GenBank from accession",
+        ),
+        param(["GenBank:XXX"], {}, [{"dbname": "GenBank", "id": "XXX"}], id="Empty genome"),
     ],
 )
 def test_get_xrefs(

--- a/src/python/tests/gff3/test_simplifier.py
+++ b/src/python/tests/gff3/test_simplifier.py
@@ -54,6 +54,22 @@ def test_get_provider_name(tmp_path: Path, genome_meta: Dict, expected_provider_
     meta_path = tmp_path / "meta.json"
     print_json(meta_path, genome_meta)
     simp = GFFSimplifier(meta_path)
+    assert simp.get_provider_name() == expected_provider_name
+
+
+@pytest.mark.parametrize(
+    "genome_meta, expected_provider_name",
+    [
+        param({}, "GenBank", id="No metadata"),
+        param({"assembly": {"provider_name": "LOREM"}}, "LOREM", id="Explicit provider name"),
+    ],
+)
+def test_init_provider_name(tmp_path: Path, genome_meta: Dict, expected_provider_name: str) -> None:
+    """Tests `GFFSimplifier.__init__` to set the `provider_name` to its `FunctionalAnnotations` attrib."""
+    # Write metadata file
+    meta_path = tmp_path / "meta.json"
+    print_json(meta_path, genome_meta)
+    simp = GFFSimplifier(meta_path)
     assert simp.annotations.provider_name == expected_provider_name
 
 

--- a/src/python/tests/gff3/test_simplifier.py
+++ b/src/python/tests/gff3/test_simplifier.py
@@ -36,13 +36,19 @@ from ensembl.io.genomio.utils import print_json
         param({"assembly": {"provider_name": "LOREM"}}, "LOREM", id="Explicit provider name"),
         param({"assembly": {"accession": "GCA00000"}}, "GenBank", id="Genbank from accession"),
         param({"assembly": {"accession": "GCF00000"}}, "RefSeq", id="RefSeq from accession"),
-        param({"assembly": {"provider_name": "LOREM", "accession": "GCA00000"}}, "LOREM", id="Explicit provider_name, GCA accession"),
-        param({"assembly": {"provider_name": "LOREM", "accession": "GCF00000"}}, "LOREM", id="Explicit provider_name, GCF accession"),
+        param(
+            {"assembly": {"provider_name": "LOREM", "accession": "GCA00000"}},
+            "LOREM",
+            id="Explicit provider_name, GCA accession",
+        ),
+        param(
+            {"assembly": {"provider_name": "LOREM", "accession": "GCF00000"}},
+            "LOREM",
+            id="Explicit provider_name, GCF accession",
+        ),
     ],
 )
-def test_get_provider_name(
-    tmp_path: Path, genome_meta: Dict, expected_provider_name: str
-) -> None:
+def test_get_provider_name(tmp_path: Path, genome_meta: Dict, expected_provider_name: str) -> None:
     """Test get_provider_name()."""
     # Write metadata file
     meta_path = tmp_path / "meta.json"

--- a/src/python/tests/gff3/test_simplifier.py
+++ b/src/python/tests/gff3/test_simplifier.py
@@ -17,7 +17,7 @@
 from contextlib import nullcontext as does_not_raise
 from os import PathLike
 from pathlib import Path
-from typing import Callable, ContextManager, Optional
+from typing import Callable, ContextManager, Dict, Optional
 
 from Bio.SeqFeature import SeqFeature
 import pytest
@@ -26,6 +26,29 @@ from pytest import param, raises
 from ensembl.io.genomio.gff3.exceptions import GFFParserError
 from ensembl.io.genomio.gff3.simplifier import GFFSimplifier
 from ensembl.io.genomio.gff3.exceptions import IgnoredFeatureError, UnsupportedFeatureError
+from ensembl.io.genomio.utils import print_json
+
+
+@pytest.mark.parametrize(
+    "genome_meta, expected_provider_name",
+    [
+        param({}, "GenBank", id="No metadata"),
+        param({"assembly": {"provider_name": "LOREM"}}, "LOREM", id="Explicit provider name"),
+        param({"assembly": {"accession": "GCA00000"}}, "GenBank", id="Genbank from accession"),
+        param({"assembly": {"accession": "GCF00000"}}, "RefSeq", id="RefSeq from accession"),
+        param({"assembly": {"provider_name": "LOREM", "accession": "GCA00000"}}, "LOREM", id="Explicit provider_name, GCA accession"),
+        param({"assembly": {"provider_name": "LOREM", "accession": "GCF00000"}}, "LOREM", id="Explicit provider_name, GCF accession"),
+    ],
+)
+def test_get_provider_name(
+    tmp_path: Path, genome_meta: Dict, expected_provider_name: str
+) -> None:
+    """Test get_provider_name()."""
+    # Write metadata file
+    meta_path = tmp_path / "meta.json"
+    print_json(meta_path, genome_meta)
+    simp = GFFSimplifier(meta_path)
+    assert simp.annotations.provider_name == expected_provider_name
 
 
 def check_one_feature(input_gff: PathLike, output_gff: PathLike, check_function: str) -> None:

--- a/src/python/tests/gff3/test_simplifier.py
+++ b/src/python/tests/gff3/test_simplifier.py
@@ -49,7 +49,7 @@ from ensembl.io.genomio.utils import print_json
     ],
 )
 def test_get_provider_name(tmp_path: Path, genome_meta: Dict, expected_provider_name: str) -> None:
-    """Test get_provider_name()."""
+    """Tests `GFFSimplifier.get_provider_name().`"""
     # Write metadata file
     meta_path = tmp_path / "meta.json"
     print_json(meta_path, genome_meta)


### PR DESCRIPTION
Fix a bug where the `provider_name` was not properly given to the `FunctionalAnnotations` object. Replace the `genome` attrib with a simpler `provider_name` string.

Also add a part to infer the `provider_name` from the `assembly.accession`, which is mandatory from the metadata, in case the `assembly.provider_name`, which is optional, is not provided.

Update and expand the tests