### PR TITLE
genomio.fasta.chunk fixed, refactored, tests added

### DIFF
--- a/config/gff_metaparser/valid_structures.conf
+++ b/config/gff_metaparser/valid_structures.conf
@@ -142,6 +142,7 @@ gene/breakpoint	IGNORE
 gene/insertion_site	IGNORE
 gene/intron	IGNORE
 
+gene/lnc_RNA/intron	IGNORE
 gene/mrna/polya_site	IGNORE
 gene/mrna/polypeptide_motif	IGNORE
 gene/mrna/intron	IGNORE

--- a/src/python/ensembl/brc4/runnable/load_sequence_data.py
+++ b/src/python/ensembl/brc4/runnable/load_sequence_data.py
@@ -907,15 +907,13 @@ class load_sequence_data(eHive.BaseRunnable):
             return fasta, cs_ranks, agps
 
         # split using script
-        en_root = self.param_required("ensembl_root_dir")
-        _splitter = pj(en_root, r"ensembl-genomio/scripts/chunk_fasta.py")
-
         os.makedirs(work_dir, exist_ok=True)
-
         _stderr = f"{work_dir}/chunking.stderr"
         _out_agp = f"{work_dir}/chunks.agp"
         _out_fasta = f"{work_dir}/chunks.fasta"
-        split_cmd = f"python {_splitter} --chunk_size {chunk_size} --agp_out {_out_agp} --out {_out_fasta} {fasta} 2> {_stderr}"
+
+        _splitter = r"fasta_chunk"
+        split_cmd = f"{_splitter} --chunk_size {chunk_size} --agp_out {_out_agp} --out {_out_fasta} --fasta_dna {fasta} 2> {_stderr}"
 
         print(f"running {split_cmd}", file=sys.stderr)
         # NB throws CalledProcessError if failed

--- a/src/python/ensembl/io/genomio/fasta/chunk.py
+++ b/src/python/ensembl/io/genomio/fasta/chunk.py
@@ -17,14 +17,22 @@
 """"Split a set of nucleotide sequence(s) (.fasta, .gz) into smaller chunks."""
 
 __all__ = [
+    "check_chunk_size_and_tolerance",
+    "chunk_fasta",
+    "chunk_fasta_stream",
+    "get_tolerated_size",
+    "prepare_out_dir_for_individuals",
     "split_seq_by_chunk_size",
     "split_seq_by_n",
 ]
 
+
+from contextlib import nullcontext
+from io import TextIOWrapper
 import logging
 from pathlib import Path
 import re
-from typing import Optional
+from typing import Any, Callable, Optional
 
 from Bio import SeqIO
 from Bio.Seq import Seq
@@ -35,9 +43,39 @@ from ensembl.utils.argparse import ArgumentParser
 from ensembl.utils.logging import init_logging_with_args
 
 
-def split_seq_by_n(seq: str, split_pattern: re.Pattern) -> list:
+def _on_value_error(msg: str) -> None:
+    """A default on_value_handler, raises ValueError with the provided `msg`.
+
+    Args:
+        msg: A message to raise ValueError with.
+    """
+    raise ValueError(msg)
+
+
+def check_chunk_size_and_tolerance(
+    chunk_size: int,
+    chunk_tolerance: int,
+    error_f: Callable[[str], None] = _on_value_error,
+):
+    """Check the chunk size and the tolerance are positive
+    and chunk size is not too small
+
+    Args:
+        chunk_size: Chunk size to check
+        chunk_tolerance: Chunk tolerance to check
+
+    Dies:
+        If checks failed dies with` parser.error`
+    """
+    if chunk_size < 50_000:
+        error_f(f"wrong '--chunk_size' value: '{chunk_size}'. should be greater then 50_000. exiting...")
+    if chunk_tolerance < 0:
+        error_f(f"wrong '--chunk_tolerance' value: '{chunk_tolerance}'. can't be less then 0. exiting...")
+
+
+def split_seq_by_n(seq: str, split_pattern: Optional[re.Pattern]) -> list[int]:
     """Split a string into chunks at the positions where the
-    pattern is found.
+    pattern is found. `N`s (pattern) are appended to the chunk on the left.
 
     The end point of each chunk will correspond to the end
     of the matching part.
@@ -45,6 +83,9 @@ def split_seq_by_n(seq: str, split_pattern: re.Pattern) -> list:
     Args:
         seq: Sequence to be split into chunks.
         split_pattern: Pattern to search in the sequence.
+
+    Returns:
+        List with open coordinates of the chunks ends (or with only a single sequence length).
     """
     seq_len = len(seq)
     if not split_pattern:
@@ -55,7 +96,9 @@ def split_seq_by_n(seq: str, split_pattern: re.Pattern) -> list:
     return split_points
 
 
-def split_seq_by_chunk_size(ends: list[int], chunk_size: int, tolerated_size: Optional[int] = None) -> list:
+def split_seq_by_chunk_size(
+    ends: list[int], chunk_size: int, tolerated_size: Optional[int] = None
+) -> list[int]:
     """Split list of end coordinates, to form chunks not longer then
     chunk_size.
 
@@ -63,7 +106,13 @@ def split_seq_by_chunk_size(ends: list[int], chunk_size: int, tolerated_size: Op
         ends: List of one or more chunk(s) to split a sequence.
         chunk_size: Size of chunks to split a sequence into.
         tolerated_size: Threshold to use instead of `chunk_size` to determine when to split a sequence.
+
+    Returns:
+        List with open coordinates of the chunks ends (or with only a single sequence length).
     """
+    if not ends or chunk_size < 1:
+        return ends
+
     if tolerated_size is None or tolerated_size < chunk_size:
         tolerated_size = chunk_size
     result = []
@@ -76,6 +125,198 @@ def split_seq_by_chunk_size(ends: list[int], chunk_size: int, tolerated_size: Op
         result.append(chunk_end)
         offset = chunk_end
     return result
+
+
+def _individual_file_opener(name: str) -> TextIOWrapper:
+    """Is used to open file for an idividual chunk sequence.
+
+    Args:
+        name: Name of the file to open
+    """
+    return open(name, "wt", encoding="utf-8")
+
+
+def chunk_fasta_stream(
+    input_fasta: TextIOWrapper,
+    chunk_size: int,
+    chunk_size_tolerated: int,
+    output_fasta: Optional[TextIOWrapper] | nullcontext[Any],
+    individual_file_prefix: Optional[str],
+    n_sequece_len: int = 0,
+    chunk_sfx: str = "ens_chunk",
+    append_offset_to_chunk_name: Optional[bool] = None,
+    open_individual: Callable[[str], TextIOWrapper] = _individual_file_opener,
+) -> list[str]:
+    """Split input TextIOWrapper stream with fasta into a smaller chunks based on
+    stratches of "N"s and then based on chunk_size_tolerated and store either to
+    the output_fasta stream (if valid) or to the files created by
+    invocation of the `open_individual` callable.
+
+    Args:
+        input_fasta: Input FASTA as the TextIOWrapper stream.
+        chunk_size: Size of the chunks to split into.
+        chunk_size_tolerated: If more flexibility allowed, use this as the maximum size of a chunk.
+        output_fasta: Output FASTA TextIOWrapper stream to store the chunks into,
+                if none or False, `open_individual` is used (see below).
+        individual_file_prefix: A file path prefix including dirs and filenames part to use as a
+                firts part of the chunk file name.
+        n_sequece_len: Length of the stretch of `N`s to split at; not slitting on `N`s if 0.
+        chunk_sfx: A string to put between the original sequence name and the chunk suffix.
+        append_offset_to_chunk_name: A flag to append 0-based offset (`_off_{offset}`) to the chunk name.
+        open_individual: A callable taking filename as an input to generatethe output file for
+                individual contig if out_put FASTA is `false` of `None`, folders should be preexisting.
+    """
+
+    chunk_size_tolerated = max(chunk_size, chunk_size_tolerated)
+    # output agp_lines list
+    agp_lines = []
+
+    # make sure not used for n_seq <= 0
+    n_split_regex = None
+    if n_sequece_len > 0:
+        pattern = f"(N{{{n_sequece_len},}})"
+        n_split_regex = re.compile(pattern)
+
+    # process stream
+    fasta_parser = SeqIO.parse(input_fasta, "fasta")
+    for rec_count, rec in enumerate(fasta_parser, start=1):
+        rec_name = str(rec.name)
+
+        ends = split_seq_by_n(str(rec.seq), n_split_regex)
+        ends = split_seq_by_chunk_size(ends, chunk_size, chunk_size_tolerated)
+
+        offset = 0
+        for chunk, chunk_end in enumerate(ends, start=1):
+            chunk_name = f"{rec_name}_{chunk_sfx}_{chunk:03d}"
+            chunk_file_name = ""
+            if individual_file_prefix:
+                chunk_file_name = f"{individual_file_prefix}.{rec_count:03d}.{chunk:03d}.fa"
+            if append_offset_to_chunk_name:
+                chunk_name += f"_off_{offset}"
+
+            rec_from = offset + 1
+            rec_to = chunk_end
+            chunk_len = chunk_end - offset
+
+            # form agp lines
+            agp_line = f"{rec_name}\t{rec_from}\t{rec_to}\t{chunk}\tW\t{chunk_name}\t1\t{chunk_len}\t+"
+            agp_lines.append(agp_line)
+
+            # use agp lines as fasta description
+            agp_line = agp_line.replace("\t", " ")
+            logging.info(f"Dumping {chunk_name} AGP {agp_line}")
+
+            # get slice and put it out
+            tmp_record = SeqRecord(
+                Seq(rec.seq[offset:chunk_end]),
+                id=chunk_name,
+                description=f"AGP {agp_line}",
+                name="",
+            )
+
+            # if user specified chunks -- store each chunk in an individual output file
+            with output_fasta and nullcontext(output_fasta) or open_individual(chunk_file_name) as out_file:
+                out_file.write(tmp_record.format("fasta"))  # type: ignore[union-attr]
+
+            del tmp_record
+            offset = chunk_end
+
+    return agp_lines
+
+
+def get_tolerated_size(size: int, tolerance: int) -> int:
+    """Calculate max tolerated size of the chunk based on initial size and percent of allowed deviation.
+
+    Args:
+        size: Base chunk size
+        tolerance: Percent of allowed deviance as integer.
+
+    Returns:
+        Maximum tolerated chunk size.
+    """
+    tolerance = max(tolerance, 0)
+
+    tolerated_size = size
+    tolerated_size += size * tolerance // 100
+    return tolerated_size
+
+
+def chunk_fasta(
+    input_fasta_file: str,
+    chunk_size: int,
+    chunk_size_tolerated: int,
+    out_file_name: str,
+    individual_file_prefix: Optional[str],
+    agp_output_file: Optional[str] = None,
+    n_sequece_len: int = 0,
+    chunk_sfx: str = "ens_chunk",
+    append_offset_to_chunk_name: Optional[bool] = None,
+) -> None:
+    """Open `input_fasta_file` and split into a smaller chunks based on
+    stratches of "N"s and then based on chunk_size_tolerated and store either to
+    the `out_file_name` if no `individual_file_prefix` is provided or
+    store each individual chunk to a file starting with non-empty `individual_file_prefix`.
+
+    Args:
+        input_fasta_file: Input FASTA
+        chunk_size: Size of the chunks to split into.
+        chunk_size_tolerated: If more flexibility allowed, use this as the maximum size of a chunk.
+        out_file_name: Output FASTA to store the chunks into if no `individual_file_prefix` is provided.
+        individual_file_prefix: A file path prefix including dirs and filenames part to use as a
+                firts part of the chunk file name.
+        agp_output_file: Output AGP file to store the map for the chunking procedure if present and non-empty.
+        n_sequece_len: Length of the stretch of `N`s to split at; not slitting on `N`s if 0.
+        chunk_sfx: A string to put between the original sequence name and the chunk suffix.
+        append_offset_to_chunk_name: Append 0-based offset in the form of `_off_{offset}` to the chunk name.
+    """
+
+    # process input fasta
+    with open_gz_file(input_fasta_file) as fasta:
+        logging.info(
+            f"splitting sequences from '{input_fasta_file}', chunk size {chunk_size:_}, \
+                splitting on {n_sequece_len} Ns (0 -- disabled)"
+        )
+        # do not open a joined file if you plan to open many indvidual ones
+        with (
+            individual_file_prefix
+            and nullcontext(None)
+            or open(out_file_name, "wt", encoding="utf-8") as out_file_joined
+        ):
+            agp_lines = chunk_fasta_stream(
+                fasta,
+                chunk_size,
+                chunk_size_tolerated,
+                out_file_joined,
+                individual_file_prefix,
+                n_sequece_len,
+                chunk_sfx,
+                append_offset_to_chunk_name,
+            )
+
+        # dump AGP
+        if agp_output_file:
+            with open(agp_output_file, "w", encoding="utf-8") as agp_out:
+                agp_out.write("\n".join(agp_lines) + "\n")
+
+
+def prepare_out_dir_for_individuals(dir_name: Path, file_part: str) -> Optional[Path]:
+    """Creates `dir_name` (including upstream dirs) and returns its paths with the `file_part` appended.
+
+    Args:
+        dir_name: Directory to create.
+        file_part: File part to append.
+
+    Returns:
+        `dir_name` with appended `file_part`.
+
+    Throws:
+        exception if not able to create directory.
+    """
+    file_prefix = None
+    if dir_name:
+        dir_name.mkdir(parents=True, exist_ok=True)
+        file_prefix = Path(dir_name, file_part)
+    return file_prefix
 
 
 def main():
@@ -103,30 +344,30 @@ def main():
     )
     parser.add_argument_dst_path(
         "--agp_output_file",
-        default=None,
         required=False,
+        default=None,
         help="AGP file with chunks to contigs mapping.",
     )
     parser.add_argument(
         "--chunk_size",
-        metavar="100_000_000",
         required=False,
-        type=int,
         default=100_000_000,
+        metavar="100_000_000",
+        type=int,
         help="Maximum chunk size (should be greater then 50k).",
     )
     parser.add_argument(
         "--chunk_sfx",
         required=False,
-        type=str,
         default="ens_chunk",
+        type=str,
         help="Added to contig ID before chunk number.",
     )
     parser.add_argument(
         "--chunk_tolerance",
         required=False,
-        type=int,
         default=0,
+        type=int,
         help="Chunk size tolerance percentage. If the to-be-written chunk is longer \
             than the defined chunk size by less than the specified tolerance percentage,\
             it will not be split.",
@@ -138,95 +379,35 @@ def main():
         type=int,
         help="Split into chunks at positions of at least this number of N characters.",
     )
-    parser.add_argument("--add_offset", required=False, action="store_true", help="Zero-based offset.")
+    parser.add_argument(
+        "--add_offset",
+        required=False,
+        action="store_true",
+        help="Append zero-based offset to chunk name ('_off_{offset}').",
+    )
 
     parser.add_log_arguments(add_log_file=True)
-
     args = parser.parse_args()
-
-    if args.chunk_size < 50_000:
-        parser.error(
-            f"wrong '--chunk_size' value: '{args.chunk_size}'. should be greater then 50_000. exiting..."
-        )
-    if args.chunk_tolerance < 0:
-        parser.error(
-            f"wrong '--chunk_tolerance' value: '{args.chunk_tolerance}'. can't be less then 0. exiting..."
-        )
-
     init_logging_with_args(args)
 
-    tolerated_chunk_len = args.chunk_size
-    tolerated_chunk_len += args.chunk_size * args.chunk_tolerance // 100
+    check_chunk_size_and_tolerance(args.chunk_size, args.chunk_tolerance, error_f=parser.error)
 
-    # make sure not used for args.n_seq <= 0
-    n_split_regex = None
-    if args.n_seq > 0:
-        pattern = f"(N{{{args.n_seq},}})"
-        n_split_regex = re.compile(pattern)
+    chunk_size_tolerated = get_tolerated_size(args.chunk_size, args.chunk_tolerance)
 
-    # output_file to write sequences to
-    file_prefix = ""
-    if args.individual_out_dir:
-        if not args.out:
-            args.out = args.fasta_dna
-        args.individual_out_dir.mkdir(parents=True, exist_ok=True)
-        file_prefix = Path(args.individual_out_dir, args.out)
+    file_prefix = prepare_out_dir_for_individuals(args.individual_out_dir, args.out or args.fasta_dna)
 
-    # process input fasta
-    fasta_file = args.fasta_dna
-    with open_gz_file(fasta_file) as fasta:
-        agp_lines = []
-        logging.info(
-            f"splitting sequences from '{fasta_file}', chunk size {args.chunk_size:_}, \
-                splitting on {args.n_seq} Ns (0 -- disabled)"
-        )
+    chunk_fasta(
+        args.fasta_dna,
+        args.chunk_size,
+        chunk_size_tolerated,
+        args.out,
+        individual_file_prefix=file_prefix,
+        agp_output_file=args.agp_output_file,
+        n_sequece_len=args.n_seq,
+        chunk_sfx=args.chunk_sfx,
+        append_offset_to_chunk_name=args.add_offset,
+    )
 
-        fasta_parser = SeqIO.parse(fasta, "fasta")
-        for rec_count, rec in enumerate(fasta_parser, start=1):
-            rec_name = str(rec.name)
 
-            ends = split_seq_by_n(str(rec.seq), n_split_regex)
-            ends = split_seq_by_chunk_size(ends, args.chunk_size, tolerated_chunk_len)
-
-            offset = 0
-            for chunk, chunk_end in enumerate(ends, start=1):
-                chunk_name = f"{rec_name}_{args.chunk_sfx}_{chunk:03d}"
-                chunk_file_name = f"{file_prefix}.{rec_count:03d}.{chunk:03d}.fa"
-                if args.add_offset:
-                    chunk_name += f"_off_{offset}"
-
-                rec_from = offset + 1
-                rec_to = chunk_end
-                chunk_len = chunk_end - offset
-
-                # form agp lines
-                agp_line = f"{rec_name}\t{rec_from}\t{rec_to}\t{chunk}\tW\t{chunk_name}\t1\t{chunk_len}\t+"
-                agp_lines.append(agp_line)
-
-                # use agp lines as fasta description
-                agp_line = agp_line.replace("\t", " ")
-                logging.info(f"Dumping {chunk_name} AGP {agp_line}")
-
-                # get slice and put it out
-                tmp_record = SeqRecord(
-                    Seq(rec.seq[offset:chunk_end]), id=chunk_name, description=f"AGP {agp_line}", name=""
-                )
-
-                # if user specified chunks stored in individual output files
-                if args.individual_out_dir:
-                    with open(chunk_file_name, "wt", encoding="utf-8") as out_file:
-                        out_file.write(tmp_record.format("fasta"))
-                else:
-                    with open(args.out, "wt", encoding="utf-8") as out_file:
-                        out_file.write(tmp_record.format("fasta"))
-
-                del tmp_record
-                offset = chunk_end
-
-        # dump AGP
-        if args.agp_output_file:
-            with open(args.agp_output_file, "w", encoding="utf-8") as agp_out:
-                agp_out.write("\n".join(agp_lines))
-
-        if not args.individual_out_dir:
-            out_file.close()
+if __name__ == "__main__":
+    main()

--- a/src/python/tests/fasta/test_chunk.py
+++ b/src/python/tests/fasta/test_chunk.py
@@ -1,0 +1,441 @@
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit testing of `ensembl.io.genomio.fasta.chunk` module.
+
+Typical usage example::
+    $ pytest test_chunk.py
+
+"""
+
+from contextlib import contextmanager, nullcontext
+from contextlib import nullcontext as does_not_raise
+from io import StringIO, TextIOWrapper
+from pathlib import Path
+import re
+from typing import Any, Callable, ContextManager, Generator, Optional
+
+import pytest
+
+import ensembl.io.genomio.fasta.chunk as FastaChunking
+
+
+@pytest.mark.parametrize(
+    "msg, expectation",
+    [
+        ("A value error test", pytest.raises(ValueError, match=r"^A value error test$")),
+    ],
+)
+def test__on_value_error(msg: str, expectation: ContextManager) -> None:
+    """Tests the `chunk._on_value_error` function.
+
+    Args:
+        msg: Msg to raise.
+        expectation: A context manager with expected exception (`pytest.raises` or nullcontext)
+    """
+
+    with expectation:
+        FastaChunking._on_value_error(msg)
+
+
+@pytest.mark.parametrize(
+    "chunk_size, chunk_tolerance, expectation",
+    [
+        (50000, 0, does_not_raise()),
+        (50000, 1, does_not_raise()),
+        (50001, 1000, does_not_raise()),
+        (49999, 0, pytest.raises(ValueError, match=r"wrong.*chunk_size")),
+        (49999, -1, pytest.raises(ValueError, match=r"wrong.*chunk_size")),
+        (50000, -1, pytest.raises(ValueError, match=r"wrong.*chunk_tolerance")),
+    ],
+)
+def test_check_chunk_size_and_tolerance(
+    chunk_size: int,
+    chunk_tolerance: int,
+    expectation: ContextManager,
+) -> None:
+    """Tests the `chunk.check_chunk_size_and_tolerance` function.
+
+    Args:
+        chunk_size: Chunk size to check
+        chunk_tolerance: Chunk tolerance to check
+        expectation: A context manager with expected exception (`pytest.raises` or nullcontext)
+    """
+
+    with expectation:
+        FastaChunking.check_chunk_size_and_tolerance(chunk_size, chunk_tolerance)
+
+
+@pytest.mark.parametrize(
+    "seq, pattern, expectation",
+    [
+        ("", None, [len("")]),
+        ("", re.compile("N"), [0]),
+        ("CANNAN", None, [len("NANNAN")]),
+        ("CANNAN", None, [6]),
+        ("CAAAAN", re.compile("N"), [6]),
+        ("NAAAAN", re.compile("N"), [1, 6]),
+        ("NANNAN", re.compile("N"), [1, 3, 4, 6]),
+        ("NANNAN", re.compile("NN"), [4, 6]),
+        ("NAAAAN", re.compile("NN"), [6]),
+    ],
+)
+def test_split_seq_by_n(seq: str, pattern: Optional[re.Pattern], expectation: list[int]) -> None:
+    """Tests the `chunk.split_seq_by_n` function.
+
+    Args:
+        seq: A sequence to split
+        pattern: A pattern to split on
+        expectation: A list of open chunk ends (like for python list slices)
+    """
+    assert FastaChunking.split_seq_by_n(seq, pattern) == expectation
+
+
+@pytest.mark.parametrize(
+    "chunk_ends, chunk_size, tolerated_size, expectation",
+    [
+        (None, 1, None, None),
+        ([], 1, None, []),
+        ([], 1, 1, []),
+        ([6], -1, None, [6]),
+        ([6], 6, None, [6]),
+        ([6], 5, None, [5, 6]),
+        ([4, 6], 0, None, [4, 6]),
+        ([4, 6], 1, None, [1, 2, 3, 4, 5, 6]),
+        ([4, 6], 2, None, [2, 4, 6]),
+        ([4, 6], 2, 4, [4, 6]),
+        ([1, 3, 4, 6], 2, 4, [1, 3, 4, 6]),  # do not join back
+        ([1, 3, 4, 6], 6, 0, [1, 3, 4, 6]),  # do not join back
+    ],
+)
+def test_split_seq_by_chunk_size(
+    chunk_ends: list[int], chunk_size: int, tolerated_size: Optional[int], expectation: list[int]
+):
+    """Tests the `chunk.split_seq_by_chunk_size` function.
+
+    Args:
+        chunk_ends: A list of chunk_ends (open ones, like for python list slices)
+        chunk_size: Chunk size
+        tolerated_size: A more relaxed value of the chunk size
+        expectation: A list of open chunk ends (python slices coordinates)
+    """
+    assert FastaChunking.split_seq_by_chunk_size(chunk_ends, chunk_size, tolerated_size) == expectation
+
+
+def test_individual_file_opener(tmp_path: Path) -> None:
+    """Tests the `chunk._individual_file_opener` function.
+
+    Args:
+        tmp_path: Where temporary files will be created.
+    """
+    test_dir = Path(tmp_path, "file_opener_test")
+    test_dir.mkdir()
+    test_path = Path(test_dir, "test.file")
+
+    with FastaChunking._individual_file_opener(str(test_path)) as out:
+        print("test", file=out)
+        print("test", file=out)
+    assert test_path.read_text(encoding="utf-8") == "test\ntest\n"
+
+    with FastaChunking._individual_file_opener(str(test_path)) as out:
+        print("test", file=out)
+    assert test_path.read_text(encoding="utf-8") == "test\n"
+
+    assert len(list(test_dir.iterdir())) == 1
+
+
+def test_prepare_out_dir_for_individuals(tmp_path: Path) -> None:
+    """Tests the `chunk.prepare_out_dir_for_individuals` function.
+
+    Args:
+        tmp_path: Where temporary files will be created.
+    """
+    test_dir = Path(tmp_path, "prepare_out_dir_test")
+    test_file = Path(test_dir, "test.file")
+
+    assert FastaChunking.prepare_out_dir_for_individuals(test_dir, "test.file") == test_file
+    assert FastaChunking.prepare_out_dir_for_individuals(test_dir, "test.file") == test_file
+
+    test_file.write_text("test\n", encoding="utf-8")
+    assert test_file.read_text(encoding="utf-8") == "test\n"
+
+    assert FastaChunking.prepare_out_dir_for_individuals(test_dir, "test.file") == test_file
+    assert len(list(test_dir.iterdir())) == 1
+
+
+@pytest.mark.parametrize(
+    "size, tolerance, expectation",
+    [
+        (-1, -1, -1),
+        (0, -1, 0),
+        (10, -1, 10),
+        (10, 20, 12),
+        (10, 29, 12),
+        (10, 30, 13),
+        (100, 29, 129),
+    ],
+)
+def test_get_tolerated_size(size: int, tolerance: int, expectation: int) -> None:
+    """Tests the `chunk.get_tolerated_size` function.
+
+    Args:
+        size: Base size
+        tolerance: Percent of allowed deviance as integer.
+        expectation: An expexted tolerated size
+    """
+    assert FastaChunking.get_tolerated_size(size, tolerance) == expectation
+
+
+@pytest.mark.parametrize(
+    "input_fasta_text, chunk_size, chunk_size_tolerated, n_sequece_len, "
+    "chunk_sfx, append_offset_to_chunk_name, "
+    "expected_chunked_fasta_text, expected_agp_list, expected_individual_files_count, "
+    "expected_raised",
+    [
+        ("", 2, 2, 2, "p", True, "", [], 0, does_not_raise()),
+        ("\n", 2, 2, 2, "p", True, "", [], 0, does_not_raise()),
+        ("AA\n", 2, 2, 2, "p", True, "", [], 0, does_not_raise()),
+        (
+            # title, no sequence
+            ">a\n",
+            2,
+            2,
+            2,  # Ns
+            "p",
+            True,
+            ">a_p_001_off_0 AGP a 1 0 1 W a_p_001_off_0 1 0 +\n",
+            ["a\t1\t0\t1\tW\ta_p_001_off_0\t1\t0\t+"],
+            1,
+            does_not_raise(),
+        ),
+        (
+            ">c\nAAANNAAA\n",
+            3,
+            3,
+            3,  # Ns
+            "p",
+            True,
+            ">c_p_001_off_0 AGP c 1 3 1 W c_p_001_off_0 1 3 +\n"
+            "AAA\n"
+            ">c_p_002_off_3 AGP c 4 6 2 W c_p_002_off_3 1 3 +\n"
+            "NNA\n"
+            ">c_p_003_off_6 AGP c 7 8 3 W c_p_003_off_6 1 2 +\n"
+            "AA\n",
+            [
+                "c\t1\t3\t1\tW\tc_p_001_off_0\t1\t3\t+",
+                "c\t4\t6\t2\tW\tc_p_002_off_3\t1\t3\t+",
+                "c\t7\t8\t3\tW\tc_p_003_off_6\t1\t2\t+",
+            ],
+            3,
+            does_not_raise(),
+        ),
+        (
+            ">c\nAAANNAAA\n",
+            3,
+            5,
+            2,  # Ns
+            "p",
+            True,
+            ">c_p_001_off_0 AGP c 1 5 1 W c_p_001_off_0 1 5 +\n"
+            "AAANN\n"
+            ">c_p_002_off_5 AGP c 6 8 2 W c_p_002_off_5 1 3 +\n"
+            "AAA\n",
+            [
+                "c\t1\t5\t1\tW\tc_p_001_off_0\t1\t5\t+",
+                "c\t6\t8\t2\tW\tc_p_002_off_5\t1\t3\t+",
+            ],
+            2,
+            does_not_raise(),
+        ),
+    ],
+)
+def test_chunk_fasta_stream(
+    input_fasta_text: str,
+    chunk_size: int,
+    chunk_size_tolerated: int,
+    n_sequece_len: int,
+    chunk_sfx: str,
+    append_offset_to_chunk_name: Optional[bool],
+    expected_chunked_fasta_text: str,
+    expected_agp_list: list[str],
+    expected_individual_files_count: int,
+    expected_raised: ContextManager,
+) -> None:
+    """Tests the `chunk.chunk_fasta_stream` function.
+
+    Args:
+        input_fasta_text: A string with the input fasta,
+        chunk_size: Size of the chunks to split into.
+        chunk_size_tolerated: If more flexibility allowed, use this as the maximum size of a chunk.
+        n_sequece_len: Length of the stretch of `N`s to split at; not slitting on `N`s if 0.
+        chunk_sfx: A string to put between the original sequence name and the chunk suffix.
+        append_offset_to_chunk_name: A flag to append 0-based offset (`_off_{offset}`) to the chunk name.
+        expected_chunked_fasta_text: Expected chuncked ouput.
+        expected_agp_list: A list with expected AGP entries.
+        expected_individual_files_count: A number of idividually creted entitities/chunks with files.
+        expected_raised: A context manager with expected exception (`pytest.raises` or nullcontext)
+    """
+
+    # a workaround for storing individual chunks
+    @contextmanager
+    def gen_individual_opener(name: str, parts: list[tuple[str, str]]) -> Generator:
+        stream = StringIO()
+        try:
+            yield stream
+        finally:
+            # Code to release resource, e.g.:
+            parts.append((name, stream.getvalue()))
+            stream.close()
+
+    parts: list[tuple[str, str]] = []
+
+    def _individual_opener(name: str):
+        return gen_individual_opener(name, parts)
+
+    # assert joined case
+    with StringIO(input_fasta_text) as input_fasta:
+        with StringIO() as output_fasta:
+            parts.clear()
+            with expected_raised:
+                agp_list = FastaChunking.chunk_fasta_stream(
+                    input_fasta,
+                    chunk_size,
+                    chunk_size_tolerated,
+                    output_fasta,
+                    None,
+                    n_sequece_len,
+                    chunk_sfx,
+                    append_offset_to_chunk_name,
+                    open_individual=_individual_opener,
+                )
+            assert output_fasta.getvalue() == expected_chunked_fasta_text
+            assert agp_list == expected_agp_list
+            assert len(parts) == 0
+
+    with StringIO(input_fasta_text) as input_fasta:
+        with nullcontext() as no_output_fasta:
+            parts.clear()
+            with expected_raised:
+                agp_list = FastaChunking.chunk_fasta_stream(
+                    input_fasta,
+                    chunk_size,
+                    chunk_size_tolerated,
+                    no_output_fasta,
+                    "/path/prefix",
+                    n_sequece_len,
+                    chunk_sfx,
+                    append_offset_to_chunk_name,
+                    open_individual=_individual_opener,
+                )
+            assert "".join(map(lambda p: p[1], parts)) == expected_chunked_fasta_text
+            assert agp_list == expected_agp_list
+            assert len(parts) == expected_individual_files_count
+
+
+@pytest.mark.parametrize(
+    "individual_file_prefix, agp_output_file_name, expected_missing_joined",
+    [
+        ("chunk", "test.agp", pytest.raises(FileNotFoundError, match=r"output.fa")),
+        ("chunk", None, pytest.raises(FileNotFoundError, match=r"output.fa")),
+        ("", "test.agp", does_not_raise()),
+        (None, "test.agp", does_not_raise()),
+        ("", "", does_not_raise()),
+        (None, None, does_not_raise()),
+    ],
+)
+def test_chunk_fasta(
+    monkeypatch: Any,
+    tmp_path: Path,
+    individual_file_prefix: Optional[str],
+    agp_output_file_name: Optional[str],
+    expected_missing_joined: ContextManager,
+) -> None:
+    """Tests the `chunk.chunk_fasta` function.
+
+    Args:
+        tmp_path: Where temporary files will be created.
+        individual_file_prefix: A file path prefix including dirs and filenames part to use as a
+                firts part of the chunk file name or None.
+        agp_output_file_name: Output AGP file name or None.
+        expected_missing_joined: A context manager with expected exception (`pytest.raises` or nullcontext).
+    """
+
+    # a helper mock function
+    def _chunk_fasta_stream_mock(
+        input_fasta: TextIOWrapper,
+        chunk_size: int,
+        chunk_size_tolerated: int,
+        output_fasta: Optional[TextIOWrapper] | nullcontext[Any],
+        individual_file_prefix: Optional[str],
+        n_sequece_len: int,
+        chunk_sfx: str,
+        append_offset_to_chunk_name: Optional[bool],
+        open_individual: Callable[[str], TextIOWrapper] = FastaChunking._individual_file_opener,
+    ) -> list[str]:
+        """Mock the `chunk.chunk_fasta_stream` function.
+
+        Args:
+            *args: Positional argumnets.
+            **kwargs: Keyword arguments.
+        """
+        chunk_file_name = ""
+        if individual_file_prefix:
+            chunk_file_name = f"{individual_file_prefix}"
+        with output_fasta and nullcontext(output_fasta) or open_individual(chunk_file_name) as out_file:
+            for line in input_fasta:
+                out_file.write(line)  # type: ignore[union-attr]
+        return ["AGP", "TEST"]
+
+    # temp dirs and files
+    test_dir = Path(tmp_path, "chunk_fasta_test")
+    test_dir.mkdir()
+
+    input_fa = Path(test_dir, "input.fa")
+    input_fa.write_text("test\n", encoding="utf-8")
+
+    output_fa = Path(test_dir, "output.fa")
+
+    individual_fa = None
+    if individual_file_prefix:
+        individual_fa = Path(test_dir, f"{individual_file_prefix}_individual.fa")
+
+    output_agp = None
+    if agp_output_file_name:
+        output_agp = Path(test_dir, f"{agp_output_file_name}")
+
+    # patch and test
+    monkeypatch.setattr(FastaChunking, "chunk_fasta_stream", _chunk_fasta_stream_mock)
+    FastaChunking.chunk_fasta(
+        str(input_fa),
+        1,  # chunk_size
+        1,  # chunk_size_tolerated
+        str(output_fa),
+        individual_file_prefix and str(individual_fa) or None,
+        agp_output_file_name and str(output_agp) or None,
+        0,  # Ns
+        "sfx",
+        True,
+    )
+
+    with expected_missing_joined:
+        assert output_fa.read_text(encoding="utf-8") == "test\n"
+
+    if individual_fa:
+        with does_not_raise():
+            assert individual_fa.read_text(encoding="utf-8") == "test\n"
+
+    # agp test
+    if output_agp:
+        with does_not_raise():
+            assert output_agp.read_text(encoding="utf-8") == "AGP\nTEST\n"


### PR DESCRIPTION
The chunking code was broken, though that didn't affect writing to individual chunk files.
But when writing to the joined output file it was reopened for writing for each chunk, possibly losing previous chunks data.