### PR TITLE
Refactor: Improve error handling, prevent dictionary mutation, and fix type hints in OSID organism script

### DIFF
--- a/scripts/stable_id_alloc/osid_add_organisms.py
+++ b/scripts/stable_id_alloc/osid_add_organisms.py
@@ -71,7 +71,7 @@ def add_organism(url: str, user: str, key: str, org_data: Dict[str, str]) -> Non
             print(f"Error: {result.status_code}")
             try:
                 print(json.dumps(result.json(), indent=4))
-            except ValueError:  # Catches JSONDecodeError if in case respobse is not JSON
+            except ValueError:  # Catches JSONDecodeError if in case response is not JSON
                 print(result.text)
     except requests.exceptions.RequestException as e:
         print(f"Network error occurred while adding organism: {e}")

--- a/scripts/stable_id_alloc/osid_add_organisms.py
+++ b/scripts/stable_id_alloc/osid_add_organisms.py
@@ -61,31 +61,48 @@ def add_organism(url: str, user: str, key: str, org_data: Dict[str, str]) -> Non
 
     add_org_url = url + "/organisms"
     headers = {"Content-type": "application/json", "Accept": "application/json"}
-    result = requests.post(add_org_url, auth=(user, key), headers=headers, json=org_data, timeout=10)
-
-    if result and result.status_code == 200:
-        print("Successfully added organism")
-    else:
-        print("Error: " + str(result))
-        print(json.dumps(json.loads(result.content), indent=4))
+    
+    try:
+        result = requests.post(add_org_url, auth=(user, key), headers=headers, json=org_data, timeout=10)
+        
+        if result and result.status_code == 200:
+            print("Successfully added organism")
+        else:
+            print(f"Error: {result.status_code}")
+            try:
+                print(json.dumps(result.json(), indent=4))
+            except ValueError:  # Catches JSONDecodeError if in case respobse is not JSON
+                print(result.text)
+    except requests.exceptions.RequestException as e:
+        print(f"Network error occurred while adding organism: {e}")
 
 
 def update_organism(url: str, user: str, key: str, org_data: Dict[str, str], organism_id: int) -> None:
     """Update an organism in OSID."""
 
-    del org_data["organismName"]
-    update_org_url = url + "/organisms" + "/" + str(organism_id)
+    # Safely creates a copy and removes the name without directly mutating the original dictionary
+    payload = org_data.copy()
+    payload.pop("organismName", None)
+
+    update_org_url = f"{url}/organisms/{organism_id}"
     headers = {"Content-type": "application/json", "Accept": "application/json"}
-    result = requests.put(update_org_url, auth=(user, key), headers=headers, json=org_data, timeout=10)
+    
+    try:
+        result = requests.put(update_org_url, auth=(user, key), headers=headers, json=payload, timeout=10)
 
-    if result and result.status_code == 204:
-        print("Successfully updated organism")
-    else:
-        print("Error: " + str(result))
-        print(json.dumps(json.loads(result.content), indent=4))
+        if result and result.status_code == 204:
+            print("Successfully updated organism")
+        else:
+            print(f"Error: {result.status_code}")
+            try:
+                print(json.dumps(result.json(), indent=4))
+            except ValueError:
+                print(result.text)
+    except requests.exceptions.RequestException as e:
+        print(f"Network error occurred while updating organism: {e}")
 
 
-def add_or_update_organism(url: str, user, key: str, organism_data: Dict[str, str], update: bool) -> None:
+def add_or_update_organism(url: str, user: str, key: str, organism_data: Dict[str, str], update: bool) -> None:
     """Either add an organism or update it if it's already in OSID."""
 
     organism_id = get_organism(url, user, key, organism_data)

--- a/scripts/stable_id_alloc/osid_add_organisms.py
+++ b/scripts/stable_id_alloc/osid_add_organisms.py
@@ -72,7 +72,8 @@ def add_organism(url: str, user: str, key: str, org_data: Dict[str, str]) -> Non
             try:
                 print(json.dumps(result.json(), indent=4))
             except ValueError:  # Catches JSONDecodeError if in case response is not JSON
-                print(result.text)
+                error_payload = {"error": "Non-JSON response from server", "raw_response": result.text}
+                print(json.dumps(error_payload, indent=4))
     except requests.exceptions.RequestException as e:
         print(f"Network error occurred while adding organism: {e}")
 
@@ -97,7 +98,8 @@ def update_organism(url: str, user: str, key: str, org_data: Dict[str, str], org
             try:
                 print(json.dumps(result.json(), indent=4))
             except ValueError:
-                print(result.text)
+                error_payload = {"error": "Non-JSON response from server", "raw_response": result.text}
+                print(json.dumps(error_payload, indent=4))
     except requests.exceptions.RequestException as e:
         print(f"Network error occurred while updating organism: {e}")
 


### PR DESCRIPTION
While going through the OSID tools, I noticed a couple of spots where the script could malfunction or behave unexpectedly, particularly during batch processing.

### The Fixes:
* **Dictionary Mutation:** In `update_organism`, the script was deleting the `organismName` key from the original input dictionary. If that data is needed elsewhere in a larger workflow, it’s gone. I switched this to use a local copy and `.pop()` to keep the original data intact.
* **Non-JSON Server Errors:** Currently, if the OSID server hits a snag (like a 500 error) and returns HTML instead of JSON, the script crashes while trying to print the error. I’ve wrapped the JSON parsing in a try/except so it falls back to printing the raw response text instead of blowing up.
* **Network Failures:** Added a `try/except` around the `requests` calls to handle timeouts/connection issues more gracefully.
* **Type Hinting:** Caught a missing `str` hint on the `user` param in `add_or_update_organism` and added it for consistency.

### Testing:
Ran this locally with some mock responses:
1. Confirmed that the input dictionary is no longer mutated after an update.
2. Verified that HTML error pages from the server now print as raw text rather than triggering a `JSONDecodeError`.