### PR TITLE
Update GenomIO to avoid too many positional arguments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,7 +176,6 @@ disable = [
     "too-few-public-methods",
     "too-many-arguments",
     "too-many-locals",
-    "too-many-positional-arguments",
     "too-many-statements",
     "unspecified-encoding",
     "wildcard-import",

--- a/src/python/ensembl/io/genomio/annotation/update_description.py
+++ b/src/python/ensembl/io/genomio/annotation/update_description.py
@@ -125,7 +125,7 @@ def load_descriptions(
         }
         # Compare, only keep the descriptions that have changed
         features_to_update = _get_features_to_update(
-            table, feat_func, feat_data, stats, report, do_update, match_xrefs
+            table, feat_func, feat_data, stats, report=report, do_update=do_update, match_xrefs=match_xrefs
         )
 
         # Show stats for this feature type
@@ -172,8 +172,9 @@ def _get_features_to_update(
     feat_func: List[Dict[str, Any]],
     feat_data: Dict[str, FeatStruct],
     stats: Dict[str, int],
-    report: bool,
-    do_update: bool,
+    *,
+    report: bool = False,
+    do_update: bool = False,
     match_xrefs: bool = True,
 ) -> List[Dict[str, Any]]:
     """Checks a list of features and returns those whose description we want to update.

--- a/src/python/ensembl/io/genomio/database/core_server.py
+++ b/src/python/ensembl/io/genomio/database/core_server.py
@@ -46,6 +46,7 @@ class CoreServer:
 
     def get_cores(
         self,
+        *,
         prefix: str = "",
         build: Optional[int] = None,
         version: Optional[int] = None,

--- a/src/python/ensembl/io/genomio/fasta/chunk.py
+++ b/src/python/ensembl/io/genomio/fasta/chunk.py
@@ -141,6 +141,7 @@ def chunk_fasta_stream(
     chunk_size_tolerated: int,
     output_fasta: Optional[TextIOWrapper] | nullcontext[Any],
     individual_file_prefix: Optional[Path],
+    *,
     n_sequence_len: int = 0,
     chunk_sfx: str = "ens_chunk",
     append_offset_to_chunk_name: Optional[bool] = None,
@@ -246,6 +247,7 @@ def chunk_fasta(
     chunk_size_tolerated: int,
     out_file_name: str,
     individual_file_prefix: Optional[Path],
+    *,
     agp_output_file: Optional[str] = None,
     n_sequence_len: int = 0,
     chunk_sfx: str = "ens_chunk",
@@ -287,9 +289,9 @@ def chunk_fasta(
                 chunk_size_tolerated,
                 out_file_joined,
                 individual_file_prefix,
-                n_sequence_len,
-                chunk_sfx,
-                append_offset_to_chunk_name,
+                n_sequence_len=n_sequence_len,
+                chunk_sfx=chunk_sfx,
+                append_offset_to_chunk_name=append_offset_to_chunk_name,
             )
 
         # dump AGP

--- a/src/python/ensembl/io/genomio/gff3/features.py
+++ b/src/python/ensembl/io/genomio/gff3/features.py
@@ -29,6 +29,7 @@ class GFFSeqFeature(SeqFeature):
     def __init__(
         self,
         location: Location | None = None,
+        *,
         type: str = "",  # pylint: disable=W0622
         id: str = "<unknown id>",  # pylint: disable=W0622
         qualifiers: dict | None = None,

--- a/src/python/ensembl/io/genomio/gff3/simplifier.py
+++ b/src/python/ensembl/io/genomio/gff3/simplifier.py
@@ -535,7 +535,7 @@ class GFFSimplifier:
             elif sub.type == "miRNA":
                 new_gene_id = f"{base_id}_{num}"
                 num += 1
-                new_gene = GFFSeqFeature(sub.location, "gene", id=new_gene_id)
+                new_gene = GFFSeqFeature(sub.location, type="gene", id=new_gene_id)
                 new_gene.qualifiers = {"source": sub.qualifiers["source"], "ID": new_gene_id}
                 new_gene.sub_features = [sub]
                 new_genes.append(new_gene)

--- a/src/python/ensembl/io/genomio/manifest/check_integrity.py
+++ b/src/python/ensembl/io/genomio/manifest/check_integrity.py
@@ -207,6 +207,7 @@ class IntegrityTool:
         list1: dict[str, int],
         list2: dict[str, int],
         name: str,
+        *,
         allowed_len_diff: int | None = None,
         special_diff: bool = False,
     ) -> list[str]:

--- a/src/python/ensembl/io/genomio/seq_region/prepare.py
+++ b/src/python/ensembl/io/genomio/seq_region/prepare.py
@@ -27,6 +27,7 @@ def prepare_seq_region_metadata(
     genome_file: StrPath,
     report_file: StrPath,
     dst_file: StrPath,
+    *,
     gbff_file: StrPath | None = None,
     to_exclude: list[str] | None = None,
     mock_run: bool = False,

--- a/src/python/tests/annotation/test_update_description.py
+++ b/src/python/tests/annotation/test_update_description.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Unit testing of `ensembl.io.genomio.annotation.update_description` module."""
+# pylint: disable=too-many-positional-arguments
 
 from contextlib import nullcontext as no_raise
 from pathlib import Path

--- a/src/python/tests/assembly/test_download.py
+++ b/src/python/tests/assembly/test_download.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Unit testing of `ensembl.io.genomio.assembly.download` module."""
+# pylint: disable=too-many-positional-arguments
 
 from contextlib import nullcontext as does_not_raise
 import filecmp

--- a/src/python/tests/assembly/test_status.py
+++ b/src/python/tests/assembly/test_status.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Unit testing of `ensembl.io.genomio.assembly.status` module."""
+# pylint: disable=too-many-positional-arguments
 
 from __future__ import annotations
 

--- a/src/python/tests/database/test_core_server.py
+++ b/src/python/tests/database/test_core_server.py
@@ -12,15 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Unit testing of `ensembl.io.genomio.database.core_server` module.
-
-The unit testing is divided into one test class per submodule/class found in this module, and one test method
-per public function/class method.
-
-Typical usage example::
-    $ pytest test_core_server.py
-
-"""
+"""Unit testing of `ensembl.io.genomio.database.core_server` module."""
+# pylint: disable=too-many-positional-arguments
 
 from __future__ import annotations
 

--- a/src/python/tests/database/test_core_server.py
+++ b/src/python/tests/database/test_core_server.py
@@ -132,5 +132,7 @@ class TestCoreServer:
         server = CoreServer(server_url)
 
         # Checks the filters from get_cores
-        all_cores = server.get_cores(prefix, build, version, dbname_re, db_list)
+        all_cores = server.get_cores(
+            prefix=prefix, build=build, version=version, dbname_re=dbname_re, db_list=db_list
+        )
         assert set(all_cores) == set(output)

--- a/src/python/tests/database/test_factory.py
+++ b/src/python/tests/database/test_factory.py
@@ -12,12 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Unit testing of `ensembl.io.genomio.database.factory` module.
-
-Typical usage example::
-    $ pytest test_factory.py
-
-"""
+"""Unit testing of `ensembl.io.genomio.database.factory` module."""
+# pylint: disable=too-many-positional-arguments
 
 from pathlib import Path
 from unittest.mock import call, Mock, patch

--- a/src/python/tests/fasta/test_chunk.py
+++ b/src/python/tests/fasta/test_chunk.py
@@ -316,9 +316,9 @@ def test_chunk_fasta_stream(
                     chunk_size_tolerated,
                     output_fasta,
                     None,
-                    n_sequence_len,
-                    chunk_sfx,
-                    append_offset_to_chunk_name,
+                    n_sequence_len=n_sequence_len,
+                    chunk_sfx=chunk_sfx,
+                    append_offset_to_chunk_name=append_offset_to_chunk_name,
                     open_individual=_individual_opener,
                 )
             assert output_fasta.getvalue() == expected_chunked_fasta_text
@@ -335,9 +335,9 @@ def test_chunk_fasta_stream(
                     chunk_size_tolerated,
                     no_output_fasta,
                     Path("/path/prefix"),
-                    n_sequence_len,
-                    chunk_sfx,
-                    append_offset_to_chunk_name,
+                    n_sequence_len=n_sequence_len,
+                    chunk_sfx=chunk_sfx,
+                    append_offset_to_chunk_name=append_offset_to_chunk_name,
                     open_individual=_individual_opener,
                 )
             assert "".join(map(lambda p: p[1], parts)) == expected_chunked_fasta_text
@@ -426,10 +426,10 @@ def test_chunk_fasta(
         1,  # chunk_size_tolerated
         str(output_fa),
         individual_file_prefix and individual_fa or None,
-        agp_output_file_name and str(output_agp) or None,
-        0,  # Ns
-        "sfx",
-        True,
+        agp_output_file=agp_output_file_name and str(output_agp) or None,
+        n_sequence_len=0,  # Ns
+        chunk_sfx="sfx",
+        append_offset_to_chunk_name=True,
     )
 
     with expected_missing_joined:

--- a/src/python/tests/fasta/test_chunk.py
+++ b/src/python/tests/fasta/test_chunk.py
@@ -12,12 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Unit testing of `ensembl.io.genomio.fasta.chunk` module.
-
-Typical usage example::
-    $ pytest test_chunk.py
-
-"""
+"""Unit testing of `ensembl.io.genomio.fasta.chunk` module."""
+# pylint: disable=too-many-positional-arguments
 
 from contextlib import contextmanager, nullcontext
 from io import StringIO, TextIOWrapper

--- a/src/python/tests/fasta/test_process.py
+++ b/src/python/tests/fasta/test_process.py
@@ -12,12 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Unit testing of `ensembl.io.genomio.fasta.process` module.
-
-Typical usage example::
-    $ pytest test_process.py
-
-"""
+"""Unit testing of `ensembl.io.genomio.fasta.process` module."""
+# pylint: disable=too-many-positional-arguments
 
 from contextlib import nullcontext as does_not_raise
 import filecmp

--- a/src/python/tests/genbank/test_extract_data.py
+++ b/src/python/tests/genbank/test_extract_data.py
@@ -12,12 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Unit testing of `ensembl.io.genomio.genbank.extract_data` module.
-
-Typical usage example::
-    $ pytest test_extract_data.py
-
-"""
+"""Unit testing of `ensembl.io.genomio.genbank.extract_data` module."""
+# pylint: disable=too-many-positional-arguments
 
 from pathlib import Path
 from typing import List

--- a/src/python/tests/genbank/test_extract_data_seq.py
+++ b/src/python/tests/genbank/test_extract_data_seq.py
@@ -12,12 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Unit testing of `ensembl.io.genomio.genbank.extract_data` module.
-
-Typical usage example::
-    $ pytest test_extract_data_seq.py
-
-"""
+"""Unit testing of `ensembl.io.genomio.genbank.extract_data` module."""
+# pylint: disable=too-many-positional-arguments
 
 from pathlib import Path
 from typing import List

--- a/src/python/tests/genome_metadata/test_extend.py
+++ b/src/python/tests/genome_metadata/test_extend.py
@@ -12,12 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Unit testing of `ensembl.io.genomio.genome_metadata.extend` module.
-
-Typical usage example::
-    $ pytest test_extend.py
-
-"""
+"""Unit testing of `ensembl.io.genomio.genome_metadata.extend` module."""
+# pylint: disable=too-many-positional-arguments
 
 from pathlib import Path
 from typing import Callable, Dict, List, Tuple

--- a/src/python/tests/genome_metadata/test_prepare.py
+++ b/src/python/tests/genome_metadata/test_prepare.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Unit testing of `ensembl.io.genomio.genome_metadata.prepare` module."""
+# pylint: disable=too-many-positional-arguments
 
 from contextlib import nullcontext as does_not_raise
 from pathlib import Path

--- a/src/python/tests/gff3/test_extract_annotation.py
+++ b/src/python/tests/gff3/test_extract_annotation.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Unit testing of `ensembl.io.genomio.gff3.extract_annotation` module."""
+# pylint: disable=too-many-positional-arguments
 
 from contextlib import nullcontext as does_not_raise
 from pathlib import Path

--- a/src/python/tests/gff3/test_simplifier.py
+++ b/src/python/tests/gff3/test_simplifier.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Unit testing of `ensembl.io.genomio.gff3.simplifier` module."""
+# pylint: disable=too-many-positional-arguments
 
 from contextlib import nullcontext as does_not_raise
 from os import PathLike

--- a/src/python/tests/gff3/test_simplifier.py
+++ b/src/python/tests/gff3/test_simplifier.py
@@ -209,7 +209,7 @@ def test_normalize_non_gene(
 ) -> None:
     """Test non-gene normalization."""
     simp = GFFSimplifier()
-    feat = GFFSeqFeature(None, in_type)
+    feat = GFFSeqFeature(None, type=in_type)
     feat.qualifiers = {"source": "LOREM"}
     if in_mobile_type is not None:
         feat.qualifiers["mobile_element_type"] = [in_mobile_type]
@@ -227,7 +227,7 @@ def test_normalize_non_gene_not_implemented() -> None:
     """Test non-gene not in the biotype list."""
     simp = GFFSimplifier()
     simp._biotypes = {"non_gene": {"supported": ["non_gene_name"]}}  # pylint: disable=protected-access
-    feat = GFFSeqFeature(None, "non_gene_name")
+    feat = GFFSeqFeature(None, type="non_gene_name")
     with raises(NotImplementedError):
         simp.normalize_non_gene(feat)
 
@@ -252,7 +252,7 @@ def test_format_gene_segments(
 ) -> None:
     """Test `format_gene_segments` without a CDS."""
     simp = GFFSimplifier()
-    feat = GFFSeqFeature(None, in_type)
+    feat = GFFSeqFeature(None, type=in_type)
     if tr_name:
         feat.qualifiers["standard_name"] = [tr_name]
     with expectation:
@@ -277,9 +277,9 @@ def test_format_gene_segments_cds(
 ) -> None:
     """Test `format_gene_segments` with a CDS (and no info on the transcript)."""
     simp = GFFSimplifier()
-    feat = GFFSeqFeature(None, "C_gene_segment")
+    feat = GFFSeqFeature(None, type="C_gene_segment")
     if has_cds:
-        cds = GFFSeqFeature(None, "CDS")
+        cds = GFFSeqFeature(None, type="CDS")
         cds.qualifiers["product"] = [cds_name]
         feat.sub_features = [cds]
     with expectation:

--- a/src/python/tests/seq_region/test_collection.py
+++ b/src/python/tests/seq_region/test_collection.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Unit testing of `ensembl.io.genomio.seq_region.collection` module."""
+# pylint: disable=too-many-positional-arguments
 
 from contextlib import nullcontext as no_raise
 from pathlib import Path

--- a/src/python/tests/seq_region/test_dump.py
+++ b/src/python/tests/seq_region/test_dump.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Unit testing of `ensembl.io.genomio.seq_region.dump` module."""
+# pylint: disable=too-many-positional-arguments
 
 from typing import Any, Callable
 

--- a/src/python/tests/seq_region/test_prepare.py
+++ b/src/python/tests/seq_region/test_prepare.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Unit testing of `ensembl.io.genomio.seq_region.prepare` module."""
+# pylint: disable=too-many-positional-arguments
 
 from pathlib import Path
 from typing import Callable


### PR DESCRIPTION
But ignore the issue in unit tests, since it is not relevant in that case.