### PR TITLE
Set GitLab CI/CD runner tag to ensure the correct job environment

### DIFF
--- a/cicd/gitlab/dot.gitlab-ci.yml
+++ b/cicd/gitlab/dot.gitlab-ci.yml
@@ -28,6 +28,10 @@ variables:
   PYTHON_IMAGE: python:3.8
   RUN_DIR: ./cicd/runtime
 
+default:
+  tags:
+    - docker
+
 # Using default stages (https://docs.gitlab.com/ee/ci/yaml/#stages): .pre > build > test > deploy > .post
 
 


### PR DESCRIPTION
It seems some available shared runners do now have Docker, which was causing failure of some of our jobs. Setting a default job tack to request all of them to have docker should address this problem.