### PR TITLE
DBconnectionLite update

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
     "bcbio-gff == 0.7.1",
     "biopython >= 1.81",
     "ensembl-py >= v2.0.2",
-    "ensembl-utils >= 0.3.0",
+    "ensembl-utils >= 0.4.0",
     "jsonschema >= 4.6.0",
     "intervaltree >= 3.1.0",
     "mysql-connector-python >= 8.0.29",
@@ -200,7 +200,6 @@ warn_unused_configs = true
 addopts = [
     "--import-mode=importlib",
     "--tb=native",
-    "--server=sqlite:///",
 ]
 testpaths = ["src/python/tests"]
 norecursedirs = ["data", "docs", "*.egg_info"]

--- a/src/python/ensembl/io/genomio/database/dbconnection_lite.py
+++ b/src/python/ensembl/io/genomio/database/dbconnection_lite.py
@@ -74,7 +74,7 @@ class DBConnectionLite(DBConnection):
             return None
 
     def get_project_release(self) -> str:
-        """Returns the project release number from the database name."""
+        """Returns the project release number from the database name. Returns empty string if not found."""
 
         match = re.search(_DB_PATTERN_RELEASE, self.db_name)
         if match:

--- a/src/python/ensembl/io/genomio/database/dbconnection_lite.py
+++ b/src/python/ensembl/io/genomio/database/dbconnection_lite.py
@@ -20,29 +20,21 @@ import logging
 import re
 from typing import Dict, List, Optional
 
-from sqlalchemy import create_engine, select
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from ensembl.core.models import Meta
-from ensembl.utils.database import DBConnection
-
+from ensembl.utils.database import DBConnection, StrURL
 
 _DB_PATTERN_RELEASE = re.compile(r".+_(?:core|otherfeatures|variation)_(?P<release>\d+)_\d+_\d+")
 
 
-class DatabaseExtension:
-    """Extension to get metadata directly from a database, assuming it has a metadata table.
-    Not meant to be used directly: use DBConnectionLite to get all the DBConnection methods.
-    """
+class DBConnectionLite(DBConnection):
+    """Extension to get metadata directly from a database, assuming it has a metadata table."""
 
-    def __init__(self, url, **kwargs) -> None:
-        self._engine = create_engine(url, **kwargs)
+    def __init__(self, url: StrURL, reflect: bool = False, **kwargs) -> None:
+        super().__init__(url, reflect, **kwargs)
         self._metadata: Dict[str, List] = {}
-
-    @property
-    def db_name(self) -> str:
-        """Returns the database name."""
-        return self._engine.url.database
 
     def get_metadata(self) -> Dict[str, List]:
         """Retrieves all metadata from the `meta` table in the database.
@@ -88,12 +80,3 @@ class DatabaseExtension:
         if match:
             return match.group(1)
         return ""
-
-
-class DBConnectionLite(DatabaseExtension, DBConnection):
-    """DBConnection without the schema loading from DB: faster but some methods will not work.
-
-    Things from DBConnection that will not work: tables, and anything that relies on metadata like
-    schema_type and schema_version. Instead for those, get them as ordinary values with
-    get_meta_value("schema_type") or get_meta_value("schema_version")
-    """

--- a/src/python/tests/conftest.py
+++ b/src/python/tests/conftest.py
@@ -19,25 +19,15 @@ will have access to the plugins, hooks and fixtures defined here.
 
 """
 
-from difflib import unified_diff
 from pathlib import Path
 from typing import Any, Callable
 
 import pytest
-from pytest import Config, FixtureRequest
+from pytest import Config
 
 from ensembl.io.genomio.utils import get_json
 
-
-@pytest.fixture(name="data_dir", scope="module")
-def local_data_dir(request: FixtureRequest) -> Path:
-    """Returns the path to the test data folder matching the test's name.
-
-    Args:
-        request: Fixture providing information of the requesting test function.
-
-    """
-    return Path(request.module.__file__).with_suffix("")
+pytest_plugins = ("ensembl.utils.plugin",)
 
 
 @pytest.fixture(scope="package")
@@ -65,26 +55,3 @@ def fixture_json_data(data_dir: Path) -> Callable[[str], Any]:
         return get_json(data_dir / file_name)
 
     return _json_data
-
-
-@pytest.fixture(name="assert_files")
-def fixture_assert_files() -> Callable[[Path, Path], None]:
-    """Returns a function that asserts if two files are equal and shows a diff if they differ."""
-
-    def _assert_files(result_path: Path, expected_path: Path) -> None:
-        with open(result_path, "r") as result_fh:
-            results = result_fh.readlines()
-        with open(expected_path, "r") as expected_fh:
-            expected = expected_fh.readlines()
-        files_diff = list(
-            unified_diff(
-                results,
-                expected,
-                fromfile=f"Test-made file {result_path.name}",
-                tofile=f"Expected file {expected_path.name}",
-            )
-        )
-        assert_message = f"Test-made and expected files differ\n{' '.join(files_diff)}"
-        assert len(files_diff) == 0, assert_message
-
-    return _assert_files

--- a/src/python/tests/conftest.py
+++ b/src/python/tests/conftest.py
@@ -27,8 +27,6 @@ from pytest import Config
 
 from ensembl.io.genomio.utils import get_json
 
-pytest_plugins = ("ensembl.utils.plugin",)
-
 
 @pytest.fixture(scope="package")
 def shared_data_dir(pytestconfig: Config) -> Path:

--- a/src/python/tests/database/test_dbconnection_lite.py
+++ b/src/python/tests/database/test_dbconnection_lite.py
@@ -36,11 +36,9 @@ _METADATA_CONTENT = {
     "species.classification": ["Insecta", "Lorem"],
 }
 
-# Use ensembl-utils UnitTestDB
-def test_get_metadata(db_factory) -> None:
-    """Tests the method get_metadata()"""
-
-    # Create and populate and Test Core DB
+@pytest.fixture(scope="module")
+def meta_test_db(db_factory) -> UnitTestDB:
+    """Returns a test database with a meta table and basic data."""
     test_db: UnitTestDB = db_factory("", "get_metadata")
     test_db.dbc.create_table(metadata.tables["coord_system"])
     test_db.dbc.create_table(metadata.tables["meta"])
@@ -50,40 +48,48 @@ def test_get_metadata(db_factory) -> None:
             for meta_value in meta_values:
                 session.add(Meta(species_id=1, meta_key=meta_key, meta_value=meta_value))
             session.commit()
+    return test_db
+
+# Use ensembl-utils UnitTestDB
+def test_get_metadata(meta_test_db: UnitTestDB) -> None:
+    """Tests the method get_metadata()"""
+
+    # Create and populate and Test Core DB
 
     # Check the new connection lite
-    dblite = DBConnectionLite(test_db.dbc.url)
+    dblite = DBConnectionLite(meta_test_db.dbc.url)
     assert dblite.get_metadata() == _METADATA_CONTENT
 
 
-# @pytest.mark.parametrize(
-#     "meta_key, meta_value",
-#     [
-#         pytest.param(
-#             "species.scientific_name", _METADATA_CONTENT["species.scientific_name"][0], id="Unique key exists"
-#         ),
-#         pytest.param(
-#             "species.classification", _METADATA_CONTENT["species.classification"][0], id="First key exists"
-#         ),
-#         pytest.param("lorem.ipsum", None, id="Non-existing key, 2 parts"),
-#         pytest.param("lorem_ipsum", None, id="Non-existing key, 1 part"),
-#     ],
-# )
-# def test_get_meta_value(dbc: DBConnectionLite, meta_key: str, meta_value: Optional[str]) -> None:
-#     """Tests the method get_meta_value()"""
-#     assert dbc.get_meta_value(meta_key) == meta_value
+@pytest.mark.parametrize(
+    "meta_key, meta_value",
+    [
+        pytest.param(
+            "species.scientific_name", _METADATA_CONTENT["species.scientific_name"][0], id="Unique key exists"
+        ),
+        pytest.param(
+            "species.classification", _METADATA_CONTENT["species.classification"][0], id="First key exists"
+        ),
+        pytest.param("lorem.ipsum", None, id="Non-existing key, 2 parts"),
+        pytest.param("lorem_ipsum", None, id="Non-existing key, 1 part"),
+    ],
+)
+def test_get_meta_value(meta_test_db: UnitTestDB, meta_key: str, meta_value: Optional[str]) -> None:
+    """Tests the method get_meta_value()"""
+    dblite = DBConnectionLite(meta_test_db.dbc.url)
+    assert dblite.get_meta_value(meta_key) == meta_value
 
 
-# @pytest.mark.parametrize(
-#     "db_name, release_version",
-#     [
-#         pytest.param("coredb_core_66_111_1", "66", id="Release version in name"),
-#         pytest.param("coredb_core_111_1", "", id="No release version in name"),
-#         pytest.param("lorem_ipsum_66_111_1", "", id="Some release version but wrong format for the rest"),
-#     ],
-# )
-# def test_get_project_release(db_name: str, release_version: str) -> None:
-#     """Tests the method get_project_release()."""
-#     db_url = f"sqlite:///{db_name}"
-#     dbc = DBConnectionLite(db_url)
-#     assert dbc.get_project_release() == release_version
+@pytest.mark.parametrize(
+    "db_name, release_version",
+    [
+        pytest.param("coredb_core_66_111_1", "66", id="Release version in name"),
+        pytest.param("coredb_core_111_1", "", id="No release version in name"),
+        pytest.param("lorem_ipsum_66_111_1", "", id="Some release version but wrong format for the rest"),
+    ],
+)
+def test_get_project_release(db_name: str, release_version: str) -> None:
+    """Tests the method get_project_release()."""
+    db_url = f"sqlite:///{db_name}"
+    dbc = DBConnectionLite(db_url)
+    assert dbc.get_project_release() == release_version

--- a/src/python/tests/database/test_dbconnection_lite.py
+++ b/src/python/tests/database/test_dbconnection_lite.py
@@ -26,7 +26,8 @@ from sqlalchemy.engine import URL
 from sqlalchemy.orm import Session
 
 from ensembl.io.genomio.database import DBConnectionLite
-from ensembl.core.models import Base, Meta
+from ensembl.core.models import Base, CoordSystem, Meta, metadata
+from ensembl.utils.database import UnitTestDB
 
 
 _METADATA_CONTENT = {
@@ -35,84 +36,54 @@ _METADATA_CONTENT = {
     "species.classification": ["Insecta", "Lorem"],
 }
 
-
-# Create a SQLite database fixture with only a meta table and limited data
-@pytest.fixture(name="db_file", scope="session")
-def db_file_test(tmp_path_factory: TempPathFactory) -> Path:
-    """Get a path to a db file."""
-    test_db_file = tmp_path_factory.mktemp("database") / "tmp_sqlite_core.db"
-    return test_db_file
-
-
-@pytest.fixture(name="db_engine", scope="session")
-def db_engine_test(db_file: Path):
-    """Get a SQLalchemy engine to a populated database."""
-    db_url = f"sqlite:///{db_file}"
-    test_db_engine = create_engine(db_url)
-    Base.metadata.tables["meta"].create(test_db_engine)
-
-    # Add some basic data
-    with Session(test_db_engine) as session:
-        metas = []
-        for meta_key, meta_values in _METADATA_CONTENT.items():
-            for meta_value in meta_values:
-                metas.append(Meta(meta_key=meta_key, meta_value=meta_value))
-        session.add_all(metas)
-        session.commit()
-    return test_db_engine
-
-
-@pytest.fixture(name="dbc", scope="session")
-@patch("ensembl.io.genomio.database.dbconnection_lite.create_engine")
-def dbc_test(mock_create_engine, db_file: Path, db_engine) -> DBConnectionLite:
-    """Provide a DBConnectionLite to the test database."""
-    mock_create_engine.return_value = db_engine
-    test_url = URL.create(f"sqlite://{db_file}")
-    dbc = DBConnectionLite(test_url)
-    return dbc
-
-
-# Tests start here
-
-
-def test_db_name(dbc: DBConnectionLite, db_file: Path) -> None:
-    """Tests the propery db_name"""
-    assert Path(dbc.db_name) == Path(db_file)
-
-
-def test_get_metadata(dbc: DBConnectionLite) -> None:
+# Use ensembl-utils UnitTestDB
+def test_get_metadata(db_factory) -> None:
     """Tests the method get_metadata()"""
-    assert dbc.get_metadata() == _METADATA_CONTENT
+
+    # Create and populate and Test Core DB
+    test_db: UnitTestDB = db_factory("", "get_metadata")
+    test_db.dbc.create_table(metadata.tables["coord_system"])
+    test_db.dbc.create_table(metadata.tables["meta"])
+    with test_db.dbc.session_scope() as session:
+        session.add(CoordSystem(species_id=1, name="Foo", rank=1))
+        for (meta_key, meta_values) in _METADATA_CONTENT.items():
+            for meta_value in meta_values:
+                session.add(Meta(species_id=1, meta_key=meta_key, meta_value=meta_value))
+            session.commit()
+
+    # Check the new connection lite
+    dblite = DBConnectionLite(test_db.dbc.url)
+    assert dblite.get_metadata() == _METADATA_CONTENT
 
 
-@pytest.mark.parametrize(
-    "meta_key, meta_value",
-    [
-        pytest.param(
-            "species.scientific_name", _METADATA_CONTENT["species.scientific_name"][0], id="Unique key exists"
-        ),
-        pytest.param(
-            "species.classification", _METADATA_CONTENT["species.classification"][0], id="First key exists"
-        ),
-        pytest.param("lorem.ipsum", None, id="Non-existing key, 2 parts"),
-        pytest.param("lorem_ipsum", None, id="Non-existing key, 1 part"),
-    ],
-)
-def test_get_meta_value(dbc: DBConnectionLite, meta_key: str, meta_value: Optional[str]) -> None:
-    """Tests the method get_meta_value()"""
-    assert dbc.get_meta_value(meta_key) == meta_value
+# @pytest.mark.parametrize(
+#     "meta_key, meta_value",
+#     [
+#         pytest.param(
+#             "species.scientific_name", _METADATA_CONTENT["species.scientific_name"][0], id="Unique key exists"
+#         ),
+#         pytest.param(
+#             "species.classification", _METADATA_CONTENT["species.classification"][0], id="First key exists"
+#         ),
+#         pytest.param("lorem.ipsum", None, id="Non-existing key, 2 parts"),
+#         pytest.param("lorem_ipsum", None, id="Non-existing key, 1 part"),
+#     ],
+# )
+# def test_get_meta_value(dbc: DBConnectionLite, meta_key: str, meta_value: Optional[str]) -> None:
+#     """Tests the method get_meta_value()"""
+#     assert dbc.get_meta_value(meta_key) == meta_value
 
 
-@pytest.mark.parametrize(
-    "db_name, release_version",
-    [
-        pytest.param("coredb_core_66_111_1", "66", id="Release version in name"),
-        pytest.param("coredb_core_111_1", "", id="No release version in name"),
-        pytest.param("lorem_ipsum_66_111_1", "", id="Some release version but wrong format for the rest"),
-    ],
-)
-def test_get_project_release(db_name: str, release_version: str) -> None:
-    """Tests the method get_project_release()."""
-    db_url = f"sqlite:///{db_name}"
-    dbc = DBConnectionLite(db_url)
-    assert dbc.get_project_release() == release_version
+# @pytest.mark.parametrize(
+#     "db_name, release_version",
+#     [
+#         pytest.param("coredb_core_66_111_1", "66", id="Release version in name"),
+#         pytest.param("coredb_core_111_1", "", id="No release version in name"),
+#         pytest.param("lorem_ipsum_66_111_1", "", id="Some release version but wrong format for the rest"),
+#     ],
+# )
+# def test_get_project_release(db_name: str, release_version: str) -> None:
+#     """Tests the method get_project_release()."""
+#     db_url = f"sqlite:///{db_name}"
+#     dbc = DBConnectionLite(db_url)
+#     assert dbc.get_project_release() == release_version


### PR DESCRIPTION
Update the DBConnectionLite module and tests to use the latest version of ensembl-utils:
- Use ensembl-utils 0.4 (remove fixtures moved to that module)
- Remove the default `--server sqlite`, already done by the plugin. It's now possible to run the tests with `--server mysql` as well
- Remove the need to extend the module to not reflect the metadata by default. Simplify the DBConnectionLite module
- Simplify DBConnectionLite tests by using the plugin and creating a simple fixture
