### PR TITLE
Update commit tag format when rebuilding docker containers

### DIFF
--- a/cicd/gitlab/dot.gitlab-ci.yml
+++ b/cicd/gitlab/dot.gitlab-ci.yml
@@ -52,9 +52,7 @@ include:
   # Genomio docker deploy (on release tag creation)
   - local: cicd/gitlab/parts/dockerbuild.genomio.gitlab-ci.yml
     rules:
-      - if: '$CI_COMMIT_TAG =~ /v[0-9]+\.[0-9]+\.[0-9]+$/'
-        when: always
-      - if: '$CI_COMMIT_TAG =~ /GenomioDockerRebuild_v[0-9]+\.[0-9]+\.[0-9]+[a-z]$/'
+      - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+[ab]?(_rebuild_[a-z])?$/'
         when: always
 
 


### PR DESCRIPTION
The new format will be, for instance, `v1.5.0_rebuild_a`, which is shorter and starts with the version for better tracking.