### PR TITLE
Increase genomio version to 1.3.0

### DIFF
--- a/src/python/ensembl/io/genomio/__init__.py
+++ b/src/python/ensembl/io/genomio/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 """Genome Input/Output (GenomIO) handling library."""
 
-__version__ = "1.2.0"
+__version__ = "1.3.0"


### PR DESCRIPTION
Genomio library release version requires changes to __init__.py. 
- Change from release version 1.2.0 (published  July 2024) to release v.1.3.0 