### PR TITLE
Add new module for DB meta data querying

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,7 @@ assembly_download = "ensembl.io.genomio.assembly.download:main"
 assembly_tracker = "ensembl.io.genomio.assembly.status:main"
 # Database
 database_factory = "ensembl.io.genomio.database.factory:main"
+query_db_meta = "ensembl.io.genomio.database.meta_getter:main"
 # Events
 events_dump = "ensembl.io.genomio.events.dump:main"
 events_load = "ensembl.io.genomio.events.load:main"

--- a/src/python/ensembl/io/genomio/__init__.py
+++ b/src/python/ensembl/io/genomio/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 """Genome Input/Output (GenomIO) handling library."""
 
-__version__ = "1.4.1"
+__version__ = "1.5.0"

--- a/src/python/ensembl/io/genomio/__init__.py
+++ b/src/python/ensembl/io/genomio/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 """Genome Input/Output (GenomIO) handling library."""
 
-__version__ = "1.4.0"
+__version__ = "1.4.1"

--- a/src/python/ensembl/io/genomio/database/__init__.py
+++ b/src/python/ensembl/io/genomio/database/__init__.py
@@ -17,3 +17,4 @@
 from .factory import *
 from .dbconnection_lite import *
 from .core_server import *
+from .meta_getter import *

--- a/src/python/ensembl/io/genomio/database/factory.py
+++ b/src/python/ensembl/io/genomio/database/factory.py
@@ -125,10 +125,11 @@ def get_core_dbs_metadata(
 
 
 def parse_args(arg_list: list[str] | None) -> argparse.Namespace:
-    """TODO
+    """Return a populated namespace with the arguments parsed from a list or from the command line.
 
     Args:
-        arg_list: TODO
+        arg_list: List of arguments to parse. If `None`, grab them from the command line.
+
     """
     parser = ArgumentParser(description=__doc__)
     parser.add_server_arguments()

--- a/src/python/ensembl/io/genomio/database/meta_getter.py
+++ b/src/python/ensembl/io/genomio/database/meta_getter.py
@@ -59,19 +59,15 @@ def get_meta_values(server_url: URL, db_name: str, meta_keys: StrPath | list[str
         query_meta_keys = input_queries
 
     # Loop over input meta_key(s) and query DB
-    if len(query_meta_keys) >= 1:
-        for meta_key in query_meta_keys:
-            input_keys_count += 1
-            meta_value = core_db.get_meta_value(f"{meta_key}")
+    for meta_key in query_meta_keys:
+        input_keys_count += 1
+        meta_value = core_db.get_meta_value(f"{meta_key}")
 
-            if meta_value is not None:
-                meta_values_located[f"{meta_key}"] = meta_value
-            else:
-                unpopulated_meta_keys.append(f"{meta_key}")
-                logging.info(f"Meta query returned no entry on meta_key: '{meta_key}'")
-    else:
-        logging.warning(f"No meta_keys found in input file {query_meta_keys}")
-        return None
+        if meta_value is not None:
+            meta_values_located[f"{meta_key}"] = meta_value
+        else:
+            unpopulated_meta_keys.append(f"{meta_key}")
+            logging.info(f"Meta query returned no entry on meta_key: '{meta_key}'")
 
     # Now assess what meta info was recovered and dump to JSON
     total_queries_located = len(meta_values_located)

--- a/src/python/ensembl/io/genomio/database/meta_getter.py
+++ b/src/python/ensembl/io/genomio/database/meta_getter.py
@@ -74,7 +74,7 @@ def get_meta_values(server_url: URL, db_name: str, meta_keys: StrPath | list[str
         return None
 
     # Now assess what meta info was recovered and dump to JSON
-    total_queries_located = len(meta_values_located.items())
+    total_queries_located = len(meta_values_located)
     if total_queries_located == input_keys_count:
         meta_populated = True
     elif (total_queries_located >= 1) and (total_queries_located < input_keys_count):

--- a/src/python/ensembl/io/genomio/database/meta_getter.py
+++ b/src/python/ensembl/io/genomio/database/meta_getter.py
@@ -86,10 +86,11 @@ def get_meta_values(server_url: URL, db_name: str, meta_keys: StrPath | list[str
 
 
 def parse_args(arg_list: list[str] | None) -> argparse.Namespace:
-    """TODO
+    """Return a populated namespace with the arguments parsed from a list or from the command line.
 
     Args:
-        arg_list: TODO
+        arg_list: List of arguments to parse. If `None`, grab them from the command line.
+
     """
     parser = ArgumentParser(description=__doc__)
     parser.add_server_arguments(include_database=True, help="core database")

--- a/src/python/ensembl/io/genomio/database/meta_getter.py
+++ b/src/python/ensembl/io/genomio/database/meta_getter.py
@@ -108,4 +108,4 @@ def main(arg_list: list[str] | None = None) -> None:
     args = parse_args(arg_list)
     init_logging_with_args(args)
 
-    _ = get_meta_values(server_url=args.url, db_name=args.database_name, meta_keys=args.meta_keys_list)
+    _ = get_meta_values(db_url=args.url, meta_keys=args.meta_keys_list)

--- a/src/python/ensembl/io/genomio/database/meta_getter.py
+++ b/src/python/ensembl/io/genomio/database/meta_getter.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""A simple helper script to connect to a core database and retrieve a single meta_value 
+or multiple meta_value and dump meta_key/value pairs to stdout / JSON."""
+
+__all__ = ["get_meta_values"]
+
+import argparse
+import logging
+import json
+from pathlib import PosixPath
+from pathlib import Path
+
+from sqlalchemy.engine import URL
+
+from ensembl.utils.argparse import ArgumentParser
+from ensembl.utils import StrPath
+from ensembl.utils.logging import init_logging_with_args
+from .dbconnection_lite import DBConnectionLite
+
+def get_meta_values(server_url: URL, db_name: str, input_queries: StrPath) -> dict[str, str]:
+    """Returns a set of meta values based on set of 1 or more input DB meta_keys.
+
+    Args:
+        server_url: Server URL where the core databases are stored.
+        db_name: Name of the target DB to query.
+        query_meta_keys: The meta table 'meta_key' list to query.
+
+    """
+    db_url = server_url.set(database=db_name)
+    core_db = DBConnectionLite(db_url)
+    query_meta_keys = []
+    unpopulated_meta_keys = []
+    meta_values_located = {}
+    input_keys_count = 0
+    meta_populated = False
+
+    # Check input type and populated query list
+    if isinstance(input_queries, PosixPath): 
+        with Path(input_queries).open(mode="r", encoding="UTF-8") as fh:
+            for line in fh.readlines():
+            # for file_inline in fh:
+                meta_key = line.strip()
+                query_meta_keys.append(meta_key)
+    elif isinstance(input_queries, list):
+        query_meta_keys = input_queries
+    
+    # Loop over input meta_key(s) and query DB
+    if len(query_meta_keys) >= 1:
+        for meta_key in query_meta_keys:
+            input_keys_count += 1
+            meta_value = core_db.get_meta_value(f"{meta_key}")
+
+            if meta_value is not None:
+                meta_values_located[f"{meta_key}"] = meta_value
+            else:
+                unpopulated_meta_keys.append(f"{meta_key}")
+                logging.info(f"Meta query returned no entry on meta_key: '{meta_key}'")
+    else:
+        logging.warning(f"No meta_keys found in input file {query_meta_keys}")
+        return
+
+    # Now assess what meta info was recovered and dump to JSON
+    total_queries_located = len(meta_values_located.items())
+    if total_queries_located == input_keys_count:
+        meta_populated = True
+    elif (total_queries_located >= 1) and (total_queries_located < input_keys_count):
+        meta_populated = True
+        logging.info(
+            f"Some query meta_keys missing [Queries (input: {input_keys_count}) vs (Located: {total_queries_located})"
+        )
+        logging.info(f"Missing meta_key(s)-> {unpopulated_meta_keys}")
+    else:
+        logging.warning("Zero input query meta_keys present/populated.")
+
+    if meta_populated is True:
+        meta_values_located["database_name"] = f"{db_name}"
+        print(json.dumps(meta_values_located, sort_keys = True, indent = "  "))
+        return meta_values_located
+    else:
+        return {}
+    
+def parse_args(arg_list: list[str] | None) -> argparse.Namespace:
+    """TODO
+
+    Args:
+        arg_list: TODO
+    """
+    parser = ArgumentParser(description=__doc__)
+    parser.add_server_arguments()
+    parser.add_argument("--database_name", default=None, help="Target database name.")
+    parser.add_argument_src_path(
+        "--meta_keys_list",
+        help="Input File | List with >=2 meta_keys to query target database."
+    )
+    parser.add_log_arguments(add_log_file=False)
+    return parser.parse_args(arg_list)
+
+
+
+def main(arg_list: list[str] | None = None) -> None:
+    args = parse_args(arg_list)
+    init_logging_with_args(args)
+
+    _ = get_meta_values(
+        server_url = args.url, 
+        db_name = args.database_name, 
+        input_queries = args.meta_keys_list
+        )

--- a/src/python/ensembl/io/genomio/database/meta_getter.py
+++ b/src/python/ensembl/io/genomio/database/meta_getter.py
@@ -71,14 +71,10 @@ def get_meta_values(server_url: URL, db_name: str, meta_keys: StrPath | list[str
 
     # Now assess what meta info was recovered and dump to JSON
     total_queries_located = len(meta_values_located)
-    if total_queries_located == input_keys_count:
+    if total_queries_located >= 1:
         meta_populated = True
-    elif (total_queries_located >= 1) and (total_queries_located < input_keys_count):
-        meta_populated = True
-        logging.info(
-            f"Some query meta_keys missing [Queries (input: {input_keys_count}) vs (Located: {total_queries_located})"
-        )
-        logging.info(f"Missing meta_key(s)-> {unpopulated_meta_keys}")
+        if total_queries_located < input_keys_count:
+            logging.info(f"Missing meta_key(s)-> {unpopulated_meta_keys}")
     else:
         logging.warning("Zero input query meta_keys present/populated.")
 

--- a/src/python/ensembl/io/genomio/database/meta_getter.py
+++ b/src/python/ensembl/io/genomio/database/meta_getter.py
@@ -40,6 +40,7 @@ def get_meta_values(db_url: URL, meta_keys: StrPath | list[str]) -> dict[str, st
         meta_keys: File path with one meta key per line or list of meta keys.
 
     """
+    db_name = str(db_url).split("/")[3]
     core_db = DBConnectionLite(db_url)
     query_meta_keys = []
     unpopulated_meta_keys = []

--- a/src/python/ensembl/io/genomio/database/meta_getter.py
+++ b/src/python/ensembl/io/genomio/database/meta_getter.py
@@ -96,8 +96,7 @@ def parse_args(arg_list: list[str] | None) -> argparse.Namespace:
         arg_list: TODO
     """
     parser = ArgumentParser(description=__doc__)
-    parser.add_server_arguments()
-    parser.add_argument("--database_name", default=None, help="Target database name.")
+    parser.add_server_arguments(include_database=True, help="core database")
     parser.add_argument_src_path(
         "--meta_keys_list", help="Input File | List with >=2 meta_keys to query target database."
     )

--- a/src/python/ensembl/io/genomio/database/meta_getter.py
+++ b/src/python/ensembl/io/genomio/database/meta_getter.py
@@ -102,7 +102,12 @@ def parse_args(arg_list: list[str] | None) -> argparse.Namespace:
 
 
 def main(arg_list: list[str] | None = None) -> None:
+    """Main script entry-point.
+
+    Args:
+        arg_list: Arguments to parse passing list to parse_args().
+    """
     args = parse_args(arg_list)
     init_logging_with_args(args)
 
-    _ = get_meta_values(server_url=args.url, db_name=args.database_name, input_queries=args.meta_keys_list)
+    _ = get_meta_values(server_url=args.url, db_name=args.database_name, meta_keys=args.meta_keys_list)

--- a/src/python/ensembl/io/genomio/database/meta_getter.py
+++ b/src/python/ensembl/io/genomio/database/meta_getter.py
@@ -38,7 +38,7 @@ def get_meta_values(server_url: URL, db_name: str, meta_keys: StrPath | list[str
     Args:
         server_url: Server URL where the core databases are stored.
         db_name: Name of the target DB to query.
-        query_meta_keys: The meta table 'meta_key' list to query.
+        meta_keys: File path with one meta key per line or list of meta keys.
 
     """
     db_url = server_url.set(database=db_name)

--- a/src/python/ensembl/io/genomio/database/meta_getter.py
+++ b/src/python/ensembl/io/genomio/database/meta_getter.py
@@ -80,7 +80,7 @@ def get_meta_values(server_url: URL, db_name: str, meta_keys: StrPath | list[str
 
     if meta_populated:
         meta_values_located["database_name"] = f"{db_name}"
-        print(json.dumps(meta_values_located, sort_keys=True, indent="  "))
+        print(json.dumps(meta_values_located, sort_keys=True, indent=2))
         return meta_values_located
     return {}
 

--- a/src/python/ensembl/io/genomio/database/meta_getter.py
+++ b/src/python/ensembl/io/genomio/database/meta_getter.py
@@ -90,8 +90,7 @@ def get_meta_values(server_url: URL, db_name: str, meta_keys: StrPath | list[str
         meta_values_located["database_name"] = f"{db_name}"
         print(json.dumps(meta_values_located, sort_keys=True, indent="  "))
         return meta_values_located
-    else:
-        return {}
+    return {}
 
 
 def parse_args(arg_list: list[str] | None) -> argparse.Namespace:

--- a/src/python/ensembl/io/genomio/database/meta_getter.py
+++ b/src/python/ensembl/io/genomio/database/meta_getter.py
@@ -32,7 +32,7 @@ from ensembl.utils.logging import init_logging_with_args
 from .dbconnection_lite import DBConnectionLite
 
 
-def get_meta_values(server_url: URL, db_name: str, input_queries: StrPath) -> dict[str, str] | None:
+def get_meta_values(server_url: URL, db_name: str, meta_keys: StrPath | list[str]) -> dict[str, str]:
     """Returns a set of meta values based on set of 1 or more input DB meta_keys.
 
     Args:

--- a/src/python/ensembl/io/genomio/database/meta_getter.py
+++ b/src/python/ensembl/io/genomio/database/meta_getter.py
@@ -40,7 +40,7 @@ def get_meta_values(db_url: URL, meta_keys: StrPath | list[str]) -> dict[str, st
         meta_keys: File path with one meta key per line or list of meta keys.
 
     """
-    db_name = str(db_url).split("/")[3]
+    db_name = db_url.database
     core_db = DBConnectionLite(db_url)
     query_meta_keys = []
     unpopulated_meta_keys = []

--- a/src/python/ensembl/io/genomio/database/meta_getter.py
+++ b/src/python/ensembl/io/genomio/database/meta_getter.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # See the NOTICE file distributed with this work for additional information
 # regarding copyright ownership.
 #
@@ -105,6 +104,7 @@ def main(arg_list: list[str] | None = None) -> None:
 
     Args:
         arg_list: Arguments to parse passing list to parse_args().
+
     """
     args = parse_args(arg_list)
     init_logging_with_args(args)

--- a/src/python/ensembl/io/genomio/database/meta_getter.py
+++ b/src/python/ensembl/io/genomio/database/meta_getter.py
@@ -32,16 +32,14 @@ from ensembl.utils.logging import init_logging_with_args
 from .dbconnection_lite import DBConnectionLite
 
 
-def get_meta_values(server_url: URL, db_name: str, meta_keys: StrPath | list[str]) -> dict[str, str]:
+def get_meta_values(db_url: URL, meta_keys: StrPath | list[str]) -> dict[str, str]:
     """Returns a set of meta values based on set of 1 or more input DB meta_keys.
 
     Args:
-        server_url: Server URL where the core databases are stored.
-        db_name: Name of the target DB to query.
+        db_url: Target core database URL.
         meta_keys: File path with one meta key per line or list of meta keys.
 
     """
-    db_url = server_url.set(database=db_name)
     core_db = DBConnectionLite(db_url)
     query_meta_keys = []
     unpopulated_meta_keys = []

--- a/src/python/ensembl/io/genomio/database/meta_getter.py
+++ b/src/python/ensembl/io/genomio/database/meta_getter.py
@@ -86,7 +86,7 @@ def get_meta_values(server_url: URL, db_name: str, meta_keys: StrPath | list[str
     else:
         logging.warning("Zero input query meta_keys present/populated.")
 
-    if meta_populated is True:
+    if meta_populated:
         meta_values_located["database_name"] = f"{db_name}"
         print(json.dumps(meta_values_located, sort_keys=True, indent="  "))
         return meta_values_located

--- a/src/python/ensembl/io/genomio/database/meta_getter.py
+++ b/src/python/ensembl/io/genomio/database/meta_getter.py
@@ -50,13 +50,13 @@ def get_meta_values(server_url: URL, db_name: str, meta_keys: StrPath | list[str
     meta_populated = False
 
     # Check input type and populated query list
-    if isinstance(input_queries, PosixPath):
-        with Path(input_queries).open(mode="r", encoding="UTF-8") as fh:
+    if isinstance(meta_keys, PosixPath):
+        with Path(meta_keys).open(mode="r", encoding="UTF-8") as fh:
             for line in fh.readlines():
                 meta_key = line.strip()
                 query_meta_keys.append(meta_key)
-    elif isinstance(input_queries, list):
-        query_meta_keys = input_queries
+    elif isinstance(meta_keys, list):
+        query_meta_keys = meta_keys
 
     # Loop over input meta_key(s) and query DB
     for meta_key in query_meta_keys:


### PR DESCRIPTION
This is a new module designed to take a defined set of input meta.meta_keys (Input file), and directly query a single core database on those keys. 

- For now, the module requires an input file but in the future it might be good to add the option of passing a list of keys separated by ',' 
- The module dumps the returned keys (1 or more if returned a value from query) in JSON format to stdout. 
- Implemented with a single function called within main().
- Also require the genomio release version to be changed from 1.4.0 to 1.4.1 to allow generation of a container and inclusion of this functionality in BUSCO NXF pipeline. 
 