### PR TITLE
Mbarba/load using xref

### DIFF
--- a/src/python/ensembl/io/genomio/annotation/load.py
+++ b/src/python/ensembl/io/genomio/annotation/load.py
@@ -62,7 +62,7 @@ def get_core_data(session: Session, table: str) -> Dict[str, Tuple[str, str, str
             .outerjoin(
                 ObjectXref,
                 and_(
-                    Transcript.gene_id == ObjectXref.ensembl_id,
+                    Transcript.transcript_id == ObjectXref.ensembl_id,
                     ObjectXref.ensembl_object_type == "transcript",
                 ),
             )

--- a/src/python/ensembl/io/genomio/database/dbconnection_lite.py
+++ b/src/python/ensembl/io/genomio/database/dbconnection_lite.py
@@ -36,7 +36,7 @@ class DatabaseExtension:
     """
 
     def __init__(self, url, **kwargs) -> None:
-        self._engine = create_engine(url, **kwargs)
+        self._engine = create_engine(url, echo=True, **kwargs)
         self._metadata: Dict[str, List] = {}
 
     @property

--- a/src/python/ensembl/io/genomio/database/dbconnection_lite.py
+++ b/src/python/ensembl/io/genomio/database/dbconnection_lite.py
@@ -36,7 +36,7 @@ class DatabaseExtension:
     """
 
     def __init__(self, url, **kwargs) -> None:
-        self._engine = create_engine(url, echo=True, **kwargs)
+        self._engine = create_engine(url, **kwargs)
         self._metadata: Dict[str, List] = {}
 
     @property


### PR DESCRIPTION
In case the stable ID does not match (possible when e.g. stable IDs have been allocated), this PR allows matching the features with their xrefs, assuming the ID from the GFF can match an xref ID

Also contains an important fix to correctly match the transcript IDs in the query