### PR TITLE
using proper "organism.production_name" metakey in the config generator

### DIFF
--- a/scripts/gff_metaparser/genmetaconf/metaconf.py
+++ b/scripts/gff_metaparser/genmetaconf/metaconf.py
@@ -233,7 +233,7 @@ class MetaConf:
             self.update("ANNOTATION_SOURCE_SFX", _ann_source_sfx, tech=True)
             _prod_name += _ann_source_sfx
         self.update("species.production_name", _prod_name)
-        self.update("organism.ensembl_name", _prod_name)
+        self.update("organism.production_name", _prod_name)
         _comm_name = self.get("species.common_name")
         self.update("organism.common_name", _comm_name)
         _display_name = _sci_name


### PR DESCRIPTION
use
```
update meta set meta_key = "organism.production_name" where meta_key = "organism.ensembl_name";
```
to fix meta keys for the already loaded cores