### PR TITLE
Upgrade ensembl-py to 2.1.2 to fix seq_region dump bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
     "bcbio-gff == 0.7.1",
     "biopython >= 1.81",
     "ensembl-py >= 2.1.2",
-    "ensembl-utils >= 0.4.1",
+    "ensembl-utils >= 0.4.4",
     "jsonschema >= 4.6.0",
     "intervaltree >= 3.1.0",
     "mysql-connector-python >= 8.0.29",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ classifiers = [
 dependencies = [
     "bcbio-gff == 0.7.1",
     "biopython >= 1.81",
-    "ensembl-py >= 2.1.0",
+    "ensembl-py >= 2.1.2",
     "ensembl-utils >= 0.4.1",
     "jsonschema >= 4.6.0",
     "intervaltree >= 3.1.0",


### PR DESCRIPTION
Fix ensembl-py ORM to allow dumps from MySQL core dbs.
Also upgrade ensembl-utils to its latest version.