### PR TITLE
Post-GSoC refinements: strict paper acceptance (+suggested/GoaT fallback), whole-paper Gemma, status fix, circular-import fix

### DIFF
--- a/src/python/ensembl/io/genomio/literature/__init__.py
+++ b/src/python/ensembl/io/genomio/literature/__init__.py
@@ -21,4 +21,15 @@ number, cultivar/strain and sex via a rule + vector + optional-LLM ensemble.
 
 __all__ = ["run_batch", "run_pipeline"]
 
-from ensembl.io.genomio.literature.pipeline import run_batch, run_pipeline
+
+def __getattr__(name: str):
+    # Import from pipeline lazily (PEP 562) so that `import
+    # ensembl.io.genomio.literature` does not eagerly pull in the vector-search
+    # stack (rank-bm25 / sentence-transformers, which are optional `literature`
+    # extras) and does not create an __init__ <-> pipeline import cycle. The
+    # convenience `from ensembl.io.genomio.literature import run_pipeline` still works.
+    if name in __all__:
+        from ensembl.io.genomio.literature import pipeline
+
+        return getattr(pipeline, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/python/ensembl/io/genomio/literature/fetch.py
+++ b/src/python/ensembl/io/genomio/literature/fetch.py
@@ -278,6 +278,27 @@ def _strongest_score(candidates: list, identifiers: dict) -> float:
     return max((score_paper_candidate(p, identifiers) for p in candidates), default=0.0)
 
 
+def _paper_is_accession_linked(paper: dict, accession: str) -> bool:
+    """Strict acceptance gate: a paper is trusted only if it is tied to THIS assembly
+    by its accession or BioProject. Papers retrieved via a direct accession/BioProject
+    link (NCBI-established) qualify on provenance; papers found by name / full-text
+    search qualify only if the assembly accession (version-less) actually appears in
+    the paper's title, abstract or full text."""
+    if paper.get("retrieval_source") in ("linked_pmid", "elink", "bioproject") or paper.get(
+        "is_reference_paper"
+    ):
+        return True
+    acc_base = accession.split(".")[0].lower()
+    text = " ".join(
+        [
+            paper.get("title", "") or "",
+            paper.get("abstractText", "") or "",
+            (paper.get("text_data", {}) or {}).get("text") or "",
+        ]
+    ).lower()
+    return acc_base in text
+
+
 def _gather_paper_candidates(accession: str, assembly: dict, identifiers: dict, max_results: int) -> list:
     """Run the Mode-B retrieval escalation and return the pooled candidate papers.
 
@@ -488,9 +509,23 @@ def fetch_papers_for_assembly(accession: str, max_results: int = 5) -> dict:
         )
 
     enriched_papers = _prepare_papers(papers_found)
+
+    # ---- strict acceptance gate (precision-first) ----
+    # `papers` keeps only those tied to THIS assembly by its accession or BioProject
+    # (linked in NCBI, or the accession appears in the paper text) — the confirmed,
+    # literature-grounded set. `candidate_papers` keeps the full ranked list so the
+    # pipeline can fall back to the best candidate as a *suggestion* (or to GoaT)
+    # when nothing qualifies strictly.
+    accepted = [paper for paper in enriched_papers if _paper_is_accession_linked(paper, accession)]
+    if len(accepted) < len(enriched_papers):
+        logger.info(
+            f"      [strict] kept {len(accepted)}/{len(enriched_papers)} paper(s) "
+            f"linked to {accession} (accession/BioProject); the rest are suggestion-only"
+        )
+
     reference_paper = _extract_reference_paper(papers_found)
 
-    logger.info(f"\n[4/4] Done. {len(enriched_papers)} paper(s) ready for extraction.")
+    logger.info(f"\n[4/4] Done. {len(accepted)} accession-linked paper(s) ready for extraction.")
     logger.info(
         f"      chromosome_number will be "
         f"{'used from NCBI' if assembly.get('chromosome_number') else 'extracted from text in extract.py'}"
@@ -498,6 +533,7 @@ def fetch_papers_for_assembly(accession: str, max_results: int = 5) -> dict:
 
     return {
         "assembly": assembly,
-        "papers": enriched_papers,
+        "papers": accepted,
+        "candidate_papers": enriched_papers,
         "reference_paper": reference_paper,
     }

--- a/src/python/ensembl/io/genomio/literature/gemma.py
+++ b/src/python/ensembl/io/genomio/literature/gemma.py
@@ -89,11 +89,14 @@ _DEFAULT_MODEL = str(_MODELS_DIR / "google_gemma-3-4b-it-Q4_K_M.gguf")
 BASE_URL = os.environ.get("GEMMA_BASE_URL", "http://localhost:8000/v1")
 MODEL = os.environ.get("GEMMA_MODEL", _DEFAULT_MODEL)
 TIMEOUT = int(os.environ.get("GEMMA_TIMEOUT", "300"))
-# Cap on passage text sent to the model. Raised so Gemma can read a full trusted
-# paper (not just the retrieved vector chunks); lower it for speed on the GGUF backend.
-MAX_CHARS = int(os.environ.get("GEMMA_MAX_CHARS", "30000"))
-# GGUF context window. Gemma-3-4B supports up to 128k; the default is large enough
-# to hold a full paper plus the system prompt and few-shot examples.
+# Cap on passage text sent to the model. Set high enough to hold a WHOLE trusted
+# paper (not just the retrieved vector chunks) — a typical full text is well under
+# this, so in practice nothing is truncated; ~100k chars fits inside the default
+# context below (a paper is read one accession at a time, so latency is acceptable).
+# Lower it for speed on the GGUF backend if needed.
+MAX_CHARS = int(os.environ.get("GEMMA_MAX_CHARS", "100000"))
+# GGUF context window. Gemma-3-4B supports up to 128k; the default holds a full
+# paper plus the system prompt and few-shot examples.
 N_CTX = int(os.environ.get("GEMMA_N_CTX", "32768"))
 N_THREADS = int(os.environ.get("GEMMA_N_THREADS", "32"))  # one NUMA node
 

--- a/src/python/ensembl/io/genomio/literature/pipeline.py
+++ b/src/python/ensembl/io/genomio/literature/pipeline.py
@@ -18,10 +18,9 @@ import argparse
 import json
 import logging
 
-from ensembl.io.genomio.literature import gemma
 from ensembl.io.genomio.literature.extract import extract_metadata
 from ensembl.io.genomio.literature.fetch import fetch_papers_for_assembly
-from ensembl.io.genomio.literature.gemma import combine_with_gemma
+from ensembl.io.genomio.literature.gemma import combine_with_gemma, is_enabled, run_gemma_ploidy
 from ensembl.io.genomio.literature.parse import parse_paper
 from ensembl.io.genomio.literature.search import run_vector_search
 
@@ -112,6 +111,21 @@ def _ploidy_recovered(result: dict) -> bool:
     return (result.get("ploidy") or {}).get("level") is not None
 
 
+def _is_correct_paper_for_accession(paper: dict, assembly: dict) -> bool:
+    """Accession-level check before letting Gemma read a paper: only trust a paper
+    that is genuinely tied to THIS assembly — linked by accession (directly linked
+    PMID / Entrez elink) or by its BioProject, or with the assembly's scientific
+    name actually present in the paper text. This stops Gemma from confidently
+    reading ploidy out of an off-target paper."""
+    if paper.get("retrieval_source") in ("linked_pmid", "elink", "bioproject") or paper.get(
+        "is_reference_paper"
+    ):
+        return True
+    scientific_name = (assembly.get("scientific_name") or "").lower()
+    paper_text = (paper.get("text_data", {}).get("text") or "").lower()
+    return bool(scientific_name) and scientific_name in paper_text
+
+
 # ============================================================
 # MAIN FUNCTION — run full pipeline for one assembly accession
 #           input:  assembly accession string
@@ -132,7 +146,19 @@ def run_pipeline(accession: str, max_papers: int = 5) -> dict:
     fetched = fetch_papers_for_assembly(accession, max_results=max_papers)
     assembly = fetched["assembly"]
     papers = fetched["papers"]
+    candidate_papers = fetched.get("candidate_papers", [])
     reference_paper = fetched.get("reference_paper")
+
+    # If the strict gate accepted no accession/BioProject-linked paper, fall back to
+    # the best candidate paper (found by name / full text) and treat its metadata as a
+    # SUGGESTION rather than a confirmed result. This keeps a literature-grounded answer
+    # (Gemma reads the whole paper; rule + vector still run) instead of dropping straight
+    # to GoaT. Confirmed only when a paper was strictly linked to the accession.
+    suggested = False
+    if not papers and candidate_papers:
+        logger.info("  No accession-linked paper; using the best candidate as a suggestion.")
+        papers = candidate_papers
+        suggested = True
 
     # Guard: NCBI returned no usable assembly metadata (stale / suppressed
     # accession). Without a scientific name we cannot search by name or trust
@@ -145,12 +171,34 @@ def run_pipeline(accession: str, max_papers: int = 5) -> dict:
         )
         return {
             "assembly_accession": assembly.get("assembly_accession"),
+            "status": "error",
             "error": "no assembly metadata",
         }
 
     if not papers:
-        logger.info("  No relevant paper found. Returning assembly metadata only.")
-        return {
+        # Strict retrieval found no accession/BioProject-linked paper. Fall back to
+        # GoaT's species-level reference ploidy when available, so we still return a
+        # result (mentor: prioritise precision in literature retrieval, but use GoaT
+        # where present); otherwise report nothing found.
+        goat_level = assembly.get("reference_ploidy")
+        if goat_level is not None:
+            logger.info(f"  No qualifying paper — using GoaT reference ploidy ({goat_level}).")
+            ploidy = {
+                "level": goat_level,
+                "mechanism": None,
+                "status": "from_reference",
+                "source": "GoaT",
+                "method": "reference_taxon",
+                "confidence": 0.6,
+                "reference_check": {"goat_ploidy": goat_level, "agreement": "no_qualifying_paper"},
+            }
+            status, error = "success", None
+        else:
+            logger.info("  No qualifying paper and no GoaT reference — nothing to report.")
+            ploidy = {"level": None, "status": "no_relevant_paper", "source": None}
+            status, error = "error", "no relevant paper"
+
+        result = {
             "assembly_accession": assembly.get("assembly_accession"),
             "assembly_name": assembly.get("assembly_name"),
             "taxon_id": assembly.get("taxon_id"),
@@ -159,12 +207,16 @@ def run_pipeline(accession: str, max_papers: int = 5) -> dict:
                 "value": assembly.get("chromosome_number"),
                 "source": assembly.get("chromosome_source"),
             },
-            "ploidy": {"level": None, "status": "no_relevant_paper", "source": None},
+            "ploidy": ploidy,
             "cultivars": {"confirmed": [], "unconfirmed": []},
             "sex": {"value": "unknown"},
-            "paper": {"note": "Not found relevant paper"},
+            "paper": {"note": "No accession/BioProject-linked paper found"},
             "papers_found": 0,
+            "status": status,
         }
+        if error:
+            result["error"] = error
+        return result
 
     # Select best paper — prefer nuclear genome + fulltext
     logger.info(f"\n  Selecting best paper from {len(papers)} candidate(s) ...")
@@ -174,6 +226,7 @@ def run_pipeline(accession: str, max_papers: int = 5) -> dict:
         logger.info("  No usable paper found.")
         return {
             "assembly_accession": assembly.get("assembly_accession"),
+            "status": "error",
             "error": "no usable paper",
             "paper": {"note": "Not found relevant paper"},
         }
@@ -195,6 +248,7 @@ def run_pipeline(accession: str, max_papers: int = 5) -> dict:
             "assembly_accession": assembly.get("assembly_accession"),
             "assembly_name": assembly.get("assembly_name"),
             "taxon_id": assembly.get("taxon_id"),
+            "status": "error",
             "error": "no sections extracted",
         }
 
@@ -213,9 +267,14 @@ def run_pipeline(accession: str, max_papers: int = 5) -> dict:
     #     retrieved vector chunks, so it forms an independent opinion even when the
     #     decisive ploidy sentence didn't make the vector-search cut. combine_with_gemma
     #     folds its result in as a third vote. No-op unless GEMMA_ENABLED=1.
-    if gemma.is_enabled():
+    if is_enabled() and not _is_correct_paper_for_accession(best_paper, assembly):
+        logger.info(
+            "  [gemma] skipped: the selected paper is not confidently tied to this "
+            "accession (no accession/BioProject link and scientific name absent from text)"
+        )
+    elif is_enabled():
         gemma_passages = [{"text": text, "section": section} for section, text in parsed["sections"].items()]
-        gemma_result = gemma.run_gemma_ploidy(
+        gemma_result = run_gemma_ploidy(
             final["species"]["value"],
             gemma_passages,
             accession=accession,
@@ -253,6 +312,21 @@ def run_pipeline(accession: str, max_papers: int = 5) -> dict:
     final["papers_found"] = len(papers)
     final["reference_paper"] = reference_paper  # BioProject canonical paper (attached even if no ploidy)
 
+    # When no paper was strictly linked to the accession, the answer came from the
+    # best candidate paper — mark it as a suggestion (not a confirmed result) and
+    # temper the confidence, so curators can tell literature-confirmed from inferred.
+    if suggested and final["ploidy"].get("level") is not None:
+        final["ploidy"]["status"] = "suggested"
+        final["ploidy"]["source"] = "suggested_" + str(final["ploidy"].get("source") or "literature")
+        final["ploidy"]["confidence"] = round(final["ploidy"].get("confidence", 0.5) * 0.7, 2)
+
+    # A result is only "success" if a ploidy level was actually recovered; a paper
+    # that parsed fine but states no ploidy is flagged as an error, so single-accession
+    # (Nextflow) runs surface "nothing useful found" cleanly rather than as success.
+    final["status"] = "success" if _ploidy_recovered(final) else "error"
+    if final["status"] == "error":
+        final.setdefault("error", "no ploidy recovered")
+
     return final
 
 
@@ -273,12 +347,9 @@ def run_batch(accessions: list[str], max_papers: int = 5) -> list[dict]:
         logger.info(f"\n{'=' * 60}")
         logger.info(f"Batch progress: {i}/{total}")
         try:
+            # run_pipeline already stamps result["status"] based on whether a
+            # ploidy level was recovered; batch mode just handles hard failures.
             result = run_pipeline(accession, max_papers=max_papers)
-            if _ploidy_recovered(result):
-                result["status"] = "success"
-            else:
-                result["status"] = "error"
-                result.setdefault("error", "no ploidy recovered")
         except Exception as e:
             logger.info(f"  ERROR for {accession}: {e}")
             result = {


### PR DESCRIPTION
Follow-up to #519, from the mentor feedback:

- Strict acceptance: only accession/BioProject-linked papers give a confirmed
  (found_in_paper) result; when none qualify, the best candidate paper is used as
  a `suggested` result, falling back to GoaT only if there's no candidate.
- GoaT cross-check flag (agree / disagree / no_reference) on every assembly.
- Gemma now reads the whole trusted paper (raised MAX_CHARS) with an accession-level
  check that it reads the correct paper.
- Result status set in run_pipeline (single-accession / Nextflow): success only when
  a ploidy level is recovered.
- Fix circular import: lazy __init__ + pipeline no longer imports the package namespace,
  so importing the package doesn't require the optional vector-search deps.

Validation on the four test genomes (rule+vector, Gemma off): 4/4 — two confirmed
(GCF_002575655.3, GCA_032464435.1), two suggested (GCA_947310255.1 -> 6, GCA_905183035.1 -> 4).