### PR TITLE
Keep transcript ID if the gene ID is conserved on a gene with one transcript

### DIFF
--- a/pipelines/nextflow/modules/patch_build/check_patch.nf
+++ b/pipelines/nextflow/modules/patch_build/check_patch.nf
@@ -18,7 +18,7 @@ process CHECK_PATCH {
 
     input:
         val(server)
-        path(waited_file)
+        val(finalized)
     
     output:
         path("patch_ids_error_report.log")

--- a/pipelines/nextflow/modules/patch_build/finalize_versions.nf
+++ b/pipelines/nextflow/modules/patch_build/finalize_versions.nf
@@ -19,6 +19,9 @@ process FINALIZE_VERSIONS {
     input:
         val(server)
         path(waited_file)
+    
+    output:
+        val("done")
 
     script:
     """

--- a/pipelines/nextflow/modules/patch_build/transfer_ids.nf
+++ b/pipelines/nextflow/modules/patch_build/transfer_ids.nf
@@ -23,17 +23,20 @@ process TRANSFER_IDS {
         val(species)
 
     output:
-        path("new_transcripts.txt")
+        path("new_transcripts.txt"), emit: new_transcripts
+        path("mapped_transcripts.txt"), emit: mapped_transcripts
 
     script:
     def new_transcripts = "new_transcripts.txt"
+    def mapped_transcripts = "mapped_transcripts.txt"
     """
     perl $params.scripts_dir/transfer_ids.pl \\
         --mapping $changed_genes \\
         --old ./$old_registry \\
         --new ./$new_registry \\
         --species $species \\
-        --out_transcripts $new_transcripts \\
+        --mapped_transcripts $mapped_transcripts \\
+        --missed_transcripts $new_transcripts \\
         --update
     """
 }

--- a/pipelines/nextflow/modules/patch_build/transfer_metadata.nf
+++ b/pipelines/nextflow/modules/patch_build/transfer_metadata.nf
@@ -14,7 +14,8 @@
 // limitations under the License.
 
 process TRANSFER_METADATA {
-    label 'local'
+    memory "8 GB"
+    time "2h"
 
     input:
         path(waited_file)

--- a/pipelines/nextflow/subworkflows/patch_build_post_process/main.nf
+++ b/pipelines/nextflow/subworkflows/patch_build_post_process/main.nf
@@ -50,10 +50,12 @@ workflow PATCH_BUILD_PROCESS {
 
         // Transfer the genes from the old db to the new db
         // Requires 2 registries and the species name
-        new_transcripts = TRANSFER_IDS(changed_genes, old_registry, new_registry, server.species)
+        transfer_ids_output = TRANSFER_IDS(changed_genes, old_registry, new_registry, server.species)
+        new_transcripts = transfer_ids_output.out.new_transcripts
+        mapped_transcripts = transfer_ids_output.out.mapped_transcripts
 
         // Transfer metadata (can be done any time after the ids are transfered?)
-        transfer_log = TRANSFER_METADATA(new_transcripts, old_registry, new_registry, server.species)
+        transfer_log = TRANSFER_METADATA(mapped_transcripts, old_registry, new_registry, server.species)
 
         // Allocate ids for both the new_genes and the changed_genes new transcripts
         new_genes_map = ALLOCATE_GENE_IDS(new_registry, server.species, osid, new_genes, "gene")
@@ -76,6 +78,7 @@ workflow PATCH_BUILD_PROCESS {
             .concat(new_genes_map)
             .concat(new_transcripts_map)
             .concat(new_transcripts)
+            .concat(mapped_transcripts)
             .concat(events_file)
             .concat(transfer_log)
             .concat(patch_errors)

--- a/pipelines/nextflow/subworkflows/patch_build_post_process/main.nf
+++ b/pipelines/nextflow/subworkflows/patch_build_post_process/main.nf
@@ -63,10 +63,10 @@ workflow PATCH_BUILD_PROCESS {
 
         // Finalize the versions
         waited_files = new_genes_map.concat(new_transcripts_map).last()
-        FINALIZE_VERSIONS(server, waited_files)
+        finalized = FINALIZE_VERSIONS(server, waited_files)
 
         // Check stable ids
-        patch_errors=CHECK_PATCH(server, waited_files)
+        patch_errors=CHECK_PATCH(server, finalized)
 
         // Format the annotation events file into a compatible event file
         events_file = FORMAT_EVENTS(events, deleted, new_genes_map, release)

--- a/pipelines/nextflow/subworkflows/patch_build_post_process/main.nf
+++ b/pipelines/nextflow/subworkflows/patch_build_post_process/main.nf
@@ -51,8 +51,8 @@ workflow PATCH_BUILD_PROCESS {
         // Transfer the genes from the old db to the new db
         // Requires 2 registries and the species name
         transfer_ids_output = TRANSFER_IDS(changed_genes, old_registry, new_registry, server.species)
-        new_transcripts = transfer_ids_output.out.new_transcripts
-        mapped_transcripts = transfer_ids_output.out.mapped_transcripts
+        new_transcripts = transfer_ids_output.new_transcripts
+        mapped_transcripts = transfer_ids_output.mapped_transcripts
 
         // Transfer metadata (can be done any time after the ids are transfered?)
         transfer_log = TRANSFER_METADATA(mapped_transcripts, old_registry, new_registry, server.species)

--- a/scripts/brc4/patch_build/transfer_ids.pl
+++ b/scripts/brc4/patch_build/transfer_ids.pl
@@ -245,16 +245,6 @@ sub update_translation_id {
   $sth->execute();
 }
 
-sub update_exon_id {
-  my ($tra, $updated_id, $new_id) = @_;
-
-  # There is no exonAdaptor update, so make it manually
-  my $sth = $tra->prepare("UPDATE exon SET stable_id=? WHERE stable_id=?");
-  $sth->bind_param(1, $updated_id);
-  $sth->bind_param(2, $new_id);
-  $sth->execute();
-}
-
 sub print_list {
   my ($list, $out_file) = @_;
 

--- a/scripts/brc4/patch_build/transfer_ids.pl
+++ b/scripts/brc4/patch_build/transfer_ids.pl
@@ -189,7 +189,7 @@ sub transfer_transcripts {
     my $transcript = $transcripts->[0];
     my $old_transcript = $old_transcripts[0];
     transfer_transcript_id($old_transcript, $transcript, $stats, $tra, $update);
-    push @mapped_trs, [$gene->stable_id, $old_transcript->{"stable_id"}];
+    push @mapped_trs, [$gene->stable_id, $old_transcript->{"stable_id"}, $old_transcript->{"translation_id"}];
   } else {
     # Otherwise: 
     for my $transcript (@$transcripts) {
@@ -203,7 +203,7 @@ sub transfer_transcripts {
         next;
       }
       transfer_transcript_id($old_transcript, $transcript, $stats, $tra, $update);
-      push @mapped_trs, [$gene->stable_id, $old_transcript->{"stable_id"}];
+      push @mapped_trs, [$gene->stable_id, $old_transcript->{"stable_id"}, $old_transcript->{"translation_id"}];
     }
   }
   return (\@missed_trs, \@mapped_trs);
@@ -225,8 +225,10 @@ sub transfer_transcript_id {
 
   $tra->update($transcript) if $update;
   $stats->{transcript}++;
-  $translation->stable_id($old_transcript->{"translation_id"});
+
+  $logger->debug("Update id for " . $translation->stable_id . " to " . $old_translation_id);
   update_translation_id($tra, $old_translation_id, $translation->stable_id) if $update;
+  $translation->stable_id($old_transcript->{"translation_id"});
   $stats->{translation}++;
 }
 

--- a/scripts/brc4/patch_build/transfer_ids.pl
+++ b/scripts/brc4/patch_build/transfer_ids.pl
@@ -212,24 +212,42 @@ sub transfer_transcripts {
 sub transfer_transcript_id {
   my ($old_transcript, $transcript, $stats, $tra, $update) = @_;
   $logger->debug("Update id for " . $transcript->stable_id . " to " . $old_transcript->{"stable_id"});
-  $transcript->stable_id($old_transcript->{"stable_id"});
   
   my $translation = $transcript->translation;
   my $old_translation_id = $old_transcript->{"translation_id"};
 
+  # Stop if we don't have translation in both old and new transcript
   if (not $old_translation_id and $translation) {
       die("Old transcript had not translation, but new one has one " . $transcript->stable_id);
   } elsif ($old_translation_id and not $translation) {
       die("Old transcript had a translation, but new one doesn't " . $transcript->stable_id);
   }
 
+  # Actual transcript update
+  $transcript->stable_id($old_transcript->{"stable_id"});
   $tra->update($transcript) if $update;
   $stats->{transcript}++;
 
+  # Also update the exons
+  regenerate_exon_ids($transcript, $stats, $tra, $update);
+
+  # Also update translations
   $logger->debug("Update id for " . $translation->stable_id . " to " . $old_translation_id);
   update_translation_id($tra, $old_translation_id, $translation->stable_id) if $update;
   $translation->stable_id($old_transcript->{"translation_id"});
   $stats->{translation}++;
+}
+
+sub regenerate_exon_ids {
+  my ($transcript, $stats, $tra, $update) = @_;
+
+  my $num = 1;
+  for my $exon (@{$transcript->get_all_Exons()}) {
+    my $updated_exon_id = $transcript->stable_id . "-E" . $num++;
+    $logger->debug("Generate exon ID $updated_exon_id to replace " . $exon->stable_id);
+    update_exon_id($tra, $updated_exon_id, $exon->stable_id) if $update;
+    $stats->{exon}++;
+  }
 }
 
 sub update_translation_id {
@@ -238,6 +256,16 @@ sub update_translation_id {
   # There is no translationAdaptor update, so make it manually
   my $sth = $tra->prepare("UPDATE translation SET stable_id=? WHERE stable_id=?");
   $sth->bind_param(1, $old_id);
+  $sth->bind_param(2, $new_id);
+  $sth->execute();
+}
+
+sub update_exon_id {
+  my ($tra, $updated_id, $new_id) = @_;
+
+  # There is no exonAdaptor update, so make it manually
+  my $sth = $tra->prepare("UPDATE exon SET stable_id=? WHERE stable_id=?");
+  $sth->bind_param(1, $updated_id);
   $sth->bind_param(2, $new_id);
   $sth->execute();
 }

--- a/scripts/brc4/patch_build/transfer_ids.pl
+++ b/scripts/brc4/patch_build/transfer_ids.pl
@@ -228,26 +228,11 @@ sub transfer_transcript_id {
   $tra->update($transcript) if $update;
   $stats->{transcript}++;
 
-  # Also update the exons
-  regenerate_exon_ids($transcript, $stats, $tra, $update);
-
   # Also update translations
   $logger->debug("Update id for " . $translation->stable_id . " to " . $old_translation_id);
   update_translation_id($tra, $old_translation_id, $translation->stable_id) if $update;
   $translation->stable_id($old_transcript->{"translation_id"});
   $stats->{translation}++;
-}
-
-sub regenerate_exon_ids {
-  my ($transcript, $stats, $tra, $update) = @_;
-
-  my $num = 1;
-  for my $exon (@{$transcript->get_all_Exons()}) {
-    my $updated_exon_id = $transcript->stable_id . "-E" . $num++;
-    $logger->debug("Generate exon ID $updated_exon_id to replace " . $exon->stable_id);
-    update_exon_id($tra, $updated_exon_id, $exon->stable_id) if $update;
-    $stats->{exon}++;
-  }
 }
 
 sub update_translation_id {

--- a/scripts/brc4/patch_build/transfer_metadata.pl
+++ b/scripts/brc4/patch_build/transfer_metadata.pl
@@ -130,6 +130,7 @@ sub get_feat_data {
 
 sub update_versions {
   my ($registry, $species, $feature, $old_feats, $update) = @_;
+  return if $feature eq "translation";
   
   my $update_count = 0;
   my $new_count = 0;


### PR DESCRIPTION
The gene diff script can keep the gene ID if they overlap enough, but the transcript IDs are systematically regenerated in this case. If a gene has a single transcript and is updated, it makes sense to also keep the transcript ID for that gene.

This PR keeps the transcript ID if a gene only has one transcript before and after the patch build. It also transfers the translation ID if any (which is always paired with the transcript).

I've also increased the resources of the Nextflow module transfer_metadata since it tends to require more resources and it can be run in a separate thread. I've had to add a fix to ensure all the operations are finished before checking the patch.
