### PR TITLE
Upgrade to ensembl-py 2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ classifiers = [
 dependencies = [
     "bcbio-gff == 0.7.1",
     "biopython >= 1.81",
-    "ensembl-py >= 2.1",
+    "ensembl-py >= 2.1.0",
     "ensembl-utils >= 0.4.1",
     "jsonschema >= 4.6.0",
     "intervaltree >= 3.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ classifiers = [
 dependencies = [
     "bcbio-gff == 0.7.1",
     "biopython >= 1.81",
-    "ensembl-py >= v2.0.2",
+    "ensembl-py >= 2.1",
     "ensembl-utils >= 0.4.1",
     "jsonschema >= 4.6.0",
     "intervaltree >= 3.1.0",

--- a/src/python/ensembl/io/genomio/database/core_server.py
+++ b/src/python/ensembl/io/genomio/database/core_server.py
@@ -22,6 +22,7 @@ import logging
 
 import sqlalchemy
 from sqlalchemy.engine import URL
+from sqlalchemy import text
 
 
 class CoreServer:
@@ -37,8 +38,9 @@ class CoreServer:
     def get_all_core_names(self) -> List[str]:
         """Query the server and retrieve all database names that look like Ensembl cores."""
 
-        all_query = self.engine.execute(r"SHOW DATABASES LIKE '%%_core_%%'")
-        dbs = [row[0] for row in all_query.fetchall()]
+        with self.engine.connect() as connection:
+            all_query = connection.execute(text(r"SHOW DATABASES LIKE '%%_core_%%'"))
+            dbs = [row[0] for row in all_query.fetchall()]
         logging.info(f"{len(dbs)} core databases on the server")
         return dbs
 

--- a/src/python/ensembl/io/genomio/genome_stats/dump.py
+++ b/src/python/ensembl/io/genomio/genome_stats/dump.py
@@ -70,7 +70,7 @@ class StatsGenerator:
 
         """
         seqs_st = (
-            select(SeqRegionAttrib.value, func.count(SeqRegionAttrib.value))
+            select(SeqRegionAttrib.value, func.count())  # pylint: disable=not-callable
             .join(AttribType)
             .filter(AttribType.code == code)
             .group_by(SeqRegionAttrib.value)
@@ -91,6 +91,7 @@ class StatsGenerator:
 
     def get_biotypes(self, table: Any) -> Dict[str, int]:
         """Returns a dict of stats about the feature biotypes."""
+        # pylint: disable-next=not-callable
         seqs_st = select(table.biotype, func.count()).group_by(table.biotype)
         biotypes = {}
         for row in self.session.execute(seqs_st):
@@ -101,12 +102,13 @@ class StatsGenerator:
     def get_feature_stats(self, table: Any) -> Dict[str, int]:
         """Returns a dict of stats about a given feature."""
         session = self.session
-        totals_st = select(func.count(table.stable_id))
+        totals_st = select(func.count()).select_from(table)  # pylint: disable=not-callable
         (total,) = session.execute(totals_st).one()
-        # pylint: disable-next=singleton-comparison
-        no_desc_st = select(func.count(table.stable_id)).filter(table.description.is_(None))
+        # pylint: disable-next=singleton-comparison,not-callable
+        no_desc_st = select(func.count()).filter(table.description.is_(None))
         (no_desc,) = session.execute(no_desc_st).one()
-        xref_desc_st = select(func.count(table.stable_id)).where(table.description.like("%[Source:%"))
+        # pylint: disable-next=not-callable
+        xref_desc_st = select(func.count()).where(table.description.like("%[Source:%"))
         (xref_desc,) = session.execute(xref_desc_st).one()
         left_over = total - no_desc - xref_desc
         feat_stats = {

--- a/src/python/tests/database/test_core_server.py
+++ b/src/python/tests/database/test_core_server.py
@@ -26,6 +26,7 @@ from typing import List, Optional
 
 import pytest
 from pytest_mock import MockerFixture
+from sqlalchemy.engine import make_url
 
 from ensembl.io.genomio.database import CoreServer
 
@@ -47,8 +48,25 @@ class MockResult:
         self.core_dbs = core_dbs
 
     def fetchall(self) -> List[List[str]]:
-        """Return a list of lists, ech one containing a single core db."""
+        """Return a list of lists, each one containing a single core db."""
         return [[x] for x in self.core_dbs]
+
+
+class MockConnection:
+    """Mock a SQLalchemy connection."""
+
+    def __init__(self, result: MockResult) -> None:
+        self.result = result
+
+    def execute(self, *args, **kwargs) -> MockResult:  # pylint: disable=unused-argument
+        """Returns a MockResult object."""
+        return self.result
+
+    def __enter__(self, *args, **kwargs):  # pylint: disable=unused-argument
+        return self
+
+    def __exit__(self, *args, **kwargs):  # pylint: disable=unused-argument
+        pass
 
 
 class MockEngine:
@@ -57,9 +75,9 @@ class MockEngine:
     def __init__(self, core_dbs: List[str]) -> None:
         self.result = MockResult(core_dbs)
 
-    def execute(self, *args, **kwargs) -> MockResult:  # pylint: disable=unused-argument
-        """Returns a MockResult object."""
-        return self.result
+    def connect(self) -> MockConnection:
+        """Return a mock connection."""
+        return MockConnection(self.result)
 
 
 class TestCoreServer:
@@ -108,7 +126,7 @@ class TestCoreServer:
         mocked_engine.return_value = MockEngine(dbs)
 
         # Fake server with mock get_all_core_names()
-        server_url = "sqlite:///:memory:"
+        server_url = make_url("sqlite:///:memory:")
         server = CoreServer(server_url)
 
         # Checks the filters from get_cores

--- a/src/python/tests/database/test_core_server.py
+++ b/src/python/tests/database/test_core_server.py
@@ -53,13 +53,13 @@ class MockResult:
 
 
 class MockConnection:
-    """Mock a SQLalchemy connection."""
+    """Mock a SQLAlchemy connection."""
 
     def __init__(self, result: MockResult) -> None:
         self.result = result
 
     def execute(self, *args, **kwargs) -> MockResult:  # pylint: disable=unused-argument
-        """Returns a MockResult object."""
+        """Returns a `MockResult` object."""
         return self.result
 
     def __enter__(self, *args, **kwargs):  # pylint: disable=unused-argument

--- a/src/python/tests/genome_stats/test_dump.py
+++ b/src/python/tests/genome_stats/test_dump.py
@@ -27,7 +27,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from sqlalchemy.orm import Session
-from sqlalchemy.sql.expression import Executable
 
 from ensembl.core.models import Gene, Transcript
 from ensembl.io.genomio.genome_stats import dump
@@ -51,19 +50,19 @@ class MockResult:
 
 # Define templates for all expected queries
 ATTRIB_COUNTS_QUERY = Template(
-    "SELECT seq_region_attrib.value, count(seq_region_attrib.value) AS count_1 "
+    "SELECT seq_region_attrib.value, count(*) AS count_1 "
     "FROM seq_region_attrib JOIN attrib_type ON attrib_type.attrib_type_id = seq_region_attrib.attrib_type_id"
     " WHERE attrib_type.code = '${code}' GROUP BY seq_region_attrib.value"
 )
 BIOTYPES_QUERY = Template(
     "SELECT ${table}.biotype, count(*) AS count_1 FROM ${table} GROUP BY ${table}.biotype"
 )
-FEATURE_STATS_TOTAL_QUERY = Template("SELECT count(${table}.stable_id) AS count_1 FROM ${table}")
+FEATURE_STATS_TOTAL_QUERY = Template("SELECT count(*) AS count_1 FROM ${table}")
 FEATURE_STATS_NULL_QUERY = Template(
-    "SELECT count(${table}.stable_id) AS count_1 FROM ${table} WHERE ${table}.description IS NULL"
+    "SELECT count(*) AS count_1 FROM ${table} WHERE ${table}.description IS NULL"
 )
 FEATURE_STATS_SOURCE_QUERY = Template(
-    "SELECT count(${table}.stable_id) AS count_1 FROM ${table} WHERE ${table}.description LIKE '%[Source:%'"
+    "SELECT count(*) AS count_1 FROM ${table} WHERE ${table}.description LIKE '%[Source:%'"
 )
 
 
@@ -71,7 +70,7 @@ class MockSession(Session):
     """Mocker of `sqlalchemy.orm.Session` class that replaces its `execute()` method for testing."""
 
     # pylint: disable-next=too-many-return-statements
-    def execute(self, statement: Executable) -> MockResult:
+    def execute(self, statement) -> MockResult:  # type: ignore[override]
         """Returns a `MockResult` object representing results of the statement execution.
 
         Args:
@@ -107,7 +106,7 @@ class MockSession(Session):
         ):
             return MockResult([[0]])
         # Fail test if the provided statement is not expected
-        raise RuntimeError()
+        raise RuntimeError(f"Could not mock results from statement: {statement}")
 
 
 class TestStatsGenerator:


### PR DESCRIPTION
Make various fixes to ensure we can upgrade to ensembl-py 2.1, which allows using SQLalchemy 2.0 and not just 1.4

Main changes are to the tests for genome_stats/dump and core_server:
- `func.count` is flagged erronously by pylint as `not-callable` (cf https://github.com/sqlalchemy/sqlalchemy/issues/9189), so added an ignore comment
- Use `func.count()` with argument (not needed)
- Replace session->execute() with session->connection->execute() (with an additional MockConnection)
- Mypy does not like how we overload `MockSession` with a different `execute()`, so added mypy ignore override

PS: We should plan to rewrite the genome_stats/dump with UniTestDB instead to avoid those mypy/pylint flags
