### PR TITLE
Bugfix mkdocs, minor version change (v1.3.1)

### DIFF
--- a/src/python/ensembl/io/genomio/__init__.py
+++ b/src/python/ensembl/io/genomio/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 """Genome Input/Output (GenomIO) handling library."""
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"


### PR DESCRIPTION
Mkdocs failed to deploy following genomio release v1.3.0, linked to issues tackled in [PR440](https://github.com/Ensembl/ensembl-genomio/pull/440). However Github actions jobs can't be just rerun following PR merge post repo release, being linked directly to initial commits prior to new initial release publishing. 

Resolution - Trigger new release, based on minor version 1.3.0 -> 1.3.1 bug fix 