### PR TITLE
Require type hints in every method and function

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -195,6 +195,7 @@ docstring-code-format = true
 
 [tool.mypy]
 mypy_path = "src/python"
+disallow_untyped_defs = true
 explicit_package_bases = true
 ignore_missing_imports = true
 show_error_codes = true

--- a/src/python/ensembl/io/genomio/assembly/status.py
+++ b/src/python/ensembl/io/genomio/assembly/status.py
@@ -55,7 +55,7 @@ class UnsupportedFormatError(Exception):
 class ReportStructure(dict):
     """Dict setter class of key report meta information"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         dict.__init__(self)
         self.update(
             {

--- a/src/python/ensembl/io/genomio/database/dbconnection_lite.py
+++ b/src/python/ensembl/io/genomio/database/dbconnection_lite.py
@@ -18,7 +18,7 @@ __all__ = ["DBConnectionLite"]
 
 import logging
 import re
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -32,7 +32,7 @@ _DB_PATTERN_RELEASE = re.compile(r".+_(?:core|otherfeatures|variation)_(?P<relea
 class DBConnectionLite(DBConnection):
     """Extension to get metadata directly from a database, assuming it has a metadata table."""
 
-    def __init__(self, url: StrURL, reflect: bool = False, **kwargs) -> None:
+    def __init__(self, url: StrURL, reflect: bool = False, **kwargs: Any) -> None:
         super().__init__(url, reflect, **kwargs)
         self._metadata: Dict[str, List] = {}
 

--- a/src/python/ensembl/io/genomio/events/load.py
+++ b/src/python/ensembl/io/genomio/events/load.py
@@ -73,7 +73,7 @@ class EventCollection:
     def __init__(self) -> None:
         self.events: List[IdEvent] = []
 
-    def load_events(self, input_file: PathLike):
+    def load_events(self, input_file: PathLike) -> None:
         """Load events from input file.
         Expected tab file columns: old_id, new_id, event_name, release, release_date
 
@@ -104,7 +104,7 @@ class EventCollection:
 
     def load_events_from_gene_diff(
         self, input_file: PathLike, release_name: str = "release_name", release_date: str = "release_date"
-    ):
+    ) -> None:
         """Load events from input file from gene_diff."""
         loaded_event = set()
 
@@ -157,8 +157,12 @@ class EventCollection:
             for to_id in to_ids.split(":"):
                 yield (from_id, to_id, event_name)
 
-    def remap_to_ids(self, map_dict: Dict[str, str]):
-        """Using a mapping dict, remap the to_id of all events."""
+    def remap_to_ids(self, map_dict: Dict[str, str]) -> None:
+        """Using a mapping dict, remap the to_id of all events.
+
+        Raises:
+            ValueError: If there are events without map information.
+        """
 
         no_map = 0
         for event in self.events:

--- a/src/python/ensembl/io/genomio/genbank/download.py
+++ b/src/python/ensembl/io/genomio/genbank/download.py
@@ -29,7 +29,7 @@ from ensembl.utils.logging import init_logging_with_args
 class DownloadError(Exception):
     """In case a download failed."""
 
-    def __init__(self, msg):
+    def __init__(self, msg: str) -> None:
         self.msg = msg
 
 

--- a/src/python/ensembl/io/genomio/genbank/extract_data.py
+++ b/src/python/ensembl/io/genomio/genbank/extract_data.py
@@ -505,7 +505,7 @@ class FormattedFilesGenerator:
         genome_data["added_seq"]["region_name"] = ids
         self._write_genome_json(genome_data)
 
-    def _write_genome_json(self, genome_data: Dict[str, Any]):
+    def _write_genome_json(self, genome_data: Dict[str, Any]) -> None:
         """
         Generate genome.json file with metadata for the assembly
 

--- a/src/python/ensembl/io/genomio/gff3/exceptions.py
+++ b/src/python/ensembl/io/genomio/gff3/exceptions.py
@@ -25,7 +25,7 @@ __all__ = [
 class GFFParserError(Exception):
     """Error when parsing a GFF3 file."""
 
-    def __init__(self, message):
+    def __init__(self, message: str) -> None:
         super().__init__(message)
         self.message = message
 

--- a/src/python/ensembl/io/genomio/gff3/extract_annotation.py
+++ b/src/python/ensembl/io/genomio/gff3/extract_annotation.py
@@ -299,8 +299,8 @@ class FunctionalAnnotations:
         empty_re = re.compile(r"^[ ]*$")
         return not bool(empty_re.match(product))
 
-    def _to_list(self):
-        all_list = []
+    def _to_list(self) -> list[Annotation]:
+        all_list: list[Annotation] = []
         for feat_dict in self.features.values():
             all_list += feat_dict.values()
         return all_list

--- a/src/python/ensembl/io/genomio/gff3/restructure.py
+++ b/src/python/ensembl/io/genomio/gff3/restructure.py
@@ -33,7 +33,7 @@ from .exceptions import GFFParserError
 from .features import GFFSeqFeature
 
 
-def _get_feat_counts(gene: GFFSeqFeature):
+def _get_feat_counts(gene: GFFSeqFeature) -> Counter:
     return Counter([feat.type for feat in gene.sub_features])
 
 
@@ -150,7 +150,7 @@ def move_cds_to_existing_mrna(gene: GFFSeqFeature) -> None:
     counts = _get_feat_counts(gene)
     if not counts.get("mRNA") or not counts.get("CDS"):
         return
-    if counts.get("mRNA") > 1:
+    if counts["mRNA"] > 1:
         raise GFFParserError(
             f"Can't fix gene {gene.id}: contains several mRNAs and CDSs, all children of the gene"
         )

--- a/src/python/ensembl/io/genomio/manifest/compute_stats.py
+++ b/src/python/ensembl/io/genomio/manifest/compute_stats.py
@@ -21,7 +21,6 @@ __all__ = [
 ]
 
 import json
-from os import PathLike
 from pathlib import Path
 from shutil import which
 from statistics import mean
@@ -30,6 +29,7 @@ from typing import Dict, List, Optional, Set, Union
 
 from BCBio import GFF
 
+from ensembl.utils import StrPath
 from ensembl.utils.archive import open_gz_file
 from ensembl.utils.argparse import ArgumentParser
 from ensembl.utils.logging import init_logging_with_args
@@ -83,7 +83,7 @@ class manifest_stats:
         self.manifest_parent = manifest_dir
         self.check_ncbi = False
 
-    def run(self, stats_path: PathLike):
+    def run(self, stats_path: StrPath) -> None:
         """Compute stats in the files and output a stats.txt file in the same folder.
 
         Raises:

--- a/src/python/ensembl/io/genomio/manifest/generate.py
+++ b/src/python/ensembl/io/genomio/manifest/generate.py
@@ -59,9 +59,9 @@ class ManifestMaker:
             json_out.write(json.dumps(manifest_data, sort_keys=True, indent=4))
         return manifest_path
 
-    def get_files_checksums(self):
+    def get_files_checksums(self) -> dict[str, dict]:
         """Compute the checksum of all the files in the directory."""
-        manifest_files = {}
+        manifest_files: dict[str, dict] = {}
         for subfile in self.dir.iterdir():
             logging.debug(f"Check file {subfile} ({subfile.stem}, {subfile.suffix})")
             used_file = False

--- a/src/python/ensembl/io/genomio/utils/json_utils.py
+++ b/src/python/ensembl/io/genomio/utils/json_utils.py
@@ -17,12 +17,13 @@
 __all__ = ["get_json", "print_json"]
 
 import json
-from os import PathLike
 from pathlib import Path
 from typing import Any
 
+from ensembl.utils import StrPath
 
-def get_json(src_path: PathLike, **kwargs) -> Any:
+
+def get_json(src_path: StrPath, **kwargs: Any) -> Any:
     """Generic data JSON loader.
 
     Args:
@@ -33,7 +34,7 @@ def get_json(src_path: PathLike, **kwargs) -> Any:
         return json.load(json_file, **kwargs)
 
 
-def print_json(dst_path: PathLike, data: Any, **kwargs) -> None:
+def print_json(dst_path: StrPath, data: Any, **kwargs: Any) -> None:
     """Generic data JSON dumper to a file, with keys sorted and pretty-printed with indent 4 by default.
 
     Args:

--- a/src/python/tests/annotation/test_update_description.py
+++ b/src/python/tests/annotation/test_update_description.py
@@ -16,10 +16,11 @@
 
 from contextlib import nullcontext as no_raise
 from pathlib import Path
-from typing import ContextManager
+from typing import Callable, ContextManager
 
 import pytest
 from pytest import CaptureFixture, param, raises
+import sqlalchemy
 from sqlalchemy import text
 
 from ensembl.io.genomio.annotation import get_core_data, load_descriptions
@@ -27,7 +28,7 @@ from ensembl.core.models import Gene, Transcript, ObjectXref, Xref, metadata
 from ensembl.utils.database import UnitTestDB
 
 
-def add_gene(dialect: str, session, gene_data: dict[str, str]) -> None:
+def add_gene(dialect: str, session: sqlalchemy.orm.Session, gene_data: dict[str, str]) -> None:
     """Add a gene and a transcript from a gene_data dict.
 
     Args:
@@ -89,7 +90,7 @@ def add_gene(dialect: str, session, gene_data: dict[str, str]) -> None:
 
 
 @pytest.fixture(name="annot_test_db", scope="module")
-def fixture_annotation_test_db(db_factory) -> UnitTestDB:
+def fixture_annotation_test_db(db_factory: Callable) -> UnitTestDB:
     """Returns a test database with all core tables and basic data."""
     test_db: UnitTestDB = db_factory(src="no_src", name="load_annotation")
     test_db.dbc.create_all_tables(metadata)

--- a/src/python/tests/assembly/test_download.py
+++ b/src/python/tests/assembly/test_download.py
@@ -65,7 +65,7 @@ def test_ftp_connection(
     ftp_url: str,
     accession: str,
     expectation: ContextManager,
-):
+) -> None:
     """Tests the FTPConnection method `establish_ftp()`.
 
     Args:
@@ -75,7 +75,7 @@ def test_ftp_connection(
         expectation: Context manager expected raise exception.
     """
 
-    def side_eff_conn(url: str):
+    def side_eff_conn(url: str) -> None:
         if not url:
             raise FTPConnectionError()
 
@@ -209,7 +209,7 @@ def test_download_single_file(
     data_file = data_dir / ftp_file
     retr_file = tmp_path / ftp_file
 
-    def mock_retr_binary(command: str, callback: Callable):
+    def mock_retr_binary(command: str, callback: Callable) -> None:
         logging.info(f"Faking the download of {command}")
         try:
             with data_file.open("rb") as data_fh:
@@ -274,7 +274,7 @@ def test_download_all_files(
 
     data_file = data_dir / md5
 
-    def side_eff_ftp_mlsd():
+    def side_eff_ftp_mlsd() -> list[tuple[str, list[str]]]:
         mlsd_ret = []
         files = data_dir.glob("*GCA_017607445.1*.gz")
         for file_path in files:
@@ -285,7 +285,7 @@ def test_download_all_files(
 
     mock_ftp.mlsd.side_effect = side_eff_ftp_mlsd
 
-    def mock_retr_binary(command: str, callback: Callable):
+    def mock_retr_binary(command: str, callback: Callable) -> None:
         logging.info(f"Faking the download of {command}")
         try:
             with data_file.open("rb") as data_fh:
@@ -430,7 +430,7 @@ def test_retrieve_assembly_data(
     else:
         download_dir = data_dir / "test_ftp_file.txt"
 
-    def side_eff_conn(url: str):
+    def side_eff_conn(url: str) -> None:
         if not url:
             raise FileDownloadError()
 

--- a/src/python/tests/database/test_core_server.py
+++ b/src/python/tests/database/test_core_server.py
@@ -22,7 +22,9 @@ Typical usage example::
 
 """
 
-from typing import List, Optional
+from __future__ import annotations
+
+from typing import Any, List, Optional
 
 import pytest
 from pytest_mock import MockerFixture
@@ -58,14 +60,14 @@ class MockConnection:
     def __init__(self, result: MockResult) -> None:
         self.result = result
 
-    def execute(self, *args, **kwargs) -> MockResult:  # pylint: disable=unused-argument
+    def execute(self, *args: Any, **kwargs: Any) -> MockResult:  # pylint: disable=unused-argument
         """Returns a `MockResult` object."""
         return self.result
 
-    def __enter__(self, *args, **kwargs):  # pylint: disable=unused-argument
+    def __enter__(self, *args: Any, **kwargs: Any) -> MockConnection:  # pylint: disable=unused-argument
         return self
 
-    def __exit__(self, *args, **kwargs):  # pylint: disable=unused-argument
+    def __exit__(self, *args: Any, **kwargs: Any) -> None:  # pylint: disable=unused-argument
         pass
 
 

--- a/src/python/tests/database/test_dbconnection_lite.py
+++ b/src/python/tests/database/test_dbconnection_lite.py
@@ -15,7 +15,7 @@
 """Unit testing of `ensembl.io.genomio.database.dbconnection_lite` module.
 """
 
-from typing import Optional
+from typing import Callable, Optional
 
 import pytest
 
@@ -32,7 +32,7 @@ _METADATA_CONTENT = {
 
 
 @pytest.fixture(name="meta_test_db", scope="module")
-def fixture_meta_test_db(db_factory) -> UnitTestDB:
+def fixture_meta_test_db(db_factory: Callable) -> UnitTestDB:
     """Returns a test database with a meta table and basic data."""
     test_db: UnitTestDB = db_factory("", "get_metadata")
     test_db.dbc.create_table(metadata.tables["coord_system"])

--- a/src/python/tests/genbank/test_extract_data_seq.py
+++ b/src/python/tests/genbank/test_extract_data_seq.py
@@ -69,7 +69,7 @@ class TestFormattedFilesGenerator:
         type_feature: str,
         gene_name: str,
         formatted_files_generator: FormattedFilesGenerator,
-    ):
+    ) -> None:
         """Test to parse the features correctly"""
         record = SeqRecord(Seq("ATGC"), id="record1")
         gene_feature = SeqFeature(FeatureLocation(10, 20), type="gene", qualifiers={gene_name: expected_name})
@@ -102,7 +102,7 @@ class TestFormattedFilesGenerator:
     def test_parse_record_with_unsupported_feature(
         self,
         formatted_files_generator: FormattedFilesGenerator,
-    ):
+    ) -> None:
         """Tests parsing records with unsupported features."""
         record = SeqRecord(Seq("ATGC"))
         unsupported_feature = SeqFeature(FeatureLocation(5, 10), type="gene")

--- a/src/python/tests/genome_metadata/test_prepare.py
+++ b/src/python/tests/genome_metadata/test_prepare.py
@@ -175,7 +175,7 @@ def test_add_species_metadata(
     genome_file: str,
     ncbi_data_organism: Dict,
     output: Dict[str, Any],
-):
+) -> None:
     """Tests the `prepare.add_species_metadata()` method.
 
     Args:
@@ -216,7 +216,7 @@ def test_prepare_genome_metadata(
     input_filename: str,
     ncbi_filename: str,
     expected_filename: str,
-):
+) -> None:
     """Tests the `prepare.prepare_genome_metadata()` method.
 
     Args:

--- a/src/python/tests/genome_stats/test_dump.py
+++ b/src/python/tests/genome_stats/test_dump.py
@@ -27,6 +27,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from sqlalchemy.orm import Session
+from sqlalchemy.sql.expression import ClauseElement
 
 from ensembl.core.models import Gene, Transcript
 from ensembl.io.genomio.genome_stats import dump
@@ -70,7 +71,7 @@ class MockSession(Session):
     """Mocker of `sqlalchemy.orm.Session` class that replaces its `execute()` method for testing."""
 
     # pylint: disable-next=too-many-return-statements
-    def execute(self, statement) -> MockResult:  # type: ignore[override]
+    def execute(self, statement: ClauseElement) -> MockResult:  # type: ignore[override]
         """Returns a `MockResult` object representing results of the statement execution.
 
         Args:


### PR DESCRIPTION
On top of the added configuration of `mypy`:
- Updated codebase accordingly
- Fixed some typos
- Updated some docstrings

It is interesting how forcing this has not only flagged a few things we missed during code review, but also a few minor issues we had in the code (and most likely a couple of bugs).