### PR TITLE
Bug fix for assembly tracker

### DIFF
--- a/src/python/ensembl/io/genomio/assembly/status.py
+++ b/src/python/ensembl/io/genomio/assembly/status.py
@@ -32,7 +32,6 @@ from os import PathLike
 from pathlib import Path
 import re
 from typing import Dict, List, Tuple, Union
-import sys
 
 from spython.main import Client
 from sqlalchemy.engine import URL
@@ -247,7 +246,7 @@ def datasets_asm_reports(
         ## Test what result we have obtained following execution of sif image and accession value
         # Returned a str, i.e. no datasets result obtained exited with fatal error
         if isinstance(raw_result, list):
-           result = raw_result[0]
+            result = raw_result[0]
         else:
             result = raw_result
 

--- a/src/python/ensembl/io/genomio/assembly/status.py
+++ b/src/python/ensembl/io/genomio/assembly/status.py
@@ -32,6 +32,7 @@ from os import PathLike
 from pathlib import Path
 import re
 from typing import Dict, List, Tuple, Union
+import sys
 
 from spython.main import Client
 from sqlalchemy.engine import URL
@@ -241,10 +242,15 @@ def datasets_asm_reports(
             image=sif_image, command=datasets_command, return_result=True, quiet=True
         )
 
-        result = client_return["message"]
+        raw_result = client_return["message"]
 
         ## Test what result we have obtained following execution of sif image and accession value
         # Returned a str, i.e. no datasets result obtained exited with fatal error
+        if isinstance(raw_result, list):
+           result = raw_result[0]
+        else:
+            result = raw_result
+
         if not isinstance(result, str):
             raise ValueError("Result obtained from datasets is not the expected format 'string'")
         if re.search("^FATAL", result):


### PR DESCRIPTION
Due to ncbi updating their version of datasets tool since assembly tracker was first introduced, meant when running assembly tracker caused it to crash out as a result of the returned query type test failing (expected _string_) but got a _list_. 

The result contained the JSONl assembly query in addition to:
Announcement message reporting a newer version of datasets was available. 

Fix checks result type returned and removes user announcement messages when using non-latest versions of datasets.  