### PR TITLE
Move gt container in main config

### DIFF
--- a/pipelines/nextflow/modules/gff3/gff3_validation.nf
+++ b/pipelines/nextflow/modules/gff3/gff3_validation.nf
@@ -15,10 +15,9 @@
 
 process GFF3_VALIDATION {
 
-  //beforeScript 'module load libffi-3.3-gcc-9.3.0-cgokng6'
   tag "${gene_models}"
   label 'adaptive'
-  container "quay.io/biocontainers/genometools-genometools:1.6.5--py310h3db02ab_0"
+  label 'container_genometools'
 
   input:
     tuple val(meta), path (gene_models, stageAs: "incoming.gff3")

--- a/pipelines/nextflow/workflows/nextflow.config
+++ b/pipelines/nextflow/workflows/nextflow.config
@@ -114,4 +114,7 @@ process {
         storeDir = { "${params.cache_dir}/${task.process.tokenize(':')[-1].toLowerCase()}/${task.tag}" }
         afterScript = { "sleep ${params.storeDir_latency}" }
     }
+    withLabel: 'container_genometools' {
+        container = "quay.io/biocontainers/genometools-genometools:1.6.5--py310h3db02ab_0"
+    }
 }


### PR DESCRIPTION
Centralize the containers url in the nextflow.config file. This makes it easier to reuse the containers in various processes using labels if needed, and it's easier to maintain in the long run.
