### PR TITLE
Mbarba/match synonym

### DIFF
--- a/src/python/ensembl/io/genomio/annotation/load.py
+++ b/src/python/ensembl/io/genomio/annotation/load.py
@@ -16,7 +16,7 @@
 
 import logging
 from pathlib import Path
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple
 
 from sqlalchemy.orm import Session
 from sqlalchemy import and_

--- a/src/python/ensembl/io/genomio/annotation/load.py
+++ b/src/python/ensembl/io/genomio/annotation/load.py
@@ -143,7 +143,7 @@ def load_descriptions(
 
 def _get_cur_feat(
     feat_data: Dict[str, FeatStruct], new_feat: Dict[str, Any], match_xrefs: bool = False
-) -> Union[FeatStruct, None]:
+) -> Optional[FeatStruct]:
     """Match a feature ID, synonyms or xrefs to a core stable ID and return the matching core feature.
 
     Returns None if no match.

--- a/src/python/ensembl/io/genomio/annotation/load.py
+++ b/src/python/ensembl/io/genomio/annotation/load.py
@@ -77,9 +77,9 @@ def get_core_data(session: Session, table: str) -> Dict[str, FeatStruct]:
     for row in session.execute(stmt):
         (feat_id, stable_id, desc, xref_name) = row
         feat_struct: FeatStruct = (feat_id, stable_id, desc)
-        feat_data[stable_id] = feat_struct
+        feat_data[stable_id.lower()] = feat_struct
         if xref_name:
-            feat_data[xref_name] = feat_struct
+            feat_data[xref_name.lower()] = feat_struct
 
     return feat_data
 
@@ -149,19 +149,19 @@ def _get_cur_feat(
     Returns None if no match.
     """
     # Match with the ID
-    cur_feat = feat_data.get(new_feat["id"])
+    cur_feat = feat_data.get(new_feat["id"].lower())
 
     # Fall back to a synonym
     if not cur_feat and "synonyms" in new_feat:
         for syn in new_feat["synonyms"]:
-            cur_feat = feat_data.get(syn)
+            cur_feat = feat_data.get(syn.lower())
             if cur_feat:
                 break
 
     # Fall back to an xref
     if not cur_feat and match_xrefs and "xrefs" in new_feat:
         for xref in new_feat["xrefs"]:
-            cur_feat = feat_data.get(xref["id"])
+            cur_feat = feat_data.get(xref["id"].lower())
             if cur_feat:
                 break
 


### PR DESCRIPTION
We're matching functional_annotation ID to the core stable_id, and we've recently also added a match from the xrefs.
This PR adds a match to the synonyms as well (this improves the matching to transfer descriptions and xrefs from an older core).

* Also make the match case insensitive
* Rewrite the code to make it a bit clearer
