### PR TITLE
Sync add-version with main (updated CICD container trigger) 

### DIFF
--- a/cicd/gitlab/dot.gitlab-ci.yml
+++ b/cicd/gitlab/dot.gitlab-ci.yml
@@ -54,6 +54,8 @@ include:
     rules:
       - if: '$CI_COMMIT_TAG =~ /v[0-9]+\.[0-9]+\.[0-9]+$/'
         when: always
+      - if: '$CI_COMMIT_TAG =~ /GenomioDockerRebuild_v[0-9]+\.[0-9]+\.[0-9]+[a-z]$/'
+        when: always
 
 
 # External pipelines

--- a/cicd/gitlab/dot.gitlab-ci.yml
+++ b/cicd/gitlab/dot.gitlab-ci.yml
@@ -52,9 +52,7 @@ include:
   # Genomio docker deploy (on release tag creation)
   - local: cicd/gitlab/parts/dockerbuild.genomio.gitlab-ci.yml
     rules:
-      - if: '$CI_COMMIT_TAG =~ /v[0-9]+\.[0-9]+\.[0-9]+$/'
-        when: always
-      - if: '$CI_COMMIT_TAG =~ /GenomioDockerRebuild_v[0-9]+\.[0-9]+\.[0-9]+[a-z]$/'
+      - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+[ab]?(_rebuild_[a-z])?$/'
         when: always
 
 


### PR DESCRIPTION
Merge changes in main with Jorges branch to add versioning to ensembl/genomio/io entry points.

- Permits manual triggering for creation of containers via genomio python version CICD variable pattern for container rebuilds.  