### PR TITLE
Move singularity enabled in slurm/lsf profiles

### DIFF
--- a/pipelines/nextflow/workflows/additional_seq_prepare/nextflow.config
+++ b/pipelines/nextflow/workflows/additional_seq_prepare/nextflow.config
@@ -24,7 +24,3 @@ params {
     prefix = null
     production_name = null
 }
-
-singularity {
-	enabled = true
-}

--- a/pipelines/nextflow/workflows/genome_prepare/nextflow.config
+++ b/pipelines/nextflow/workflows/genome_prepare/nextflow.config
@@ -23,7 +23,3 @@ params {
     output_dir = "output_genome_prepare"
     ncbi_check = 1
 }
-
-singularity {
-	enabled = true
-}

--- a/pipelines/nextflow/workflows/nextflow.config
+++ b/pipelines/nextflow/workflows/nextflow.config
@@ -55,6 +55,9 @@ profiles {
             submitRateLimit = '10/1sec'
             exitReadTimeout = 30.min
         }
+        singularity {
+            enabled = true
+        }
     }
 
     lsf {
@@ -66,6 +69,9 @@ profiles {
             submitRateLimit = '10/1sec'
             exitReadTimeout = 30.min
             perJobMemLimit = true
+        }
+        singularity {
+            enabled = true
         }
     }
 


### PR DESCRIPTION
Only enable singularity on our cluster, i.e. when we use the profiles `slurm` or `lsf`, instead of systematically. This means that singularity is no longer enabled by default when run locally (by default without a `--profile`), in particular where it is not available (e.g. on a Mac).

NB: on Mac you can use Docker for processes that have a container, so you should add this to your `~/.nextflow/config`:
```
docker.enabled = true
```
(Unless you want to use you current environment)


This should make all our pipelines (and their tests) run on both clusters and laptops without changing the default configs