### PR TITLE
Update GenomIO to use ensembl-utils v0.3.0

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 """Global pytest configuration for Ensembl GenomIO tests."""
 
-pytest_plugins = ("ensembl.plugins.pytest_unittest",)
+pytest_plugins = ("ensembl.utils.plugin",)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
     "biopython == 1.81",
     "ensembl-hive @ git+https://github.com/Ensembl/ensembl-hive.git",
     "ensembl-py @ git+https://github.com/Ensembl/ensembl-py.git",  # minimum v2.0.0
-    "ensembl-utils >= 0.2.0",
+    "ensembl-utils >= 0.3.0",
     "jsonschema >= 4.6.0",
     "intervaltree >= 3.1.0",
     "mysql-connector-python >= 8.0.29",

--- a/src/python/ensembl/io/genomio/annotation/load.py
+++ b/src/python/ensembl/io/genomio/annotation/load.py
@@ -22,9 +22,9 @@ from sqlalchemy.orm import Session
 from sqlalchemy import and_
 
 from ensembl.core.models import Gene, Transcript, ObjectXref, Xref
-from ensembl.database import DBConnection
 from ensembl.io.genomio.utils import get_json
 from ensembl.utils.argparse import ArgumentParser
+from ensembl.utils.database import DBConnection
 from ensembl.utils.logging import init_logging_with_args
 
 

--- a/src/python/ensembl/io/genomio/database/dbconnection_lite.py
+++ b/src/python/ensembl/io/genomio/database/dbconnection_lite.py
@@ -23,8 +23,8 @@ from typing import Dict, List, Optional
 from sqlalchemy import create_engine, select
 from sqlalchemy.orm import Session
 
-from ensembl.database import DBConnection
 from ensembl.core.models import Meta
+from ensembl.utils.database import DBConnection
 
 
 _DB_PATTERN_RELEASE = re.compile(r".+_(?:core|otherfeatures|variation)_(?P<release>\d+)_\d+_\d+")

--- a/src/python/ensembl/io/genomio/genome_stats/dump.py
+++ b/src/python/ensembl/io/genomio/genome_stats/dump.py
@@ -24,9 +24,9 @@ from sqlalchemy import select, func
 from sqlalchemy.orm import Session
 
 from ensembl.core.models import SeqRegionAttrib, AttribType, Gene, Transcript
-from ensembl.database import URL
 from ensembl.io.genomio.database import DBConnectionLite
 from ensembl.utils.argparse import ArgumentParser
+from ensembl.utils.database import StrURL
 from ensembl.utils.logging import init_logging_with_args
 
 
@@ -129,7 +129,7 @@ class StatsGenerator:
         return genome_stats
 
 
-def dump_genome_stats(url: URL) -> Dict[str, Any]:
+def dump_genome_stats(url: StrURL) -> Dict[str, Any]:
     """Returns JSON object containing the genome stats (assembly and annotation) of the given core database.
 
     Args:

--- a/src/python/ensembl/io/genomio/seq_region/rename.py
+++ b/src/python/ensembl/io/genomio/seq_region/rename.py
@@ -24,8 +24,8 @@ from sqlalchemy import select, or_
 from sqlalchemy.orm import Session
 
 from ensembl.core.models import SeqRegion, SeqRegionSynonym, SeqRegionAttrib
-from ensembl.database import DBConnection
 from ensembl.utils.argparse import ArgumentParser
+from ensembl.utils.database import DBConnection
 from ensembl.utils.logging import init_logging_with_args
 
 


### PR DESCRIPTION
`ensembl-utils` will host the `database` and `plugin` modules previously hosted in `ensembl-py` as of v0.3.0. This PR covers the changes required in our codebase to migrate to this change.

_Note:_ CI/CD checks will not pass until `ensembl-utils` v0.3.0 is out [[link](https://github.com/Ensembl/ensembl-utils/pull/8)].