### PR TITLE
Adding CICD trigger to allow non versioned release genomio container builds 

### DIFF
--- a/cicd/gitlab/dot.gitlab-ci.yml
+++ b/cicd/gitlab/dot.gitlab-ci.yml
@@ -54,6 +54,8 @@ include:
     rules:
       - if: '$CI_COMMIT_TAG =~ /v[0-9]+\.[0-9]+\.[0-9]+$/'
         when: always
+      - if: '$CI_COMMIT_TAG =~ /container_rebuild_[0-9]+$/'
+        when: always
 
 
 # External pipelines

--- a/cicd/gitlab/dot.gitlab-ci.yml
+++ b/cicd/gitlab/dot.gitlab-ci.yml
@@ -54,7 +54,7 @@ include:
     rules:
       - if: '$CI_COMMIT_TAG =~ /v[0-9]+\.[0-9]+\.[0-9]+$/'
         when: always
-      - if: '$CI_COMMIT_TAG =~ /container_rebuild_[0-9]+$/'
+      - if: '$CI_COMMIT_TAG =~ /GenomioDockerRebuild_v[0-9]+\.[0-9]+\.[0-9]+[a-z]$/'
         when: always
 
 


### PR DESCRIPTION
This PR is simply attempting to allow genomio maintainers to decouple the creation of a genomio python container from the current paradigm of A (Create versioned release) -> trigger CICD docker generation and publish to gitlab + dockerhub. 

If a user wants to for whatever reason rebuild the docker container (in this case we needed to rebuild as the container was missing 'ps') then commits can be made, then tagged with a format specific _[git tag](https://docs.gitlab.com/ee/user/project/repository/tags/)_. This should (in principle), though as of now is untested, allow for manual triggering of the pipeline via selection of said git tag. 

**Tag format:** 
GenomioDockerRebuild_v[0-9]+\.[0-9]+\.[0-9]+[a-z]$

In this case, the first ever manual trigger is named: GenomioDockerRebuild_v1.5.0a

I wanted to keep the genomio version information intact as this should aid future tag creation and history tracing. 

Users wanting to create a new tag for the above purpose of CICD pipeline initiation should follow the format and check before creation using `git tag -l --merged`. If a second tag is needed on the same version of genomio (i.e. release version), then serially increment the suffix **letter** a-> b-> c-> d... etc. 