### PR TITLE
Set same behaviour as later Nextflow versions (23.05+)

### DIFF
--- a/pipelines/nextflow/workflows/nextflow.config
+++ b/pipelines/nextflow/workflows/nextflow.config
@@ -57,6 +57,7 @@ profiles {
         }
         singularity {
             enabled = true
+            autoMounts = true
         }
     }
 
@@ -72,6 +73,7 @@ profiles {
         }
         singularity {
             enabled = true
+            autoMounts = true
         }
     }
 


### PR DESCRIPTION
I'm also considering dropping support for LSF since we should be using only SLURM now, but will leave that decision to the reviewer.