### PR TITLE
Fix for mkdocs deployment

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ to install the project.
 1. [Install](install.md)
 2. [Usage](usage.md)
 3. [Code of Conduct](code_of_conduct.md)
-4. [Code reference](reference/)
+4. [Code reference](reference/ensembl/io/genomio)
 
 ## Ehive pipelines
 

--- a/src/python/ensembl/io/genomio/assembly/download.py
+++ b/src/python/ensembl/io/genomio/assembly/download.py
@@ -66,7 +66,7 @@ def establish_ftp(ftp_conn: FTP, ftp_url: str, accession: str) -> FTP:
     Args:
         ftp_conn: FTP class object.
         ftp_url: Specific FTP URL in connection request.
-        sub_dir_path: Path of sub directory housing required data for download.
+        accession: Genome accession required data for download.
 
     Raises:
         UnsupportedFormatError: If `accession` does not follow INSDC's accession format.

--- a/src/python/ensembl/io/genomio/database/factory.py
+++ b/src/python/ensembl/io/genomio/database/factory.py
@@ -33,7 +33,7 @@ def format_db_data(server_url: URL, dbs: List[str], brc_mode: bool = False) -> L
     """Returns a metadata list from the given databases on a server.
 
     Args:
-        server: Server URL where all the databases are hosted.
+        server_url: Server URL where all the databases are hosted.
         dbs: List of database names.
         brc_mode: If true, assign ``BRC4.organism_abbrev`` as the species, and ``BRC4.component`` as the
             division. Otherwise, the species will be ``species.production_name`` and the division will be

--- a/src/python/ensembl/io/genomio/external_db/__init__.py
+++ b/src/python/ensembl/io/genomio/external_db/__init__.py
@@ -1,0 +1,17 @@
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""External DB map module."""
+
+from .db_map import *


### PR DESCRIPTION
There were some out of sync function signatures remaining in two modules which caused mkdocs to complain and ultimately fail to deply to gh-pages.

Modules affected:
- assembly/download 
- database/factory

Additionally, added missing __init__.py for external_db (key reason for killed mkdocs deployment)