### PR TITLE
Allow mapping mRNA IDs from the Apollo FASTA file to protein IDs

### DIFF
--- a/src/perl/Bio/EnsEMBL/Pipeline/Runnable/EG/LoadGFF3/ReportSeqEdits.pm
+++ b/src/perl/Bio/EnsEMBL/Pipeline/Runnable/EG/LoadGFF3/ReportSeqEdits.pm
@@ -212,7 +212,7 @@ sub protein_seq_report {
 
         if (exists $protein{$tn_id}) {
           $feat_id = $tn_id;
-        }elsif (exists $protein{$tt_id}) {
+        } elsif (exists $protein{$tt_id}) {
           $feat_id = $tt_id;
         }
 

--- a/src/perl/Bio/EnsEMBL/Pipeline/Runnable/EG/LoadGFF3/ReportSeqEdits.pm
+++ b/src/perl/Bio/EnsEMBL/Pipeline/Runnable/EG/LoadGFF3/ReportSeqEdits.pm
@@ -185,7 +185,8 @@ sub protein_seq_report {
   
   my @results;
   my @fixes;
-  my %translations;
+  my %translations_dict;
+  my %transcripts_dict;
   
   my $slices = $sa->fetch_all( 'toplevel', undef, 0, 1 );
 
@@ -213,12 +214,14 @@ sub protein_seq_report {
           $feat_id = $tn_id;
         }elsif (exists $protein{$tt_id}) {
           $feat_id = $tt_id;
-        } else {
-          push @results, [$tt_id, $tn_id, 'Not in file', $db_seq, ''];
+        # Don't need to check if we only load a subset of sequences
+        # } else {
+        #   push @results, [$tt_id, $tn_id, 'Not in file', $db_seq, ''];
         }
 
         if ($feat_id) {
-          $translations{$tn_id} = 1;
+          $translations_dict{$tn_id} = 1;
+          $transcripts_dict{$tt_id} = 1;
 
           my $file_seq = $protein{$feat_id};
           $file_seq =~ s/(\*|\-)$//;
@@ -248,9 +251,8 @@ sub protein_seq_report {
     }
   }
 
-  
   foreach my $id (keys %protein) {
-    if (! exists $translations{$id}) {
+    if (not exists $translations_dict{$id} and not exists $transcripts_dict{$id}) {
       push @results, ['', $id, 'Not in db', '', $protein{$id}];
     }
   }

--- a/src/perl/Bio/EnsEMBL/Pipeline/Runnable/EG/LoadGFF3/ReportSeqEdits.pm
+++ b/src/perl/Bio/EnsEMBL/Pipeline/Runnable/EG/LoadGFF3/ReportSeqEdits.pm
@@ -214,9 +214,6 @@ sub protein_seq_report {
           $feat_id = $tn_id;
         }elsif (exists $protein{$tt_id}) {
           $feat_id = $tt_id;
-        # Don't need to check if we only load a subset of sequences
-        # } else {
-        #   push @results, [$tt_id, $tn_id, 'Not in file', $db_seq, ''];
         }
 
         if ($feat_id) {

--- a/src/perl/Bio/EnsEMBL/Pipeline/Runnable/EG/LoadGFF3/ReportSeqEdits.pm
+++ b/src/perl/Bio/EnsEMBL/Pipeline/Runnable/EG/LoadGFF3/ReportSeqEdits.pm
@@ -207,11 +207,20 @@ sub protein_seq_report {
       if ($translation) {
         my $tn_id  = $translation->stable_id;
         my $db_seq = $translation->seq;
+        my $feat_id = "";
 
         if (exists $protein{$tn_id}) {
+          $feat_id = $tn_id;
+        }elsif (exists $protein{$tt_id}) {
+          $feat_id = $tt_id;
+        } else {
+          push @results, [$tt_id, $tn_id, 'Not in file', $db_seq, ''];
+        }
+
+        if ($feat_id) {
           $translations{$tn_id} = 1;
 
-          my $file_seq = $protein{$tn_id};
+          my $file_seq = $protein{$feat_id};
           $file_seq =~ s/(\*|\-)$//;
 
           if ($db_seq ne $file_seq) {
@@ -234,9 +243,6 @@ sub protein_seq_report {
 "UPDATE gene INNER JOIN transcript USING (gene_id) SET gene.biotype = 'protein_coding', transcript.biotype = 'protein_coding' WHERE transcript.stable_id = '$tt_id';";
             }
           }
-
-        } else {
-          push @results, [$tt_id, $tn_id, 'Not in file', $db_seq, ''];
         }
       }
     }


### PR DESCRIPTION
The FASTA file that we get for the patch build from Apollo usually uses the mRNA IDs for the protein sequences. Instead of asking everytime to chagne the FASTA file to use the protein IDs instead, I've modified our loader to allow matching protein IDs (already loaded in the core database) using the mRNA/transcript IDs from the Apollo FASTA file.

Additionally, I've removed the log "Not in file" which can contain a lot of sequences (since the patch build FASTA file only contains the genes that have changed). This prevents that whole list of sequences to fill the email at the end of the loading.
