### PR TITLE
Fix logic name from RepeatMasker Repbase analysis

### DIFF
--- a/src/python/ensembl/io/genomio/features/convert_to_genomio_json.py
+++ b/src/python/ensembl/io/genomio/features/convert_to_genomio_json.py
@@ -925,7 +925,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     _add_repeatmasker_common_args(repbase_parser)
     repbase_parser.set_defaults(
-        analysis_logic_name="repeatmask_rmlib",
+        analysis_logic_name="repeatmask_repbase",
         analysis_display_label="Repeats: Repbase",
         analysis_description=(
             'Repeats identified by <a rel="external" href="http://www.repeatmasker.org">RepeatMasker</a>, '

--- a/src/python/tests/features/test_convert_to_genomio_json.py
+++ b/src/python/tests/features/test_convert_to_genomio_json.py
@@ -1281,7 +1281,7 @@ def test_parse_args(data_dir: Path, tmp_path: Path, use_repeatmodeler_lib: bool)
 
     if use_repeatmodeler_lib:
         assert args.program_version == "4.1.7"
-        assert args.analysis_logic_name == "repeatmask_rmlib"
+        assert args.analysis_logic_name == "repeatmask_repbase"
         assert args.analysis_display_label == "Repeats: Repbase"
         assert args.analysis_description == (
             'Repeats identified by <a rel="external" href="http://www.repeatmasker.org">RepeatMasker'

--- a/src/python/tests/features/test_convert_to_genomio_json.py
+++ b/src/python/tests/features/test_convert_to_genomio_json.py
@@ -1385,7 +1385,7 @@ def test_main_passes_expected_arguments(
             "input_path": input_path,
             "repeatmasker_consensus_lib_path": consensus_lib,
             "output_path": output_path,
-            "analysis_logic_name": "repeatmask_rmlib",
+            "analysis_logic_name": "repeatmask_repbase",
             "analysis_display_label": "Repeats: Repbase",
             "analysis_description": (
                 'Repeats identified by <a rel="external" href="http://www.repeatmasker.org">RepeatMasker'


### PR DESCRIPTION
Make logic name consistent with current core DB analysis logic name for RepeatMasker Repbase.  Doesn't affect module logic, only JSON output.