### PR TITLE
Update code for Biopython 1.84 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ classifiers = [
 ]
 dependencies = [
     "bcbio-gff == 0.7.1",
-    "biopython == 1.83",
+    "biopython >= 1.81",
     "ensembl-hive @ git+https://github.com/Ensembl/ensembl-hive.git",
     "ensembl-py @ git+https://github.com/Ensembl/ensembl-py.git",  # minimum v2.0.0
     "ensembl-utils >= 0.3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ classifiers = [
 ]
 dependencies = [
     "bcbio-gff == 0.7.1",
-    "biopython == 1.81",
+    "biopython == 1.83",
     "ensembl-hive @ git+https://github.com/Ensembl/ensembl-hive.git",
     "ensembl-py @ git+https://github.com/Ensembl/ensembl-py.git",  # minimum v2.0.0
     "ensembl-utils >= 0.3.0",

--- a/src/python/ensembl/io/genomio/genbank/extract_data.py
+++ b/src/python/ensembl/io/genomio/genbank/extract_data.py
@@ -414,7 +414,7 @@ class FormattedFilesGenerator:
             else:
                 codon_table = int(codon_table)
 
-            seq_obj: Dict = {
+            seq_obj: Dict[str, Any] = {
                 "name": seq.id,
                 "coord_system_level": "chromosome",
                 "circular": (seq.annotations["topology"] == "circular"),

--- a/src/python/ensembl/io/genomio/genbank/extract_data.py
+++ b/src/python/ensembl/io/genomio/genbank/extract_data.py
@@ -117,7 +117,7 @@ class FormattedFilesGenerator:
                 record.description = ""
                 record.organelle = None
                 if record.id in organella:
-                    record.organelle = organella[record.id]
+                    record.annotations["organelle"] = organella[record.id]
                 self.seq_records.append(record)
 
         if len(self.seq_records) >= 1:
@@ -421,12 +421,13 @@ class FormattedFilesGenerator:
                 "codon_table": codon_table,
                 "length": len(seq.seq),
             }
-            if seq.organelle:
-                seq_obj["location"] = self._prepare_location(seq.organelle)
+            if "organelle" in seq.annotations:
+                seq_obj["location"] = self._prepare_location(str(seq.annotations["organelle"]))
                 if not codon_table:
                     logging.warning(
                         (
-                            f"'{seq.organelle}' is an organelle: make sure to change the codon table number "
+                            f"'{seq.annotations['organelle']}' is an organelle: "
+                            "make sure to change the codon table number "
                             f"in {self.files['seq_region']} manually if it is not the standard codon table"
                         )
                     )

--- a/src/python/ensembl/io/genomio/gff3/extract_annotation.py
+++ b/src/python/ensembl/io/genomio/gff3/extract_annotation.py
@@ -321,9 +321,9 @@ class FunctionalAnnotations:
         """Record the functional_annotations of a gene and its children features."""
         self.add_feature(gene, "gene")
 
-        for transcript in gene.sub_features:
+        for transcript in gene.sub_features:  # type: ignore[attr-defined]
             self.add_feature(transcript, "transcript", gene.id, [gene.id])
-            for feat in transcript.sub_features:
+            for feat in transcript.sub_features:  # type: ignore[attr-defined]
                 if feat.type == "CDS":
                     self.add_feature(feat, "translation", transcript.id, [gene.id, transcript.id])
                     # Store CDS functional annotation only once

--- a/src/python/ensembl/io/genomio/gff3/extract_annotation.py
+++ b/src/python/ensembl/io/genomio/gff3/extract_annotation.py
@@ -28,9 +28,8 @@ from pathlib import Path
 import re
 from typing import Any, Dict, List, Optional
 
-from Bio.SeqFeature import SeqFeature
-
 from ensembl.io.genomio.utils.json_utils import print_json
+from .features import GFFSeqFeature
 
 
 Annotation = Dict[str, Any]
@@ -75,7 +74,7 @@ class FunctionalAnnotations:
             "transcript": {},
         }
 
-    def get_xrefs(self, feature: SeqFeature) -> List[Dict[str, Any]]:
+    def get_xrefs(self, feature: GFFSeqFeature) -> List[Dict[str, Any]]:
         """Get the xrefs from the Dbxref field."""
         all_xref: List[Dict[str, str]] = []
 
@@ -128,7 +127,7 @@ class FunctionalAnnotations:
 
     def add_feature(
         self,
-        feature: SeqFeature,
+        feature: GFFSeqFeature,
         feat_type: str,
         parent_id: Optional[str] = None,
         all_parent_ids: Optional[List[str]] = None,
@@ -158,12 +157,12 @@ class FunctionalAnnotations:
                 raise AnnotationError(f"No parent possible for {feat_type} {feature.id}")
 
     def _generic_feature(
-        self, feature: SeqFeature, feat_type: str, parent_ids: Optional[List[str]] = None
+        self, feature: GFFSeqFeature, feat_type: str, parent_ids: Optional[List[str]] = None
     ) -> Dict[str, Any]:
         """Create a feature object following the specifications.
 
         Args:
-            feature: The SeqFeature to add to the list.
+            feature: The GFFSeqFeature to add to the list.
             feat_type: Feature type of the feature to store (e.g. gene, transcript, translation).
             all_parent_ids: All parent IDs to remove from non-informative descriptions.
 
@@ -317,13 +316,13 @@ class FunctionalAnnotations:
         feats_list = self._to_list()
         print_json(Path(out_path), feats_list)
 
-    def store_gene(self, gene: SeqFeature) -> None:
+    def store_gene(self, gene: GFFSeqFeature) -> None:
         """Record the functional_annotations of a gene and its children features."""
         self.add_feature(gene, "gene")
 
-        for transcript in gene.sub_features:  # type: ignore[attr-defined]
+        for transcript in gene.sub_features:
             self.add_feature(transcript, "transcript", gene.id, [gene.id])
-            for feat in transcript.sub_features:  # type: ignore[attr-defined]
+            for feat in transcript.sub_features:
                 if feat.type == "CDS":
                     self.add_feature(feat, "translation", transcript.id, [gene.id, transcript.id])
                     # Store CDS functional annotation only once

--- a/src/python/ensembl/io/genomio/gff3/features.py
+++ b/src/python/ensembl/io/genomio/gff3/features.py
@@ -20,8 +20,6 @@ __all__ = [
     "GFFSeqFeature",
 ]
 
-from typing import List
-
 from Bio.SeqFeature import SeqFeature, Location
 
 
@@ -34,7 +32,7 @@ class GFFSeqFeature(SeqFeature):
         type: str = "",  # pylint: disable=W0622
         id: str = "<unknown id>",  # pylint: disable=W0622
         qualifiers: dict | None = None,
-        sub_features: List[GFFSeqFeature] | None = None,
+        sub_features: list[GFFSeqFeature] | None = None,
     ):
         super().__init__(location, type=type, id=id, qualifiers=qualifiers)
         if sub_features is None:

--- a/src/python/ensembl/io/genomio/gff3/features.py
+++ b/src/python/ensembl/io/genomio/gff3/features.py
@@ -15,6 +15,7 @@
 """GFF3 features."""
 
 from __future__ import annotations
+from typing import List
 
 from Bio.SeqFeature import SeqFeature, Location
 
@@ -31,9 +32,9 @@ class GFFSeqFeature(SeqFeature):
         self,
         location: Location | None = None,
         type: str = "",  # pylint: disable=W0622
-        id: str ="<unknown id>",  # pylint: disable=W0622
+        id: str = "<unknown id>",  # pylint: disable=W0622
         qualifiers: dict | None = None,
-        sub_features: list = None,
+        sub_features: List[GFFSeqFeature] | None = None,
     ):
         super().__init__(location, type=type, id=id, qualifiers=qualifiers)
         if sub_features is None:

--- a/src/python/ensembl/io/genomio/gff3/features.py
+++ b/src/python/ensembl/io/genomio/gff3/features.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 """GFF features."""
 
+from __future__ import annotations
+
 from Bio.SeqFeature import SeqFeature
 
 
@@ -37,3 +39,11 @@ class GFFSeqFeature(SeqFeature):
         if not sub_features:
             sub_features = []
         self.sub_features = sub_features
+
+    @classmethod
+    def cast(cls, feat: SeqFeature) -> GFFSeqFeature:
+        """Cast a SeqFeature to a GFFSeqFeature."""
+        feat.__class__ = cls
+        if not hasattr(feat, "sub_features"):
+            feat.sub_features = []  # type: ignore[attr-defined]
+        return feat  # type: ignore[return-value]

--- a/src/python/ensembl/io/genomio/gff3/features.py
+++ b/src/python/ensembl/io/genomio/gff3/features.py
@@ -15,14 +15,14 @@
 """GFF3 features."""
 
 from __future__ import annotations
-from typing import List
-
-from Bio.SeqFeature import SeqFeature, Location
-
 
 __all__ = [
     "GFFSeqFeature",
 ]
+
+from typing import List
+
+from Bio.SeqFeature import SeqFeature, Location
 
 
 class GFFSeqFeature(SeqFeature):

--- a/src/python/ensembl/io/genomio/gff3/features.py
+++ b/src/python/ensembl/io/genomio/gff3/features.py
@@ -1,0 +1,39 @@
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""GFF features."""
+
+from Bio.SeqFeature import SeqFeature
+
+
+__all__ = [
+    "GFFSeqFeature",
+]
+
+
+class GFFSeqFeature(SeqFeature):
+    """SeqFeature with sub_features as used by Bio.SeqFeature, to be used for typing."""
+
+    def __init__(
+        self,
+        location=None,
+        type="",  # pylint: disable=W0622
+        id="<unknown id>",  # pylint: disable=W0622
+        qualifiers=None,
+        sub_features=None,
+    ):
+        super().__init__(location, type=type, id=id, qualifiers=qualifiers)
+        if not sub_features:
+            sub_features = []
+        self.sub_features = sub_features

--- a/src/python/ensembl/io/genomio/gff3/features.py
+++ b/src/python/ensembl/io/genomio/gff3/features.py
@@ -16,7 +16,7 @@
 
 from __future__ import annotations
 
-from Bio.SeqFeature import SeqFeature
+from Bio.SeqFeature import SeqFeature, Location
 
 
 __all__ = [
@@ -33,9 +33,11 @@ class GFFSeqFeature(SeqFeature):
         type: str = "",  # pylint: disable=W0622
         id: str ="<unknown id>",  # pylint: disable=W0622
         qualifiers: dict | None = None,
-        sub_features: list = [],
+        sub_features: list = None,
     ):
         super().__init__(location, type=type, id=id, qualifiers=qualifiers)
+        if sub_features is None:
+            sub_features = []
         self.sub_features = sub_features
 
     @classmethod

--- a/src/python/ensembl/io/genomio/gff3/features.py
+++ b/src/python/ensembl/io/genomio/gff3/features.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""GFF features."""
+"""GFF3 features."""
 
 from __future__ import annotations
 
@@ -25,19 +25,17 @@ __all__ = [
 
 
 class GFFSeqFeature(SeqFeature):
-    """SeqFeature with sub_features as used by Bio.SeqFeature, to be used for typing."""
+    """Extends `Bio.SeqFeature.SeqFeature` with sub_features, to be used for typing."""
 
     def __init__(
         self,
-        location=None,
-        type="",  # pylint: disable=W0622
-        id="<unknown id>",  # pylint: disable=W0622
-        qualifiers=None,
-        sub_features=None,
+        location: Location | None = None,
+        type: str = "",  # pylint: disable=W0622
+        id: str ="<unknown id>",  # pylint: disable=W0622
+        qualifiers: dict | None = None,
+        sub_features: list = [],
     ):
         super().__init__(location, type=type, id=id, qualifiers=qualifiers)
-        if not sub_features:
-            sub_features = []
         self.sub_features = sub_features
 
     @classmethod

--- a/src/python/ensembl/io/genomio/gff3/id_allocator.py
+++ b/src/python/ensembl/io/genomio/gff3/id_allocator.py
@@ -153,8 +153,8 @@ class StableIDAllocator:
         Args:
             pseudogene: Pseudogene feature.
         """
-        for transcript in pseudogene.sub_features:
-            for feat in transcript.sub_features:
+        for transcript in pseudogene.sub_features:  # type: ignore[attr-defined]
+            for feat in transcript.sub_features:  # type: ignore[attr-defined]
                 if feat.type == "CDS":
                     feat.id = self.normalize_cds_id(feat.id)
                     if feat.id in ("", pseudogene.id):

--- a/src/python/ensembl/io/genomio/gff3/id_allocator.py
+++ b/src/python/ensembl/io/genomio/gff3/id_allocator.py
@@ -21,7 +21,7 @@ import logging
 import re
 from typing import Dict, List, Optional, Set
 
-from Bio.SeqFeature import SeqFeature
+from .features import GFFSeqFeature
 
 
 class InvalidStableID(ValueError):
@@ -143,7 +143,7 @@ class StableIDAllocator:
             return ""
         return normalized_cds_id
 
-    def normalize_pseudogene_cds_id(self, pseudogene: SeqFeature) -> None:
+    def normalize_pseudogene_cds_id(self, pseudogene: GFFSeqFeature) -> None:
         """Normalizes every CDS ID of the provided pseudogene.
 
         Ensure each CDS from a pseudogene has a proper ID:
@@ -153,15 +153,15 @@ class StableIDAllocator:
         Args:
             pseudogene: Pseudogene feature.
         """
-        for transcript in pseudogene.sub_features:  # type: ignore[attr-defined]
-            for feat in transcript.sub_features:  # type: ignore[attr-defined]
+        for transcript in pseudogene.sub_features:
+            for feat in transcript.sub_features:
                 if feat.type == "CDS":
                     feat.id = self.normalize_cds_id(feat.id)
                     if feat.id in ("", pseudogene.id):
                         feat.id = f"{transcript.id}_cds"
                         feat.qualifiers["ID"] = feat.id
 
-    def normalize_gene_id(self, gene: SeqFeature, refseq: Optional[bool] = False) -> str:
+    def normalize_gene_id(self, gene: GFFSeqFeature, refseq: Optional[bool] = False) -> str:
         """Returns a normalized gene stable ID.
 
         Removes any unnecessary prefixes, but will generate a new stable ID if the normalized one is

--- a/src/python/ensembl/io/genomio/gff3/restructure.py
+++ b/src/python/ensembl/io/genomio/gff3/restructure.py
@@ -15,8 +15,6 @@
 """Restructure a gene model to a standard representation: `gene -> [ mRNAs -> [CDSs, exons] ]`
 """
 
-from __future__ import annotations
-
 __all__ = [
     "restructure_gene",
     "add_transcript_to_naked_gene",

--- a/src/python/ensembl/io/genomio/gff3/restructure.py
+++ b/src/python/ensembl/io/genomio/gff3/restructure.py
@@ -78,7 +78,6 @@ def add_transcript_to_naked_gene(gene: GFFSeqFeature) -> None:
 
     transcript = GFFSeqFeature(gene.location, type="transcript")
     transcript.qualifiers["source"] = gene.qualifiers["source"]
-    transcript.sub_features = []
     gene.sub_features = [transcript]
     logging.debug(f"Inserted 1 transcript for a lone gene {gene.id}")
 
@@ -100,7 +99,6 @@ def move_only_cdss_to_new_mrna(gene: GFFSeqFeature) -> None:
             logging.debug(f"Create a new mRNA for {cds.id}")
             transcript = GFFSeqFeature(gene.location, type="mRNA")
             transcript.qualifiers["source"] = gene.qualifiers["source"]
-            transcript.sub_features = []
             transcripts_dict[cds.id] = transcript
 
         # Add the CDS to the transcript
@@ -109,7 +107,6 @@ def move_only_cdss_to_new_mrna(gene: GFFSeqFeature) -> None:
         # Also add an exon in the same location
         exon = GFFSeqFeature(cds.location, type="exon")
         exon.qualifiers["source"] = gene.qualifiers["source"]
-        exon.sub_features = []
         transcripts_dict[cds.id].sub_features.append(exon)
 
     transcripts = list(transcripts_dict.values())
@@ -222,7 +219,6 @@ def _check_sub_exons(mrna: GFFSeqFeature, cdss: List[GFFSeqFeature], sub_exons: 
         # No exons in the mRNA? Create them with the CDS coordinates
         for cur_cds in cdss:
             sub_exon = GFFSeqFeature(cur_cds.location, type="exon")
-            sub_exon.sub_features = []
             new_sub_exons.append(sub_exon)
     mrna.sub_features += new_sub_exons
 

--- a/src/python/ensembl/io/genomio/gff3/restructure.py
+++ b/src/python/ensembl/io/genomio/gff3/restructure.py
@@ -198,7 +198,7 @@ def move_cds_to_existing_mrna(gene: SeqFeature) -> None:
     logging.debug(f"Gene {gene.id}: moved {len(cdss)} CDSs to the mRNA")
 
 
-def _check_sub_exons(mrna: SeqFeature, cdss: SeqFeature, sub_exons: List[SeqFeature]) -> None:
+def _check_sub_exons(mrna: SeqFeature, cdss: List[SeqFeature], sub_exons: List[SeqFeature]) -> None:
     """Check that the exons of the mRNA and the CDSs match.
     If there are no exons, create them from the CDSs.
     """

--- a/src/python/ensembl/io/genomio/gff3/restructure.py
+++ b/src/python/ensembl/io/genomio/gff3/restructure.py
@@ -15,6 +15,8 @@
 """Restructure a gene model to a standard representation: `gene -> [ mRNAs -> [CDSs, exons] ]`
 """
 
+from __future__ import annotations
+
 __all__ = [
     "restructure_gene",
     "add_transcript_to_naked_gene",
@@ -29,16 +31,15 @@ from collections import Counter
 import logging
 from typing import List
 
-from Bio.SeqFeature import SeqFeature
-
 from .exceptions import GFFParserError
+from .features import GFFSeqFeature
 
 
-def _get_feat_counts(gene: SeqFeature):
+def _get_feat_counts(gene: GFFSeqFeature):
     return Counter([feat.type for feat in gene.sub_features])
 
 
-def restructure_gene(gene: SeqFeature) -> None:
+def restructure_gene(gene: GFFSeqFeature) -> None:
     """Standardize the structure of a gene model:
     - Add a transcript if there are no children
     - Move the CDS and exons to an mRNA if they are directly under the gene
@@ -69,20 +70,20 @@ def restructure_gene(gene: SeqFeature) -> None:
         raise GFFParserError(f"Gene {gene.id} contains direct CDSs and exons children")
 
 
-def add_transcript_to_naked_gene(gene: SeqFeature) -> None:
+def add_transcript_to_naked_gene(gene: GFFSeqFeature) -> None:
     """Add an unspecific transcript to a gene without any sub features."""
 
     if (len(gene.sub_features) > 0) or (gene.type != "gene"):
         return
 
-    transcript = SeqFeature(gene.location, type="transcript")
+    transcript = GFFSeqFeature(gene.location, type="transcript")
     transcript.qualifiers["source"] = gene.qualifiers["source"]
     transcript.sub_features = []
     gene.sub_features = [transcript]
     logging.debug(f"Inserted 1 transcript for a lone gene {gene.id}")
 
 
-def move_only_cdss_to_new_mrna(gene: SeqFeature) -> None:
+def move_only_cdss_to_new_mrna(gene: GFFSeqFeature) -> None:
     """Add intermediate mRNAs to a gene with only CDS children.
     Do nothing if some sub-features are not CDS.
     """
@@ -97,7 +98,7 @@ def move_only_cdss_to_new_mrna(gene: SeqFeature) -> None:
         # We create as many transcripts as there are different CDS IDs
         if cds.id not in transcripts_dict:
             logging.debug(f"Create a new mRNA for {cds.id}")
-            transcript = SeqFeature(gene.location, type="mRNA")
+            transcript = GFFSeqFeature(gene.location, type="mRNA")
             transcript.qualifiers["source"] = gene.qualifiers["source"]
             transcript.sub_features = []
             transcripts_dict[cds.id] = transcript
@@ -106,7 +107,7 @@ def move_only_cdss_to_new_mrna(gene: SeqFeature) -> None:
         transcripts_dict[cds.id].sub_features.append(cds)
 
         # Also add an exon in the same location
-        exon = SeqFeature(cds.location, type="exon")
+        exon = GFFSeqFeature(cds.location, type="exon")
         exon.qualifiers["source"] = gene.qualifiers["source"]
         exon.sub_features = []
         transcripts_dict[cds.id].sub_features.append(exon)
@@ -117,7 +118,7 @@ def move_only_cdss_to_new_mrna(gene: SeqFeature) -> None:
     logging.debug(f"Insert transcript-exon feats for {gene.id} ({len(transcripts)} CDSs)")
 
 
-def move_only_exons_to_new_mrna(gene: SeqFeature) -> None:
+def move_only_exons_to_new_mrna(gene: GFFSeqFeature) -> None:
     """Add an mRNA for a gene that only has exons and move the exons under the mRNA.
     No change if the gene has other sub_features than exon.
     """
@@ -126,7 +127,7 @@ def move_only_exons_to_new_mrna(gene: SeqFeature) -> None:
     if (len(counts) != 1) or not counts.get("exon"):
         return
 
-    transcript = SeqFeature(gene.location, type="mRNA")
+    transcript = GFFSeqFeature(gene.location, type="mRNA")
     transcript.qualifiers["source"] = gene.qualifiers["source"]
     transcript.sub_features = gene.sub_features
     gene.sub_features = [transcript]
@@ -134,7 +135,7 @@ def move_only_exons_to_new_mrna(gene: SeqFeature) -> None:
     logging.debug(f"Insert transcript for {gene.id} ({len(gene.sub_features)} exons)")
 
 
-def move_cds_to_existing_mrna(gene: SeqFeature) -> None:
+def move_cds_to_existing_mrna(gene: GFFSeqFeature) -> None:
     """Move CDS child features of a gene to the mRNA.
 
     This is to fix the case where we have the following structure::
@@ -198,7 +199,7 @@ def move_cds_to_existing_mrna(gene: SeqFeature) -> None:
     logging.debug(f"Gene {gene.id}: moved {len(cdss)} CDSs to the mRNA")
 
 
-def _check_sub_exons(mrna: SeqFeature, cdss: List[SeqFeature], sub_exons: List[SeqFeature]) -> None:
+def _check_sub_exons(mrna: GFFSeqFeature, cdss: List[GFFSeqFeature], sub_exons: List[GFFSeqFeature]) -> None:
     """Check that the exons of the mRNA and the CDSs match.
     If there are no exons, create them from the CDSs.
     """
@@ -220,13 +221,13 @@ def _check_sub_exons(mrna: SeqFeature, cdss: List[SeqFeature], sub_exons: List[S
     else:
         # No exons in the mRNA? Create them with the CDS coordinates
         for cur_cds in cdss:
-            sub_exon = SeqFeature(cur_cds.location, type="exon")
+            sub_exon = GFFSeqFeature(cur_cds.location, type="exon")
             sub_exon.sub_features = []
             new_sub_exons.append(sub_exon)
     mrna.sub_features += new_sub_exons
 
 
-def remove_extra_exons(gene: SeqFeature) -> None:
+def remove_extra_exons(gene: GFFSeqFeature) -> None:
     """Remove duplicated exons existing in both the gene and the mRNAs.
 
     This is a special case where a gene contains proper mRNAs, etc. but also extra exons for the same
@@ -267,7 +268,7 @@ def remove_extra_exons(gene: SeqFeature) -> None:
             raise GFFParserError(f"Can't remove extra exons for {gene.id}, not all start with 'id-'")
 
 
-def remove_cds_from_pseudogene(gene: SeqFeature) -> None:
+def remove_cds_from_pseudogene(gene: GFFSeqFeature) -> None:
     """Removes the CDSs from a pseudogene.
 
     This assumes the CDSs are sub features of the transcript or the gene.

--- a/src/python/ensembl/io/genomio/gff3/simplifier.py
+++ b/src/python/ensembl/io/genomio/gff3/simplifier.py
@@ -424,7 +424,8 @@ class GFFSimplifier:
         seg_type = self._get_segment_type(transcript)
         if not seg_type:
             # Get the information from a CDS instead
-            cdss = list(filter(lambda x: x.type == "CDS", transcript.sub_features))
+            sub_feats: List[SeqFeature] = transcript.sub_features
+            cdss: List[SeqFeature] = list(filter(lambda x: x.type == "CDS", sub_feats))
             if cdss:
                 seg_type = self._get_segment_type(cdss[0])
             if not seg_type:

--- a/src/python/ensembl/io/genomio/manifest/check_integrity.py
+++ b/src/python/ensembl/io/genomio/manifest/check_integrity.py
@@ -29,9 +29,9 @@ from typing import Any, Dict, List, Optional, Union
 
 from BCBio import GFF
 from Bio import SeqIO
-from Bio.SeqFeature import SeqFeature
 
 from ensembl.io.genomio.utils import get_json
+from ensembl.io.genomio.gff3.features import GFFSeqFeature
 from ensembl.utils.archive import open_gz_file
 from ensembl.utils.argparse import ArgumentParser
 from ensembl.utils.logging import init_logging_with_args
@@ -326,7 +326,7 @@ class Manifest:
         self.lengths = {**self.lengths, **stats}
 
     def _retrieve_gff_gene_lengths(
-        self, feat: SeqFeature, genes: Lengths, peps: Lengths, all_peps: Lengths
+        self, feat: GFFSeqFeature, genes: Lengths, peps: Lengths, all_peps: Lengths
     ) -> None:
         """Record genes and peptides lengths from a feature.
 

--- a/src/python/ensembl/io/genomio/manifest/check_integrity.py
+++ b/src/python/ensembl/io/genomio/manifest/check_integrity.py
@@ -28,7 +28,8 @@ import re
 from typing import Any, Dict, List, Optional, Union
 
 from BCBio import GFF
-from Bio import SeqIO, SeqFeature
+from Bio import SeqIO
+from Bio.SeqFeature import SeqFeature
 
 from ensembl.io.genomio.utils import get_json
 from ensembl.utils.archive import open_gz_file

--- a/src/python/ensembl/io/genomio/seq_region/prepare.py
+++ b/src/python/ensembl/io/genomio/seq_region/prepare.py
@@ -264,7 +264,7 @@ def get_genbank_id(record: SeqRecord) -> Optional[str]:
     """
     genbank_id = None
     if "comment" in record.annotations:
-        comment = record.annotations["comment"]
+        comment = str(record.annotations["comment"])
         comment = re.sub(r"[ \n\r]+", " ", comment)
         match = re.search(r"The reference sequence was derived from ([^\.]+)\.", comment)
         if match:

--- a/src/python/tests/genbank/test_extract_data.py
+++ b/src/python/tests/genbank/test_extract_data.py
@@ -147,7 +147,7 @@ class TestWriteFormattedFiles:
             FeatureLocation(10, 20), type="CDS", qualifiers={"gene": ["GlyrA"], "transl_table": "2"}
         )
         record.features.append(CDS_feature)
-        record.organelle = "mitochondrion"
+        record.annotations["organelle"] = "mitochondrion"
         formatted_files_generator.seq_records = [record]
         # pylint: disable=protected-access
         formatted_files_generator._format_write_seq_json()

--- a/src/python/tests/genbank/test_extract_data.py
+++ b/src/python/tests/genbank/test_extract_data.py
@@ -246,7 +246,7 @@ class TestWriteFormattedFiles:
         record.features.append(CDS_feature)
         formatted_files_generator.files["fasta_pep"] = tmp_path / "pep.fasta"
         # pylint: disable=protected-access
-        formatted_files_generator._write_pep_fasta(record)
+        formatted_files_generator._write_pep_fasta([record])
         assert (tmp_path / "pep.fasta").exists()
 
         fasta_pep = SeqIO.read((tmp_path / "pep.fasta"), "fasta")

--- a/src/python/tests/genbank/test_extract_data_seq.py
+++ b/src/python/tests/genbank/test_extract_data_seq.py
@@ -244,7 +244,7 @@ class TestFormattedFilesGenerator:
         formatted_files_generator: FormattedFilesGenerator,
     ) -> None:
         """Test that `get_number_of_codons` returns correct value based on feature type and qualifier"""
-        rec = SeqRecord(seq="", id="1JOY", name="EnvZ")
+        rec = SeqRecord(seq=Seq(""), id="1JOY", name="EnvZ")
         seq_feature = SeqFeature(type=type_feature, qualifiers={"transl_table": [expected_value]})
         rec.features.append(seq_feature)
         # pylint: disable=protected-access

--- a/src/python/tests/gff3/test_id_allocator.py
+++ b/src/python/tests/gff3/test_id_allocator.py
@@ -25,6 +25,7 @@ import pytest
 from BCBio import GFF
 from Bio.SeqRecord import SeqRecord
 from ensembl.io.genomio.gff3.id_allocator import StableIDAllocator, InvalidStableID
+from ensembl.io.genomio.gff3.features import GFFSeqFeature
 from pytest import raises
 
 
@@ -193,7 +194,7 @@ def test_normalize_pseudogene_cds_id(
 
     # Load record and update feature
     record = _read_record(data_dir / input_gff)
-    features = record.features
+    features = [GFFSeqFeature.cast(feat) for feat in record.features]
     record.features = []
     for feature in features:
         ids.normalize_pseudogene_cds_id(feature)
@@ -232,7 +233,7 @@ def test_normalize_gene_id(
 
     with expected:
         for feature in features:
-            feature.id = ids.normalize_gene_id(feature)
+            feature.id = ids.normalize_gene_id(GFFSeqFeature.cast(feature))
             assert feature.id == expected_id
 
 
@@ -258,7 +259,7 @@ def test_normalize_gene_id_duplicate(
     found_ids = []
     with expected:
         for feature in features:
-            new_feature_id = ids.normalize_gene_id(feature)
+            new_feature_id = ids.normalize_gene_id(GFFSeqFeature.cast(feature))
             if new_feature_id and feature.id != new_feature_id:
                 found_ids.append(new_feature_id)
         assert found_ids == expected_ids

--- a/src/python/tests/gff3/test_restructure.py
+++ b/src/python/tests/gff3/test_restructure.py
@@ -17,12 +17,13 @@
 from contextlib import nullcontext as does_not_raise
 from typing import Any, ContextManager, Dict, List, Union
 
-from Bio.SeqFeature import SeqFeature, SimpleLocation
+from Bio.SeqFeature import SimpleLocation
 import pytest
 from pytest import param, raises
 
 from ensembl.io.genomio.gff3.exceptions import GFFParserError
 from ensembl.io.genomio.gff3 import restructure
+from ensembl.io.genomio.gff3.features import GFFSeqFeature
 
 
 class FeatGenerator:
@@ -34,18 +35,17 @@ class FeatGenerator:
     region = "LOREM"
     source = "Foo"
 
-    def make(self, ftype: str, number: int = 1) -> List[SeqFeature]:
+    def make(self, ftype: str, number: int = 1) -> List[GFFSeqFeature]:
         """Returns a list with a defined number of features of a given type."""
         feats = []
         for _ in range(0, number):
             loc = SimpleLocation(self.start, self.end, self.strand)
-            feat = SeqFeature(loc, type=ftype)
+            feat = GFFSeqFeature(loc, type=ftype)
             feat.qualifiers["source"] = self.source
-            feat.sub_features = []
             feats.append(feat)
         return feats
 
-    def make_structure(self, children: List[Any]) -> List[SeqFeature]:
+    def make_structure(self, children: List[Any]) -> List[GFFSeqFeature]:
         """Returns a list of SeqFeature children structure from the form:
         struct = ["mRNA"]
         struct = [{"mRNA": ["CDS", "exon"]}, "exon", "exon"]
@@ -64,7 +64,7 @@ class FeatGenerator:
 
         return output
 
-    def get_sub_structure(self, feat: SeqFeature) -> Union[Dict, str]:
+    def get_sub_structure(self, feat: GFFSeqFeature) -> Union[Dict, str]:
         """Create a children structure from a SeqFeature."""
         if feat.sub_features:
             feat_subs = []

--- a/src/python/tests/gff3/test_simplifier.py
+++ b/src/python/tests/gff3/test_simplifier.py
@@ -19,13 +19,13 @@ from os import PathLike
 from pathlib import Path
 from typing import Callable, ContextManager, Dict, Optional
 
-from Bio.SeqFeature import SeqFeature
 import pytest
 from pytest import param, raises
 
 from ensembl.io.genomio.gff3.exceptions import GeneSegmentError, GFFParserError
 from ensembl.io.genomio.gff3.simplifier import GFFSimplifier
 from ensembl.io.genomio.gff3.exceptions import IgnoredFeatureError, UnsupportedFeatureError
+from ensembl.io.genomio.gff3.features import GFFSeqFeature
 from ensembl.io.genomio.utils import print_json
 
 
@@ -209,13 +209,12 @@ def test_normalize_non_gene(
 ) -> None:
     """Test non-gene normalization."""
     simp = GFFSimplifier()
-    feat = SeqFeature(None, in_type)
+    feat = GFFSeqFeature(None, in_type)
     feat.qualifiers = {"source": "LOREM"}
     if in_mobile_type is not None:
         feat.qualifiers["mobile_element_type"] = [in_mobile_type]
     if in_product is not None:
         feat.qualifiers["product"] = [in_product]
-    feat.sub_features = []
     with expectation:
         new_feat = simp.normalize_non_gene(feat)
         if new_feat is not None:
@@ -228,7 +227,7 @@ def test_normalize_non_gene_not_implemented() -> None:
     """Test non-gene not in the biotype list."""
     simp = GFFSimplifier()
     simp._biotypes = {"non_gene": {"supported": ["non_gene_name"]}}  # pylint: disable=protected-access
-    feat = SeqFeature(None, "non_gene_name")
+    feat = GFFSeqFeature(None, "non_gene_name")
     with raises(NotImplementedError):
         simp.normalize_non_gene(feat)
 
@@ -253,10 +252,9 @@ def test_format_gene_segments(
 ) -> None:
     """Test `format_gene_segments` without a CDS."""
     simp = GFFSimplifier()
-    feat = SeqFeature(None, in_type)
+    feat = GFFSeqFeature(None, in_type)
     if tr_name:
         feat.qualifiers["standard_name"] = [tr_name]
-    feat.sub_features = []
     with expectation:
         new_feat = simp.format_gene_segments(feat)
         assert new_feat.type == out_type
@@ -279,10 +277,9 @@ def test_format_gene_segments_cds(
 ) -> None:
     """Test `format_gene_segments` with a CDS (and no info on the transcript)."""
     simp = GFFSimplifier()
-    feat = SeqFeature(None, "C_gene_segment")
-    feat.sub_features = []
+    feat = GFFSeqFeature(None, "C_gene_segment")
     if has_cds:
-        cds = SeqFeature(None, "CDS")
+        cds = GFFSeqFeature(None, "CDS")
         cds.qualifiers["product"] = [cds_name]
         feat.sub_features = [cds]
     with expectation:


### PR DESCRIPTION
Remade https://github.com/Ensembl/ensembl-genomio/pull/297 from the latest main.
Various type hints fixes along the way.

One big change: I've added a new `GFFSeqFeature` object, subclass of `Bio.SeqFeature`. The only difference is that this one has an additional attribute "sub_features" that the GFF parser adds.

By replacing every occurrence, we can make sure that we use the correct typing without ignoring the warnings. Bonus benefit: we no longer need to add `sub_features = []` every time we create a `SeqFeature` object.

Other change, similar problem: we used to add an attribute `organelle` to the `SeqRecord`. I've changed it to store this information in the existing `annotations` instead.


I have set the biopython version to 1.3 for now