### PR TITLE
Add no_fail option to integrity for nextflow to not die

### DIFF
--- a/pipelines/nextflow/modules/manifest/integrity.nf
+++ b/pipelines/nextflow/modules/manifest/integrity.nf
@@ -23,11 +23,21 @@ process CHECK_INTEGRITY {
         tuple val(meta), path(manifest_files)
     
     output:
-        tuple val(meta), path(manifest_files)
+        tuple val(meta), path("*.*", includeInputs: true)
 
     shell:
         brc_mode = params.brc_mode ? '--brc_mode' : ''
+        integrity_file = "integrity.out"
         '''
-        manifest_check_integrity --manifest_file ./manifest.json !{brc_mode}
+        manifest_check_integrity \
+            --manifest_file ./manifest.json \
+            --no_fail \
+            !{brc_mode} \
+            > !{integrity_file}
+        
+        # Only keep integrity file if there are errors to report
+        if [ ! -s !{integrity_file} ]
+            then rm !{integrity_file}
+        fi
         '''
 }

--- a/src/python/ensembl/io/genomio/manifest/check_integrity.py
+++ b/src/python/ensembl/io/genomio/manifest/check_integrity.py
@@ -416,13 +416,20 @@ class Manifest:
 class IntegrityTool:
     """Check the integrity of sequence and annotation files in the genome"""
 
-    def __init__(self, manifest_file: Path, brc_mode: bool = False, ignore_final_stops: bool = False) -> None:
+    def __init__(
+        self,
+        manifest_file: Path,
+        brc_mode: bool = False,
+        ignore_final_stops: bool = False,
+        no_fail: bool = False,
+    ) -> None:
         self.manifest = Manifest(manifest_file)
         self.brc_mode = False
         self.set_brc_mode(brc_mode)
         self.ignore_final_stops = False
         self.set_ignore_final_stops(ignore_final_stops)
         self.errors: List[str] = []
+        self.no_fail = no_fail
 
     def add_errors(self, errors: Union[List[str], str]) -> None:
         """Store the given errors (list or single string) in the list of all errors."""
@@ -536,7 +543,11 @@ class IntegrityTool:
 
         if self.errors:
             errors_str = "\n".join(self.errors)
-            raise InvalidIntegrityError(f"Integrity test failed:\n{errors_str}")
+            message = f"Integrity test failed:\n{errors_str}"
+            if self.no_fail:
+                print(message)
+            else:
+                raise InvalidIntegrityError(message)
 
     def set_brc_mode(self, brc_mode: bool) -> None:
         """Set brc mode for this tool and the manifest."""
@@ -770,11 +781,14 @@ def main() -> None:
     parser.add_argument(
         "--ignore_final_stops", action="store_true", help="Ignore final stop when calculating peptide length"
     )
+    parser.add_argument(
+        "--no_fail", action="store_true", help="In case of errors, don't fail but print errors to stdout."
+    )
     parser.add_log_arguments(add_log_file=True)
     args = parser.parse_args()
     init_logging_with_args(args)
 
-    inspector = IntegrityTool(args.manifest_file, args.brc_mode, args.ignore_final_stops)
+    inspector = IntegrityTool(args.manifest_file, args.brc_mode, args.ignore_final_stops, args.no_fail)
     inspector.check_integrity()
 
 


### PR DESCRIPTION
Add a `--no_fail` argument to the `check_integrity.py` script. The default behaviour is still to fail when an integrity fails (most notably for the genome loader).

This PR changes the default manifest integrity Nextflow module to use that `--no_fail` option so as to not kill the whole pipeline when an integrity check fails. Instead, `integrity.out` files are created in each folder and only kept if there have been errors. .

Impacted pipelines: prepare_genome, additional_seq_prepare, dump_files

PS: We should think about writing a final report (sent by email or printed to screen/file) to show what went wrong at the end of a pipeline.