### PR TITLE
Add ps for genomio container

### DIFF
--- a/src/python/ensembl/io/genomio/__init__.py
+++ b/src/python/ensembl/io/genomio/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 """Genome Input/Output (GenomIO) handling library."""
 
-__version__ = "1.5.1"
+__version__ = "1.5.0"


### PR DESCRIPTION
Quick update to address the fact that genomio container is missing procps installation i.e. lacks 'ps' which is required for nextflow integration. 

- Add installation to docker file