### PR TITLE
Store RefSeq gene xref

### DIFF
--- a/src/python/ensembl/io/genomio/gff3/extract_annotation.py
+++ b/src/python/ensembl/io/genomio/gff3/extract_annotation.py
@@ -96,7 +96,7 @@ class FunctionalAnnotations:
         # Add RefSeq ID xref if it looks like one
         if self.provider_name == "RefSeq":
             if feature.type == "gene" and feature.id.startswith("LOC"):
-                xref_dbs = [x["dbname"] for x in all_xref]
+                xref_dbs = {x["dbname"] for x in all_xref}
                 if "RefSeq" not in xref_dbs:
                     all_xref.append({"dbname": "RefSeq", "id": feature.id})
         return all_xref

--- a/src/python/ensembl/io/genomio/gff3/extract_annotation.py
+++ b/src/python/ensembl/io/genomio/gff3/extract_annotation.py
@@ -92,6 +92,13 @@ class FunctionalAnnotations:
 
             xrefs = {"dbname": dbname, "id": name}
             all_xref.append(xrefs)
+
+        # Add RefSeq ID xref if it looks like one
+        if self.provider_name == "RefSeq":
+            if feature.type == "gene" and feature.id.startswith("LOC"):
+                xref_dbs = [x["dbname"] for x in all_xref]
+                if "RefSeq" not in xref_dbs:
+                    all_xref.append({"dbname": "RefSeq", "id": feature.id})
         return all_xref
 
     def get_features(self, feat_type: str) -> Dict[str, Annotation]:


### PR DESCRIPTION
Immediately store the RefSeq gene ID as xref if it's ID is in the LOC* format.

(NB: the other RefSeq features transcripts and translations are already stored because they are in the dbxref)